### PR TITLE
added toggle raw

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -118,16 +118,3 @@
   bottom: 0;
   left: -2rem;
 }
-
-.raw {
-    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    padding: 1rem;
-    background-color: rgb(246, 248, 250);
-    border-radius: 3px;
-    font-size: 0.875rem;
-    overflow-x: scroll;
-}
-
-.hide {
-    display: none;
-}

--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -118,3 +118,16 @@
   bottom: 0;
   left: -2rem;
 }
+
+.raw {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    padding: 1rem;
+    background-color: rgb(246, 248, 250);
+    border-radius: 3px;
+    font-size: 0.875rem;
+    overflow-x: scroll;
+}
+
+.hide {
+    display: none;
+}

--- a/resources/public/cljdoc.js
+++ b/resources/public/cljdoc.js
@@ -3,7 +3,8 @@
 var NSPage = document.querySelector(".ns-page")
 
 if (NSPage) {
-  initSrollIndicator()
+    initSrollIndicator()
+    initToggleRaw()
 }
 
 function initSrollIndicator() {
@@ -40,6 +41,28 @@ function initSrollIndicator() {
   mainScrollView.addEventListener("scroll", drawScrollIndicator)
 
   drawScrollIndicator()
+}
+
+function initToggleRaw() {
+    var toggles = Array.from(document.querySelectorAll(".toggle-raw"))
+
+    function addToggleHandlers() {
+        toggles.forEach((el, idx) => {
+            el.addEventListener("click", function () {
+                var parent = el.parentElement
+                var markdown = parent.querySelector(".markdown")
+                var raw = parent.querySelector(".raw")
+                if (markdown.classList.contains("hide")) {
+                    markdown.classList.remove("hide")
+                    raw.classList.add("hide")
+                } else {
+                    markdown.classList.add("hide")
+                    raw.classList.remove("hide")
+                }
+            })
+        })
+    }
+    addToggleHandlers()
 }
 
 window.onbeforeunload = function(){

--- a/resources/public/cljdoc.js
+++ b/resources/public/cljdoc.js
@@ -3,8 +3,8 @@
 var NSPage = document.querySelector(".ns-page")
 
 if (NSPage) {
-    initSrollIndicator()
-    initToggleRaw()
+  initSrollIndicator()
+  initToggleRaw()
 }
 
 function initSrollIndicator() {
@@ -44,25 +44,27 @@ function initSrollIndicator() {
 }
 
 function initToggleRaw() {
-    var toggles = Array.from(document.querySelectorAll(".toggle-raw"))
+  var toggles = Array.from(document.querySelectorAll(".js--toggle-raw"))
 
-    function addToggleHandlers() {
-        toggles.forEach((el, idx) => {
-            el.addEventListener("click", function () {
-                var parent = el.parentElement
-                var markdown = parent.querySelector(".markdown")
-                var raw = parent.querySelector(".raw")
-                if (markdown.classList.contains("hide")) {
-                    markdown.classList.remove("hide")
-                    raw.classList.add("hide")
-                } else {
-                    markdown.classList.add("hide")
-                    raw.classList.remove("hide")
-                }
-            })
-        })
-    }
-    addToggleHandlers()
+  function addToggleHandlers() {
+    toggles.forEach((el, idx) => {
+      el.addEventListener("click", function () {
+        var parent = el.parentElement
+        var markdown = parent.querySelector(".markdown")
+        var raw = parent.querySelector(".raw")
+        if (markdown.classList.contains("dn")) {
+          markdown.classList.remove("dn")
+          raw.classList.add("dn")
+          el.innerText = "raw docstring"
+        } else {
+          markdown.classList.add("dn")
+          raw.classList.remove("dn")
+          el.innerText = "formatted docstring"
+        }
+      })
+    })
+  }
+  addToggleHandlers()
 }
 
 window.onbeforeunload = function(){

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -32,12 +32,14 @@
       [nil m])))
 
 (defn docstring->html [doc-str render-wiki-link]
-  [:div.lh-copy.markdown
-   (-> doc-str
-       (rich-text/markdown-to-html
+  [:div
+   [:div.lh-copy.markdown
+    (-> doc-str
+        (rich-text/markdown-to-html
          {:escape-html? true
           :render-wiki-link (comp render-wiki-link parse-wiki-link)})
-       hiccup/raw)])
+        hiccup/raw)]
+   [:pre.lh-copy.raw.hide (hiccup/raw doc-str)]])
 
 (defn render-wiki-link-fn
   "Given the `current-ns` and a function `ns-link-fn` that is assumed
@@ -100,7 +102,8 @@
            [:a.link.f7.gray.hover-dark-gray.mr2
             {:href (platf/get-field def :src-uri p)}
             (format "source (%s)" p)])
-         [:a.link.f7.gray.hover-dark-gray {:href (platf/get-field def :src-uri)} "source"]))]))
+         [:a.link.f7.gray.hover-dark-gray.mr2 {:href (platf/get-field def :src-uri)} "source"]))
+     [:a.link.f7.gray.hover-dark-gray.toggle-raw {:href "#"} "toggle raw"]]))
 
 (defn namespace-list [{:keys [current]} namespaces]
   (let [base-params (select-keys (first namespaces) [:group-id :artifact-id :version])

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -39,7 +39,8 @@
          {:escape-html? true
           :render-wiki-link (comp render-wiki-link parse-wiki-link)})
         hiccup/raw)]
-   [:pre.lh-copy.raw.hide (hiccup/raw doc-str)]])
+   [:pre.lh-copy.bg-near-white.code.pa3.br2.f6.overflow-x-scroll.dn.raw
+    doc-str]])
 
 (defn render-wiki-link-fn
   "Given the `current-ns` and a function `ns-link-fn` that is assumed
@@ -103,7 +104,7 @@
             {:href (platf/get-field def :src-uri p)}
             (format "source (%s)" p)])
          [:a.link.f7.gray.hover-dark-gray.mr2 {:href (platf/get-field def :src-uri)} "source"]))
-     [:a.link.f7.gray.hover-dark-gray.toggle-raw {:href "#"} "toggle raw"]]))
+     [:a.link.f7.gray.hover-dark-gray.js--toggle-raw {:href "#"} "raw docstring"]]))
 
 (defn namespace-list [{:keys [current]} namespaces]
   (let [base-params (select-keys (first namespaces) [:group-id :artifact-id :version])


### PR DESCRIPTION
Sometimes the renderer mangles some quasi md in docstrings. I started to think about extending the md parser but i think it's an intractable problem. so instead add a option to just render the raw docstring. Motivating example in the images from `re-frame.std-interceptors`'s docstring:

<img width="852" alt="screen shot 2018-09-22 at 3 20 25 pm" src="https://user-images.githubusercontent.com/4926258/45921065-47863500-be7c-11e8-93ec-963037d3b104.png">

<img width="834" alt="screen shot 2018-09-22 at 3 20 58 pm" src="https://user-images.githubusercontent.com/4926258/45921066-4fde7000-be7c-11e8-801c-dcb76ba1a3df.png">
