### PR TITLE
Support Gitlab URLs

### DIFF
--- a/modules/shared-utils/src/cljdoc/util.clj
+++ b/modules/shared-utils/src/cljdoc/util.clj
@@ -131,14 +131,20 @@
 ;;                                (-> cljdoc-edn :pom :version))))))
 
 
-(defn gh-owner [gh-url]
-  (second (re-find #"^https*://github.com/([^\/]+)/" gh-url)))
+(defn scm-owner [scm-url]
+  (get (re-find #"^https*://(github|gitlab).com/([^\/]+)/" scm-url) 2))
 
-(defn gh-repo [gh-url]
-  (second (re-find #"^https*://github.com/[^\/]+/([^/]+)" gh-url)))
+(defn scm-repo [scm-url]
+  (get (re-find #"^https*://(github|gitlab).com/[^\/]+/([^/]+)" scm-url) 2))
 
-(defn gh-coordinate [gh-url]
-  (str (gh-owner gh-url) "/" (gh-repo gh-url)))
+(defn scm-coordinate [scm-url]
+  (str (scm-owner scm-url) "/" (scm-repo scm-url)))
+
+(defn scm-provider [scm-url]
+  (case (second (re-find #"^https*://(github|gitlab).com" scm-url))
+    "github" :github
+    "gitlab" :gitlab
+    nil))
 
 (defn github-url [type]
   (let [base "https://github.com/cljdoc/cljdoc"]

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -62,7 +62,9 @@
      (if doc-html
        [:div#doc-html.markdown.lh-copy.pv4
         (hiccup/raw doc-html)
-        [:a.db.f7.tr {:href doc-scm-url} "Edit on GitHub"]]
+        [:a.db.f7.tr {:href doc-scm-url} (if (= :gitlab (util/scm-provider doc-scm-url))
+                                           "Edit on GitLab"
+                                           "Edit on GitHub")]]
        [:div.lh-copy.pv6.tc
         #_[:pre (pr-str (dissoc args :top-bar-component :doc-tree-component :namespace-list-component))]
         [:span.f4.serif.gray.i "Space intentionally left blank."]])])])

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -105,6 +105,6 @@
     (if scm-url
       [:a.link.dim.gray.f6.tr
        {:href scm-url}
-       [:img.v-mid.mr2 {:src "https://icon.now.sh/github"}]
-       [:span.dib (util/gh-coordinate scm-url)]]
+       [:img.v-mid.mr2 {:src (str "https://icon.now.sh/" (name (util/scm-provider scm-url)))}]
+       [:span.dib (util/scm-coordinate scm-url)]]
       [:a.f6.link.blue {:href (util/github-url :userguide/scm-faq)} "SCM info missing"])]])

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -48,7 +48,7 @@
       [:a.link.dim.gray.f6.tr
        {:href scm-url}
        [:img.v-mid.mr2 {:src "https://icon.now.sh/github"}]
-       [:span.dib (util/gh-coordinate scm-url)]])]])
+       [:span.dib (util/scm-coordinate scm-url)]])]])
 
 (defn page [{:keys [version-entity namespace article-title scm-url]} contents]
   (let [sub-page? (or namespace article-title)]

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -90,8 +90,8 @@
       (.put broken-img "src" (fix-image file-path
                                         (.get broken-img "src")
                                         {:scm-base (str "https://raw.githubusercontent.com/"
-                                                        (util/gh-owner (:url scm)) "/"
-                                                        (util/gh-repo (:url scm)) "/"
+                                                        (util/scm-owner (:url scm)) "/"
+                                                        (util/scm-repo (:url scm)) "/"
                                                         scm-rev "/")})))
     (.toString doc)))
 

--- a/test/cljdoc/util_test.clj
+++ b/test/cljdoc/util_test.clj
@@ -4,10 +4,18 @@
             [clojure.test :as t])
   (:import (clojure.lang ExceptionInfo)))
 
-(t/deftest gh-coordinate-test
-  (t/is (= "circleci" (util/gh-owner "https://github.com/circleci/clj-yaml")))
-  (t/is (= "clj-yaml" (util/gh-repo "https://github.com/circleci/clj-yaml")))
-  (t/is (= "circleci/clj-yaml" (util/gh-coordinate "https://github.com/circleci/clj-yaml"))))
+(t/deftest scm-coordinate-test
+  (t/is (= "circleci" (util/scm-owner "https://github.com/circleci/clj-yaml")))
+  (t/is (= "eval" (util/scm-owner "https://gitlab.com/eval/otarta")))
+  (t/is (= "clj-yaml" (util/scm-repo "https://github.com/circleci/clj-yaml")))
+  (t/is (= "otarta" (util/scm-repo "https://gitlab.com/eval/otarta")))
+  (t/is (= "circleci/clj-yaml" (util/scm-coordinate "https://github.com/circleci/clj-yaml")))
+  (t/is (= "eval/otarta" (util/scm-coordinate "https://gitlab.com/eval/otarta"))))
+
+(t/deftest scm-provider-test
+  (t/is (= :github (util/scm-provider "https://github.com/circleci/clj-yaml")))
+  (t/is (= :gitlab (util/scm-provider "https://gitlab.com/eval/otarta")))
+  (t/is (= nil (util/scm-provider "https://unknown-scm.com/circleci/clj-yaml"))))
 
 (t/deftest find-artifact-repository-test
   (t/is (= (repositories/find-artifact-repository "org.clojure/clojure" "1.9.0")


### PR DESCRIPTION
Support Gitlab URLs in repo link & icon and update "Edit on Github" link at bottom of article.