### PR TITLE
added section headers to doc pages for easier nav

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -118,3 +118,27 @@
   bottom: 0;
   left: -2rem;
 }
+
+
+/** Doc Nav ------------------------------------------------ **/
+
+#doc-title {
+    text-align: left;
+    flex: 1;
+    margin-left: 10px;
+    overflow-x: hidden;
+}
+
+#doc-section {
+    text-align: right;
+    flex: 1;
+}
+
+#doc-nav {
+    height: 50px;
+    right: 0;
+    position: absolute;
+    justify-content: center;
+    align-items: center;
+    display: flex;
+}

--- a/resources/public/cljdoc.js
+++ b/resources/public/cljdoc.js
@@ -1,9 +1,13 @@
 "use strict"
 
 var NSPage = document.querySelector(".ns-page")
+var DocPage = document.querySelector("#doc-html")
 
 if (NSPage) {
   initSrollIndicator()
+}
+if (DocPage) {
+    initDocTitle()
 }
 
 function initSrollIndicator() {
@@ -52,6 +56,44 @@ window.onbeforeunload = function(){
     localStorage.setItem("sidebarScrollPos", JSON.stringify(data))
   }
 };
+
+function initDocTitle () {
+    var mainScrollView = document.querySelector(".main-scroll-view")
+    var docHtml = document.querySelector("#doc-html")
+    var docHeaders = Array.from(docHtml.querySelectorAll("h1, h2, h3, h4, h5, h6"))
+    var docTitle = document.querySelector("#doc-title")
+    var lastIndex = null
+
+    function isBelow(container, element) {
+        var containerTop = container.getBoundingClientRect().top
+        var elementTop = element.getBoundingClientRect().top - 1
+        // minus one for anchors to be correct
+        return containerTop > elementTop
+    }
+
+    function immediatelyAbove (container, elements) {
+        for (let j = 0; j < elements.length - 1; j++) {
+            if (!isBelow(container, elements[j+1])) {
+                return j
+            }
+        }
+        return elements.length - 1
+    }
+
+    function changeTitle() {
+        var index = immediatelyAbove(mainScrollView, docHeaders)
+        if (index !== lastIndex) {
+            var anchor = docHeaders[index].querySelector('a')
+            var url = new URL(anchor.href)
+            docTitle.innerText = anchor.innerText
+            docTitle.href = url.hash
+            // set last index so it doesn't trigger super often
+            lastIndex = index
+        }
+    }
+    mainScrollView.addEventListener("scroll", changeTitle)
+    changeTitle()
+}
 
 (function() {
   var scrollPosData = JSON.parse(localStorage.getItem("sidebarScrollPos"))

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -38,6 +38,11 @@
                      (doc-tree-view cache-id (:children doc-page) current-page)])))
          (into [:ul.list.pl2]))))
 
+(def doc-nav
+  [:div#doc-nav.bb.b--black-10 {:style {:left "16rem"}}
+   [:div#doc-section "Current Section:"]
+   [:a#doc-title.link.blue {:href "#"} ""]])
+
 (defn doc-page [{:keys [top-bar-component
                         doc-tree-component
                         namespace-list-component
@@ -48,12 +53,14 @@
    (layout/sidebar
     (article-list doc-tree-component)
     namespace-list-component)
+   (when doc-html doc-nav)
    (layout/main-container
-    {:offset "16rem"}
+    (cond-> {:offset "16rem"}
+      doc-html (assoc :extra-height 50))
     [:div.mw7.center
      ;; TODO dispatch on a type parameter that becomes part of the attrs map
      (if doc-html
-       [:div.markdown.lh-copy.pv4
+       [:div#doc-html.markdown.lh-copy.pv4
         (hiccup/raw doc-html)
         [:a.db.f7.tr {:href doc-scm-url} "Edit on GitHub"]]
        [:div.lh-copy.pv6.tc

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -64,22 +64,23 @@
 (defn sidebar-title [title]
   [:h4.ttu.f7.fw5.mt1.mb2.tracked.gray title])
 
-(def TOP-BAR-HEIGHT "57px")
+(def TOP-BAR-HEIGHT 57)
 
 (defn sidebar [& contents]
   [:div.absolute.w5.bottom-0.left-0.pa3.pa4-ns.overflow-scroll.br.b--black-10
    {:class "js--sidebar"
-    :style {:top TOP-BAR-HEIGHT}} ; CSS HACK
+    :style {:top (str TOP-BAR-HEIGHT "px")}} ; CSS HACK
    contents])
 
 (defn sidebar-two [& contents]
   [:div.absolute.w5.bottom-0.left-0.pa3.pa4-ns.overflow-scroll.br.b--black-10.sidebar-scroll-view
-   {:style {:top TOP-BAR-HEIGHT :left "16rem"}} ; CSS HACK
+   {:style {:top (str TOP-BAR-HEIGHT "px") :left "16rem"}} ; CSS HACK
    contents])
 
-(defn main-container [{:keys [offset]} & content]
+(defn main-container [{:keys [offset extra-height]} & content]
    [:div.absolute.bottom-0.right-0
-    {:style {:left offset :top TOP-BAR-HEIGHT}}
+    {:style {:left offset
+             :top (str (+ TOP-BAR-HEIGHT (or extra-height 0)) "px")}}
     (into [:div.absolute.top-0.bottom-0.left-0.right-0.overflow-y-scroll.ph4-ns.ph2.main-scroll-view]
           content)])
 


### PR DESCRIPTION
closes #20 

Not really sure if it's what you had in mind but I took a swing at it anyways.

Some open topics are what level of header it should display (like should h4's and above not get added) and whether the top margin on body should be reduced.

It's the bar with the current section for anyone that doesn't want to build it:
<img width="1270" alt="screen shot 2018-09-16 at 7 38 03 pm" src="https://user-images.githubusercontent.com/4926258/45602252-f217d700-b9e8-11e8-8bbf-18ddd7990372.png">
