### PR TITLE
Fix db name

### DIFF
--- a/src/cljdoc/cli.clj
+++ b/src/cljdoc/cli.clj
@@ -24,7 +24,7 @@
                                  (:pom (repositories/local-uris project version))
                                  (:pom (repositories/artifact-uris project version))))
                             slurp read-string)
-        storage  (storage/->SQLiteStorage (config/db))
+        storage  (storage/->SQLiteStorage (config/db (config/config)))
         scm-info (ingest/scm-info project (:pom-str analysis-result))]
     (ingest/ingest-cljdoc-edn storage analysis-result)
     (when (or (:url scm-info) git)

--- a/src/cljdoc/cli.clj
+++ b/src/cljdoc/cli.clj
@@ -24,7 +24,7 @@
                                  (:pom (repositories/local-uris project version))
                                  (:pom (repositories/artifact-uris project version))))
                             slurp read-string)
-        storage  (storage/->SQLiteStorage (config/build-log-db))
+        storage  (storage/->SQLiteStorage (config/db))
         scm-info (ingest/scm-info project (:pom-str analysis-result))]
     (ingest/ingest-cljdoc-edn storage analysis-result)
     (when (or (:url scm-info) git)

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -47,9 +47,7 @@
    :subprotocol "sqlite",
    :foreign_keys true
    :cache_size 10000
-   ;; That this file is named `build-log.db` is no longer accurate
-   ;; and will be changed in a subsequent commit
-   :subname (str (data-dir config) "build-log.db")
+   :subname (str (data-dir config) "cljdoc.db.sqlite")
    ;; These settings are permanent but it seems like
    ;; this is the easiest way to set them. In a migration
    ;; they fail because they return results.

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -47,7 +47,12 @@
    :subprotocol "sqlite",
    :foreign_keys true
    :cache_size 10000
-   :subname (str (data-dir config) "cljdoc.db.sqlite")
+   :subname (let [new-path (str (data-dir config) "cljdoc.db.sqlite")
+                  old-path (str (data-dir config) "build-log.db")]
+              (if (.exists (io/file new-path))
+                new-path
+                (do (log/warnf "Database needs to be moved from %s to %s" old-path new-path)
+                    old-path)))
    ;; These settings are permanent but it seems like
    ;; this is the easiest way to set them. In a migration
    ;; they fail because they return results.

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -41,20 +41,20 @@
   [config]
   (get config :statsd))
 
-(defn build-log-db
-  ([] (build-log-db (config)))
-  ([config]
-   {:classname "org.sqlite.JDBC",
-    :subprotocol "sqlite",
-    :foreign_keys true
-    :cache_size 10000
-    ;; That this file is named `build-log.db` is no longer accurate
-    :subname (str (data-dir config) "build-log.db")
-    ;; These settings are permanent but it seems like
-    ;; this is the easiest way to set them. In a migration
-    ;; they fail because they return results.
-    :synchronous "NORMAL"
-    :journal_mode "WAL"}))
+(defn db
+  [config]
+  {:classname "org.sqlite.JDBC",
+   :subprotocol "sqlite",
+   :foreign_keys true
+   :cache_size 10000
+   ;; That this file is named `build-log.db` is no longer accurate
+   ;; and will be changed in a subsequent commit
+   :subname (str (data-dir config) "build-log.db")
+   ;; These settings are permanent but it seems like
+   ;; this is the easiest way to set them. In a migration
+   ;; they fail because they return results.
+   :synchronous "NORMAL"
+   :journal_mode "WAL"})
 
 (defn autobuild-clojars-releases?
   ([] (autobuild-clojars-releases? (config)))

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -84,14 +84,14 @@
 
 (comment
   (require 'ragtime.repl 'ragtime.jdbc)
-  (def config {:datastore  (ragtime.jdbc/sql-database (cljdoc.config/build-log-db))
+  (def config {:datastore  (ragtime.jdbc/sql-database (cljdoc.config/db))
                :migrations (ragtime.jdbc/load-resources "migrations")})
 
   (ragtime.repl/rollback config)
 
   (ragtime.repl/migrate config)
 
-  (def bt (->SQLBuildTracker (cljdoc.config/build-log-db)))
+  (def bt (->SQLBuildTracker (cljdoc.config/db)))
 
   (running-build bt "amazonica" "amazonica" "0.3.132")
 

--- a/src/cljdoc/server/release_monitor.clj
+++ b/src/cljdoc/server/release_monitor.clj
@@ -85,7 +85,7 @@
   (tt/stop!))
 
 (comment
-  (def db-spec (cljdoc.config/build-log-db))
+  (def db-spec (cljdoc.config/db))
 
   (build-queuer-job-fn db-spec true)
 

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -23,7 +23,7 @@
 (defn system-config [env-config]
   (let [ana-service (cfg/analysis-service env-config)
         port        (cfg/get-in env-config [:cljdoc/server :port])]
-    {:cljdoc/sqlite          {:db-spec (cfg/build-log-db env-config)
+    {:cljdoc/sqlite          {:db-spec (cfg/db env-config)
                               :dir     (cfg/data-dir env-config)}
      :cljdoc/build-tracker   (ig/ref :cljdoc/sqlite)
      :cljdoc/release-monitor {:db-spec  (ig/ref :cljdoc/sqlite)
@@ -32,7 +32,7 @@
                        :host             (get-in env-config [:cljdoc/server :host])
                        :build-tracker    (ig/ref :cljdoc/build-tracker)
                        :analysis-service (ig/ref :cljdoc/analysis-service)
-                       :storage          (storage/->SQLiteStorage (cfg/build-log-db env-config))}
+                       :storage          (storage/->SQLiteStorage (cfg/db env-config))}
      :cljdoc/analysis-service (case ana-service
                                 :local     [:local {:full-build-url (str "http://localhost:" port "/api/full-build")}]
                                 :circle-ci [:circle-ci (cfg/circle-ci env-config)])


### PR DESCRIPTION
SQLite has been used for a while before eventually all data has been migrated into it (see [ADR#0013](https://github.com/cljdoc/cljdoc/blob/master/doc/adr/0013-move-to-sqlite-for-storage.md)). This resulted in some drift between the database file name and what it was actually used for. Previously only used for build logs the file name was `build-log.db` but after the migration this is no longer accurate.

This PR changes the filename and related functions while still supporting the old location (with a warning being logged).


