### PR TITLE
Change primary domain from cljdoc.xyz to cljdoc.org

### DIFF
--- a/ops/cljdoc.tf
+++ b/ops/cljdoc.tf
@@ -8,7 +8,6 @@ provider "aws" {
   secret_key = "${var.aws_secret_key}"
 }
 
-
 provider "digitalocean" {
   token = "${var.do_token}"
 }
@@ -38,11 +37,12 @@ module "backups_bucket" {
 # DigitalOcean Server ------------------------------------------------
 
 resource "digitalocean_droplet" "cljdoc_api" {
-  image  = "${file("image/image-id")}"
-  name   = "cljdoc-1"
-  region = "ams3"
-  size   = "2gb"
+  image      = "${file("image/image-id")}"
+  name       = "cljdoc-1"
+  region     = "ams3"
+  size       = "2gb"
   monitoring = true
+
   # supplying a key here seems to be the only way to
   # not get a root password via email, despite having
   # added SSH keys to the snapshot/image before
@@ -69,6 +69,24 @@ resource "aws_route53_record" "main" {
   provider = "aws.prod"
   zone_id  = "${aws_route53_zone.cljdoc_zone.zone_id}"
   name     = "${var.domain}"
+  type     = "A"
+  ttl      = "300"
+  records  = ["${digitalocean_droplet.cljdoc_api.ipv4_address}"]
+}
+
+resource "aws_route53_record" "xyz_api" {
+  provider = "aws.prod"
+  zone_id  = "${aws_route53_zone.cljdoc_zone.zone_id}"
+  name     = "${var.api_xyz_domain}"
+  type     = "A"
+  ttl      = "300"
+  records  = ["${digitalocean_droplet.cljdoc_api.ipv4_address}"]
+}
+
+resource "aws_route53_record" "xyz_main" {
+  provider = "aws.prod"
+  zone_id  = "${aws_route53_zone.cljdoc_zone.zone_id}"
+  name     = "${var.xyz_domain}"
   type     = "A"
   ttl      = "300"
   records  = ["${digitalocean_droplet.cljdoc_api.ipv4_address}"]

--- a/ops/cljdoc.tfvars
+++ b/ops/cljdoc.tfvars
@@ -1,7 +1,12 @@
 # Alias must not contain dots.
 # It is used for references inside the template.
 
-domain      = "cljdoc.xyz"
-domainAlias = "cljdoc_xyz"
+domain = "cljdoc.org"
 
-api_domain  = "api.cljdoc.xyz"
+domainAlias = "cljdoc_org"
+
+api_domain = "api.cljdoc.org"
+
+xyz_domain = "cljdoc.xyz"
+
+api_xyz_domain = "api.cljdoc.xyz"

--- a/ops/get-cert.sh
+++ b/ops/get-cert.sh
@@ -2,13 +2,23 @@
 
 set -eou pipefail
 
-domain="cljdoc.xyz"
+domain="cljdoc.org"
 
-echo "--- Getting Certificate -------------------------------------------------------"
+echo "--- Getting .org Certificate -------------------------------------------------------"
 
 certbot certonly -m martinklepsch@gmail.com -d "$domain" --nginx --agree-tos --non-interactive
 
-echo "--- Linking Server Block ------------------------------------------------------"
+echo "--- Linking .org Server Block ------------------------------------------------------"
+
+ln -s "/etc/nginx/sites-available/$domain.conf" "/etc/nginx/sites-enabled/$domain.conf"
+
+domain="cljdoc.xyz"
+
+echo "--- Getting .xyz Certificate -------------------------------------------------------"
+
+certbot certonly -m martinklepsch@gmail.com -d "$domain" --nginx --agree-tos --non-interactive
+
+echo "--- Linking .xyz Server Block ------------------------------------------------------"
 
 ln -s "/etc/nginx/sites-available/$domain.conf" "/etc/nginx/sites-enabled/$domain.conf"
 

--- a/ops/image/cljdoc.org.conf
+++ b/ops/image/cljdoc.org.conf
@@ -1,8 +1,8 @@
 server {
     listen      80;
-    server_name cljdoc.xyz;
-    access_log  /var/log/nginx/cljdoc-xyz-access.log timed_combined;
-    error_log   /var/log/nginx/cljdoc-xyz-error.log;
+    server_name cljdoc.org;
+    access_log  /var/log/nginx/cljdoc-access.log timed_combined;
+    error_log   /var/log/nginx/cljdoc-error.log;
 
     rewrite ^/(.*)/$ /$1 permanent;
 
@@ -16,11 +16,12 @@ server {
 
     listen [::]:443 ssl ipv6only=on; # managed by Certbot
     listen 443 ssl; # managed by Certbot
-    ssl_certificate /etc/letsencrypt/live/cljdoc.xyz/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/cljdoc.xyz/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/cljdoc.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/cljdoc.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
-    return 301 https://cljdoc.org$request_uri;
-
+    if ($scheme != "https") {
+        return 301 https://$host$request_uri;
+    }
 }

--- a/ops/image/packer.json
+++ b/ops/image/packer.json
@@ -32,6 +32,11 @@
         },
         {
             "type": "file",
+            "source": "cljdoc.org.conf",
+            "destination": "/etc/nginx/sites-available/cljdoc.org.conf"
+        },
+        {
+            "type": "file",
             "source": "cljdoc-api.service",
             "destination": "/etc/systemd/system/cljdoc-api.service"
         }

--- a/ops/public_bucket/bucket.tf
+++ b/ops/public_bucket/bucket.tf
@@ -27,12 +27,14 @@ resource "aws_s3_bucket" "public_bucket" {
 
 data "aws_iam_policy_document" "bucket_write_user_policy" {
   provider = "aws.prod"
+
   statement {
     effect  = "Allow"
     actions = ["s3:*"]
+
     resources = [
       "${aws_s3_bucket.public_bucket.arn}",
-      "${aws_s3_bucket.public_bucket.arn}/*"
+      "${aws_s3_bucket.public_bucket.arn}/*",
     ]
   }
 }
@@ -47,8 +49,8 @@ resource "aws_iam_user_policy" "bucket_write_user_policy" {
 
 resource "aws_iam_user" "bucket_write_user" {
   provider = "aws.prod"
-  name = "${var.bucket_name}-user"
-  path = "/cljdoc/"
+  name     = "${var.bucket_name}-user"
+  path     = "/cljdoc/"
 }
 
 resource "aws_iam_access_key" "bucket_write_user_key" {
@@ -57,13 +59,13 @@ resource "aws_iam_access_key" "bucket_write_user_key" {
 }
 
 output "bucket_name" {
-    value = "${var.bucket_name}"
+  value = "${var.bucket_name}"
 }
 
 output "write_user_access_key" {
-    value = "${aws_iam_access_key.bucket_write_user_key.id}"
+  value = "${aws_iam_access_key.bucket_write_user_key.id}"
 }
 
 output "write_user_secret" {
-    value = "${aws_iam_access_key.bucket_write_user_key.secret}"
+  value = "${aws_iam_access_key.bucket_write_user_key.secret}"
 }

--- a/ops/variables.tf
+++ b/ops/variables.tf
@@ -10,6 +10,10 @@ variable "domain" {}
 variable "domainAlias" {}
 variable "api_domain" {}
 
+variable "xyz_domain" {}
+
+variable "api_xyz_domain" {}
+
 variable "cf_alias_zone_id" {
   description = "Fixed hardcoded constant zone_id that is used for all CloudFront distributions"
   default     = "Z2FDTNDATAQYW2"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -8,7 +8,7 @@
                  :project "cljdoc"}}
  :cljdoc/version #or [#env CLJDOC_VERSION "dev"]
  :cljdoc/server {:port 8000
-                 :host #profile {:prod "cljdoc.xyz"
+                 :host #profile {:prod "cljdoc.org"
                                  :default "localhost"}
                  :analysis-service #profile {:default :local
                                              :prod :circle-ci}


### PR DESCRIPTION
I'm not sure if I got everything here, but it seems like a reasonable start. Rather than trying to do the redirects in Clojure, I added a new server config for the xyz and 301 redirected to the new domain.

api.cljdoc.org also needs to be handled, but that doesn't seem to be currently working (SSL error), so it might not need to be done at the same time.

Fixes #135