### PR TITLE
Only run the deploy on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,3 +75,6 @@ workflows:
       - deploy:
           requires:
             - build
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
This prevents deploys from running in pull requests (which fail because env vars aren't exported) and on cljdoc branches (which would presumably succeed).