### PR TITLE
WIP Nginx in Docker

### DIFF
--- a/ops/docker/nginx/5xx.html
+++ b/ops/docker/nginx/5xx.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class="gr__cljdoc_xyz">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>cljdoc — down for maintenance</title>
+    <meta charset="utf-8">
+    <link href="cljdoc-502_files/tachyons.css" rel="stylesheet" type="text/css">
+    <link href="cljdoc-502_files/github-gist.css" rel="stylesheet" type="text/css">
+    <link href="cljdoc-502_files/cljdoc.css" rel="stylesheet" type="text/css">
+  </head>
+  <body data-gr-c-s-loaded="true">
+    <div class="sans-serif">
+      <div class="mw7 center pv4">
+        <h1 class="f1">cljdoc<span class="dib v-mid ml3 pv1 ph2 ba b--moon-gray br1 ttu fw5 f7 gray tracked">alpha</span></h1>
+        <p class="f2 lh-copy">is currently down for maintenance.</p>
+        <div class="dark-gray mt4">
+          <p>If this state persists, please let us know in in
+            <a class="link blue" href="https://clojurians.slack.com/messages/C8V0BQ0M6/">#cljdoc</a> on
+            <a class="link blue" href="http://clojurians.net/">Slack</a>.
+            Or open an issue on
+            <a class="link blue" href="https://github.com/martinklepsch/cljdoc">GitHub</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/ops/docker/nginx/Dockerfile
+++ b/ops/docker/nginx/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY cljdoc.xyz.conf /etc/nginx/sites-enabled/
+COPY nginx.conf /etc/nginx
+COPY 5xx.html /usr/share/nginx/html
+
+VOLUME /etc/nginx
+VOLUME /var/log/nginx

--- a/ops/docker/nginx/README.md
+++ b/ops/docker/nginx/README.md
@@ -12,3 +12,15 @@ docker build -t cljdoc-nginx .
 docker run --name cljdoc-nginx -p 80:80 -p 443:443 -d --rm cljdoc-nginx
 ```
 
+- [ ] use terraform to create a user with [this policy](https://github.com/certbot/certbot/blob/master/certbot-dns-route53/examples/sample-aws-policy.json) for DNS based certbot auth
+- [ ] figure out how to provide AWS creds to `get-cert.sh` and run it on the instance
+- [ ] some lines in cljdoc.xyz.conf cause nginx to fall over (ssl related)
+- [ ] it's not clear to me yet how to access logs of nginx cljdoc server block
+
+### Certificates
+
+Getting certificates with nginx running in docker is different and I
+couldn't quite get it to work.  Somewhere down this road I discovered
+that certbot provides DNS challenge plugins as Docker containers and
+because this works without any running web server it's significantly
+easier to get a certificate.

--- a/ops/docker/nginx/README.md
+++ b/ops/docker/nginx/README.md
@@ -1,0 +1,14 @@
+# Nginx docker setup
+
+This has been created in order to be able to easily test Nginx configuration locally.
+
+Useful commands:
+
+```sh
+# build the image
+docker build -t cljdoc-nginx .
+
+# run the image 
+docker run --name cljdoc-nginx -p 80:80 -p 443:443 -d --rm cljdoc-nginx
+```
+

--- a/ops/docker/nginx/cljdoc.xyz.conf
+++ b/ops/docker/nginx/cljdoc.xyz.conf
@@ -1,0 +1,36 @@
+server {
+    listen      80;
+    server_name cljdoc.xyz;
+    access_log  /var/log/nginx/cljdoc-access.log timed_combined;
+    error_log   /var/log/nginx/cljdoc-error.log;
+
+    rewrite ^/(.*)/$ /$1 permanent;
+    
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    error_page 500 502 503 504 /5xx.html;
+    location = /5xx.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
+
+
+    listen [::]:443 ssl ipv6only=on; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/cljdoc.xyz/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/cljdoc.xyz/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    # To test this configuration locally it's convenient to comment
+    # out the below redirect so you can use plain HTTP
+    if ($scheme != "https") {
+        return 301 https://$host$request_uri;
+    }
+}

--- a/ops/docker/nginx/nginx.conf
+++ b/ops/docker/nginx/nginx.conf
@@ -1,0 +1,45 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $request_time $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    log_format timed_combined '$remote_addr - $remote_user [$time_local] '
+    '"$request" $status $body_bytes_sent '
+    '"$http_referer" "$http_user_agent" '
+    '$request_time $upstream_response_time';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    include /etc/nginx/sites-enabled/*.conf;
+    server_names_hash_bucket_size 64;
+}

--- a/ops/get-cert.sh
+++ b/ops/get-cert.sh
@@ -2,16 +2,46 @@
 
 set -eou pipefail
 
+email="martinklepsch@gmail.com"
 domain="cljdoc.xyz"
 
 echo "--- Getting Certificate -------------------------------------------------------"
 
-certbot certonly -m martinklepsch@gmail.com -d "$domain" --nginx --agree-tos --non-interactive
+export AWS_ACCESS_KEY_ID="FIXME"
+export AWS_SECRET_ACCESS_KEY="FIXME"
 
-echo "--- Linking Server Block ------------------------------------------------------"
+# certbot certonly -m "$email" -d "$domain" --nginx --agree-tos --non-interactive
 
-ln -s "/etc/nginx/sites-available/$domain.conf" "/etc/nginx/sites-enabled/$domain.conf"
+# Using certbot with route53 requires building certbot manually
+# certbot certonly -m "$email" -d "$domain" --dns-route53 --agree-tos --non-interactive
+
+# So here we go and use their docker images -----------------------------------------
+
+# Permissions can be fixed by appending :Z
+# https://stackoverflow.com/a/34537509
+# -v /tmp/le:/tmp/:Z
+
+# TODO figure out if this line is necessary:
+# -v /etc/letsencrypt-lib/:/var/lib/letsencrypt-d \
+
+docker run -it --rm \
+       --name certbot \
+       -v /tmp/letsencrypt:/etc/letsencrypt/:Z \
+       -v /etc/letsencrypt-lib/:/var/lib/letsencrypt-d \
+       -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+       -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+       certbot/dns-route53 certonly -m "$email" --dns-route53 -d "$domain" --agree-tos --non-interactive
+
+echo "--- Moving certs in right place -----------------------------------------------"
+
+mv "/tmp/letsencrypt/live/$domain" /etc/letsencrypt/live/
+
+echo "--- Clean up docker mount -----------------------------------------------------"
+
+rm -rf /tmp/letsencrypt
 
 echo "--- Restarting Nginx ----------------------------------------------------------"
+
+# TODO fix this
 
 systemctl restart nginx


### PR DESCRIPTION
While discussing #35 with a friend it came up that it is pretty hard to test with the current setup. Docker came up and would certainly make this easier but might affect other things.

I added the line to the nginx config more or less manually now but really this should see some better solution. I played around with Docker a bit (just for nginx, cljdoc would still be a regular systemd service).

Checklist of things that are still unclear/tbd:

- [ ] use terraform to create a user with [this policy](https://github.com/certbot/certbot/blob/master/certbot-dns-route53/examples/sample-aws-policy.json) for DNS based certbot auth
- [ ] figure out how to provide AWS creds to `get-cert.sh` and run it on the instance
- [ ] some lines in cljdoc.xyz.conf cause nginx to fall over (ssl related)
- [ ] it's not clear to me yet how to access logs of nginx cljdoc server block
- [ ] how do deploy all this to the server and update it
- [ ] how to manage the docker/nginx process ([systemd-docker](https://github.com/ibuildthecloud/systemd-docker)?)