### PR TITLE
108: Fixed wikilinks from rendering inside code blocks

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,10 +14,11 @@
         org.asciidoctor/asciidoctorj {:mvn/version "1.5.6"},
         com.beust/jcommander {:mvn/version "1.35"} ; tools-deps issue?
         org.jruby/jruby-complete {:mvn/version "1.7.26"} ; tools-deps issue?
-        com.atlassian.commonmark/commonmark {:mvn/version "0.11.0"},
-        com.atlassian.commonmark/commonmark-ext-autolink {:mvn/version "0.11.0"},
-        com.atlassian.commonmark/commonmark-ext-gfm-tables {:mvn/version "0.11.0"},
-        com.atlassian.commonmark/commonmark-ext-heading-anchor {:mvn/version "0.11.0"},
+        com.vladsch.flexmark/flexmark {:mvn/version "0.34.18"}
+        com.vladsch.flexmark/flexmark-ext-autolink {:mvn/version "0.34.18"}
+        com.vladsch.flexmark/flexmark-ext-gfm-tables {:mvn/version "0.34.18"}
+        com.vladsch.flexmark/flexmark-ext-anchorlink {:mvn/version "0.34.18"}
+        com.vladsch.flexmark/flexmark-ext-wikilink {:mvn/version "0.34.18"}
         com.cognitect/transit-clj {:mvn/version "0.8.300"},
         org.clojure/java.jdbc {:mvn/version "0.7.0"},
         hiccup {:mvn/version "2.0.0-alpha1"},

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -34,8 +34,9 @@
 (defn docstring->html [doc-str render-wiki-link]
   [:div.lh-copy.markdown
    (-> doc-str
-       (string/replace #"\[\[(.+?)\]\]" (comp render-wiki-link parse-wiki-link second))
-       (rich-text/markdown-to-html {:escape-html? true})
+       (rich-text/markdown-to-html
+         {:escape-html? true
+          :render-wiki-link (comp render-wiki-link parse-wiki-link)})
        hiccup/raw)])
 
 (defn render-wiki-link-fn
@@ -44,10 +45,8 @@
   a `[ns var]` tuple and will return a Markdown link to the specified ns/var."
   [current-ns ns-link-fn]
   (fn render-wiki-link-inner [[ns var]]
-    (format "[`%s`](%s)"
-            (str (str ns (when (and ns var) "/") var))
-            (str (ns-link-fn (if ns (util/replant-ns current-ns ns) current-ns))
-                 (when var (str "#" var))))))
+    (str (ns-link-fn (if ns (util/replant-ns current-ns ns) current-ns))
+         (when var (str "#" var)))))
 
 (defn render-doc [mp render-wiki-link]
   (if (platf/varies? mp :doc)


### PR DESCRIPTION
Replaced dependency commonmark with flexmark and used the latter's
wikilink extension with a custom renderer.

Found no existing tests to update...
Some basic manual tests, no obvious breakages.