### PR TITLE
Show toggle for `raw docstring` when docstring exists

### DIFF
--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -68,7 +68,8 @@
 (defn def-block
   [def render-wiki-link]
   {:pre [(platf/multiplatform? def)]}
-  (let [def-name (platf/get-field def :name)]
+  (let [def-name (platf/get-field def :name)
+        docstring (render-doc def render-wiki-link)]
     [:div.def-block
      [:hr.mv3.b--black-10]
      [:h4.def-block-title.mv0.pv3
@@ -86,7 +87,7 @@
            [:span.f7.ttu.gray.db.nb2 (get {"clj" "Clojure" "cljs" "ClojureScript"} p) " arglists"]
            (render-arglists def-name (platf/get-field def :arglists p))])
         (render-arglists def-name (platf/get-field def :arglists)))]
-     (render-doc def render-wiki-link)
+     docstring
      (when (seq (platf/get-field def :members))
        [:div.lh-copy.pl3.bl.b--black-10
         (for [m (platf/get-field def :members)]
@@ -104,7 +105,7 @@
             {:href (platf/get-field def :src-uri p)}
             (format "source (%s)" p)])
          [:a.link.f7.gray.hover-dark-gray.mr2 {:href (platf/get-field def :src-uri)} "source"]))
-     (when (not (nil? (render-doc def render-wiki-link)))
+     (when (not (nil? docstring))
        [:a.link.f7.gray.hover-dark-gray.js--toggle-raw {:href "#"} "raw docstring"])]))
 
 (defn namespace-list [{:keys [current]} namespaces]

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -68,8 +68,7 @@
 (defn def-block
   [def render-wiki-link]
   {:pre [(platf/multiplatform? def)]}
-  (let [def-name (platf/get-field def :name)
-        docstring (render-doc def render-wiki-link)]
+  (let [def-name (platf/get-field def :name)]
     [:div.def-block
      [:hr.mv3.b--black-10]
      [:h4.def-block-title.mv0.pv3
@@ -87,7 +86,7 @@
            [:span.f7.ttu.gray.db.nb2 (get {"clj" "Clojure" "cljs" "ClojureScript"} p) " arglists"]
            (render-arglists def-name (platf/get-field def :arglists p))])
         (render-arglists def-name (platf/get-field def :arglists)))]
-     docstring
+     (render-doc def render-wiki-link)
      (when (seq (platf/get-field def :members))
        [:div.lh-copy.pl3.bl.b--black-10
         (for [m (platf/get-field def :members)]
@@ -105,7 +104,7 @@
             {:href (platf/get-field def :src-uri p)}
             (format "source (%s)" p)])
          [:a.link.f7.gray.hover-dark-gray.mr2 {:href (platf/get-field def :src-uri)} "source"]))
-     (when (not (nil? docstring))
+     (when (seq (platf/all-vals def :doc))
        [:a.link.f7.gray.hover-dark-gray.js--toggle-raw {:href "#"} "raw docstring"])]))
 
 (defn namespace-list [{:keys [current]} namespaces]

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -104,7 +104,8 @@
             {:href (platf/get-field def :src-uri p)}
             (format "source (%s)" p)])
          [:a.link.f7.gray.hover-dark-gray.mr2 {:href (platf/get-field def :src-uri)} "source"]))
-     [:a.link.f7.gray.hover-dark-gray.js--toggle-raw {:href "#"} "raw docstring"]]))
+     (when (not (nil? (render-doc def render-wiki-link)))
+       [:a.link.f7.gray.hover-dark-gray.js--toggle-raw {:href "#"} "raw docstring"])]))
 
 (defn namespace-list [{:keys [current]} namespaces]
   (let [base-params (select-keys (first namespaces) [:group-id :artifact-id :version])


### PR DESCRIPTION
fixes #119 

**issue to be solved:** 
at the moment, the toggle `raw docstring` is always shown, even when no docstring is available

**solution:**
only show the toggle when `render-doc` returns something else than `nil`

ideas or suggestions for improvements are welcome 😃 