### PR TITLE
fix #151: make analyzer version a circle ci build parameter

### DIFF
--- a/resources/migrations/005-add-analyzer-version-column-to-builds.down.sql
+++ b/resources/migrations/005-add-analyzer-version-column-to-builds.down.sql
@@ -1,0 +1,1 @@
+-- column removal not supported in sqlite

--- a/resources/migrations/005-add-analyzer-version-column-to-builds.up.sql
+++ b/resources/migrations/005-add-analyzer-version-column-to-builds.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE builds ADD analyzer_version;

--- a/script/trigger-circle-analysis.sh
+++ b/script/trigger-circle-analysis.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 project="$1"
 version="$2"
 jar_path="$3"
+pom_path="$3"
+cljdoc_version=$(git rev-parse HEAD)
 
 # $CIRCLE_BUILDER_PROJECT must be Circle CI project set up
 # with the configuration that can be found in the cljdoc-builder project
@@ -11,7 +13,9 @@ jar_path="$3"
 # For the repo above the value should be "github/martinklepsch/cljdoc-builder"
 
 curl -u "$CIRCLE_API_TOKEN:" \
+     -d build_parameters[CLJDOC_ANALYZER_VERSION]="$cljdoc_version" \
      -d build_parameters[CLJDOC_PROJECT]="$project" \
      -d build_parameters[CLJDOC_PROJECT_VERSION]="$version" \
      -d build_parameters[CLJDOC_PROJECT_JAR]="$jar_path" \
+     -d build_parameters[CLJDOC_PROJECT_POM]="$pom_path" \
      "https://circleci.com/api/v1.1/project/$CIRCLE_BUILDER_PROJECT/tree/master"

--- a/script/trigger-circle-analysis.sh
+++ b/script/trigger-circle-analysis.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 project="$1"
 version="$2"
 jar_path="$3"
-pom_path="$3"
+pom_path="$4"
 cljdoc_version=$(git rev-parse HEAD)
 
 # $CIRCLE_BUILDER_PROJECT must be Circle CI project set up

--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -15,7 +15,7 @@
   purpose."
   (trigger-build [_ {:keys [build-id project version jarpath pompath]}]))
 
-(defrecord CircleCI [api-token builder-project]
+(defrecord CircleCI [api-token builder-project analyzer-version]
   IAnalysisService
   (trigger-build
     [_ {:keys [build-id project version jarpath pompath]}]
@@ -23,7 +23,8 @@
     (http/post (str "https://circleci.com/api/v1.1/project/" builder-project "/tree/master")
                {:accept "application/json"
                 ;; https://github.com/hiredman/clj-http-lite/issues/15
-                :form-params {"build_parameters[CLJDOC_BUILD_ID]" build-id
+                :form-params {"build_parameters[CLJDOC_ANALYZER_VERSION]" analyzer-version
+                              "build_parameters[CLJDOC_BUILD_ID]" build-id
                               "build_parameters[CLJDOC_PROJECT]" project
                               "build_parameters[CLJDOC_PROJECT_VERSION]" version
                               "build_parameters[CLJDOC_PROJECT_JAR]" jarpath
@@ -31,10 +32,11 @@
                 :basic-auth [api-token ""]})))
 
 (defn circle-ci
-  [api-token builder-project]
+  [{:keys [api-token builder-project analyzer-version]}]
   (assert (seq api-token) "blank or nil api-token passed to CircleCI component")
   (assert (seq builder-project) "blank or nil builder-project passed to CircleCI component")
-  (->CircleCI api-token builder-project))
+  (assert (seq analyzer-version) "blank or nil analyzer-version passed to CircleCI component")
+  (->CircleCI api-token builder-project analyzer-version))
 
 (defn circle-ci? [x]
   (instance? CircleCI x))

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -27,7 +27,13 @@
   ([] (circle-ci (config)))
   ([config]
    {:api-token       (get-in config [:secrets :circle-ci :api-token])
-    :builder-project (get-in config [:secrets :circle-ci :builder-project])}))
+    :builder-project (get-in config [:secrets :circle-ci :builder-project])
+    ;; Instead of using the version currently running we could also
+    ;; retrieve the latest commit on master from Github directly.
+    ;; This would allow us to update the analyzer without
+    ;; redeploying the cljdoc server. See GitHub API:
+    ;; https://developer.github.com/v3/repos/commits/
+    :analyzer-version (get-in config [:cljdoc/version])}))
 
 (defn analysis-service
   ([] (analysis-service (config)))

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -59,14 +59,15 @@
                     :build-id build-id})]
     (if (analysis-service/circle-ci? analysis-service)
       (let [build-num (-> ana-resp :body json/parse-string (get "build_num"))
-            job-url   (str "https://circleci.com/gh/martinklepsch/cljdoc-builder/" build-num)]
+            job-url   (str "https://circleci.com/gh/martinklepsch/cljdoc-builder/" build-num)
+            ana-v     (:analyzer-version analysis-service)]
         (when (= 201 (:status ana-resp))
           (assert build-num "build number missing from CircleCI response")
-          (build-log/analysis-kicked-off! build-tracker build-id job-url)
+          (build-log/analysis-kicked-off! build-tracker build-id job-url ana-v)
           (log/infof "Kicked of analysis job {:build-id %s :circle-url %s}" build-id job-url))
         build-id)
       (do
-        (build-log/analysis-kicked-off! build-tracker build-id nil)
+        (build-log/analysis-kicked-off! build-tracker build-id nil nil)
         build-id))))
 
 (defn full-build

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -12,7 +12,7 @@
   (analysis-requested!
     ;; "Track a request for analysis and return the build's ID."
     [_ group-id artifact-id version])
-  (analysis-kicked-off! [_ build-id analysis-job-uri])
+  (analysis-kicked-off! [_ build-id analysis-job-uri analyzer-version])
   (analysis-received! [_ build-id cljdoc-edn-uri])
   (failed! [_ build-id error])
   (api-imported! [_ build-id])
@@ -32,11 +32,12 @@
                        :analysis_requested_ts (now)})
          (first)
          ((keyword "last_insert_rowid()"))))
-  (analysis-kicked-off! [_ build-id analysis-job-uri]
+  (analysis-kicked-off! [_ build-id analysis-job-uri analyzer-version]
     (sql/update! db-spec
                  "builds"
                  {:analysis_job_uri analysis-job-uri
-                  :analysis_triggered_ts (now)}
+                  :analysis_triggered_ts (now)
+                  :analyzer_version analyzer-version}
                  ["id = ?" build-id]))
   (analysis-received! [_ build-id cljdoc-edn-uri]
     (sql/update! db-spec

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -41,7 +41,7 @@
 (defmethod ig/init-key :cljdoc/analysis-service [_ [type opts]]
   (log/infof "Starting Analysis Service %s" type)
   (case type
-    :circle-ci (analysis-service/circle-ci (:api-token opts) (:builder-project opts))
+    :circle-ci (analysis-service/circle-ci opts)
     :local     (analysis-service/->Local (:full-build-url opts))))
 
 (defmethod ig/init-key :cljdoc/sqlite [_ {:keys [db-spec dir]}]


### PR DESCRIPTION
Fixes #151. This allows us to link builds to analyzer versions making it easier to detect regressions with newer releases. 