### PR TITLE
Add syntax highlighting via Highlight.js #18

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -71,3 +71,9 @@
   bottom: 0;
   left: -2rem;
 }
+
+/** Namespace Page Code Blocks -------------------------------------- **/
+
+.ns-page .def-block .hljs {
+  padding: inherit;
+}

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -23,10 +23,17 @@
                  [:title (:title opts)]
                  [:meta {:charset "utf-8"}]
                  [:link {:rel "stylesheet" :href "https://unpkg.com/tachyons@4.9.0/css/tachyons.min.css"}]
-                 (hiccup.page/include-css "/cljdoc.css")]
+                 (hiccup.page/include-css
+                   "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/styles/github-gist.min.css"
+                   "/cljdoc.css")]
                 [:div.sans-serif
                  contents]
-                (hiccup.page/include-js "/cljdoc.js")]))
+                (hiccup.page/include-js
+                  "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/highlight.min.js"
+                  "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/languages/clojure.min.js"
+                  "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/languages/clojure-repl.min.js"
+                  "/cljdoc.js")
+                [:script "hljs.initHighlightingOnLoad();"]]))
 
 (defn sidebar-title [title]
   [:h4.ttu.f7.fw5.tracked.gray title])
@@ -58,13 +65,19 @@
                   (subs scm-url 19)
                   (log/error "SCM Url missing from version-meta" version-meta))]]]])
 
+(defn def-code-block
+  [content]
+  [:pre
+   [:code.db.mb2 {:class "language-clojure"}
+    content]])
+
 (defn def-block [platforms]
   (assert (coll? platforms) "def meta is not a map")
   ;; Currently we just render any platform, this obviously
   ;; isn't the best we can do
   (let [def-meta (first (sort-by :platform platforms))]
     (cljdoc.spec/assert :cljdoc.spec/def-full def-meta)
-    [:div
+    [:div.def-block
      [:hr.mv3.b--black-10]
      [:h4.def-block-title
       {:name (:name def-meta), :id (:name def-meta)}
@@ -76,7 +89,7 @@
      ;;   [:code (pr-str def-meta)])
      [:div.lh-copy
       (for [argv (sort-by count (:arglists def-meta))]
-        [:code.db.mb2 (str "(" (:name def-meta) (when (seq argv) " ") (clojure.string/join " " argv) ")")])]
+        (def-code-block (str "(" (:name def-meta) (when (seq argv) " ") (clojure.string/join " " argv) ")")))]
      (when (:doc def-meta)
        [:div.lh-copy.markdown
         (-> (:doc def-meta) markup/markdown-to-html hiccup/raw)])
@@ -86,7 +99,7 @@
           [:div
            [:h5 (:name m)]
            (for [argv (sort-by count (:arglists m))]
-             [:code.db.mb2 (str "(" (:name m) " " (clojure.string/join " " argv) ")")])
+             (def-code-block (str "(" (:name m) " " (clojure.string/join " " argv) ")")))
            (when (:doc m)
              [:p (:doc m)])])])]))
 


### PR DESCRIPTION
Highlight.js is the quickest and easiest way to add syntax highlighting
support that works for Markdown, AsciiDoc, and potential other
documentation formats.

I investigated server-side syntax highlighting via Clygments
(https://github.com/bfontaine/clygments), but it currently doesn't
support guessing the language of the code block.

Furthermore, the AsciiDocJ extension API proved to be quite fiddly.
Using it to reliably convert all AsciiDoc codeblocks would probably be a
somewhat larger effort.

Highlight.js is able to guess the code block language, but the downside
is that the default distribution provides support for 23 of the most
common programming languages. Adding support for every new language
comes at the cost of increased network payload for users.