### PR TITLE
Add better 404 page

### DIFF
--- a/src/cljdoc/render/error.clj
+++ b/src/cljdoc/render/error.clj
@@ -1,0 +1,16 @@
+(ns cljdoc.render.error
+  (:require [cljdoc.render.layout :as layout]
+            [cljdoc.util :as util]
+            [cljdoc.render.home :as home]))
+
+(def not-found-message-404
+  "We couldn't find anything here...")
+
+(defn not-found-404 []
+  (->> [:div.pt4
+        [:div.mt5.mt6-l.mw7.center.pa4.pa0-l
+         [:p.f2-ns.f3.mv3.w-90-l.lh-copy not-found-message-404]
+         [:p.lh-copy.i "What library are you looking for? Find it here 👇"]
+         (home/search-app)]]
+       (layout/page {})
+       (str)))

--- a/src/cljdoc/render/error.clj
+++ b/src/cljdoc/render/error.clj
@@ -1,15 +1,13 @@
 (ns cljdoc.render.error
-  (:require [cljdoc.render.layout :as layout]
-            [cljdoc.util :as util]
+  (:require [cljdoc.util :as util]
+            [cljdoc.render.layout :as layout]
             [cljdoc.render.home :as home]))
 
-(def not-found-message-404
-  "We couldn't find anything here...")
 
 (defn not-found-404 []
   (->> [:div.pt4
         [:div.mt5.mt6-l.mw7.center.pa4.pa0-l
-         [:p.f2-ns.f3.mv3.w-90-l.lh-copy not-found-message-404]
+         [:p.f2-ns.f3.mv3.w-90-l.lh-copy "We couldn't find anything here..."]
          [:p.lh-copy.i "What library are you looking for? Find it here 👇"]
          (home/search-app)]]
        (layout/page {})

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -268,10 +268,9 @@
   {:name ::not-found-interceptor
    :leave (fn [context]
             (if-not (http/response? (:response context))
-              (do (log/info ::not-found-interceptor)
-                (assoc context :response {:status 404
-                                          :headers {"Content-Type" "text/html"}
-                                          :body (error/not-found-404)}))
+              (assoc context :response {:status 404
+                                        :headers {"Content-Type" "text/html"}
+                                        :body (error/not-found-404)})
               context))})
 
 (defn offline-bundle []

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -2,6 +2,7 @@
   (:require [cljdoc.render.build-req :as render-build-req]
             [cljdoc.render.build-log :as render-build-log]
             [cljdoc.render.home :as render-home]
+            [cljdoc.render.error :as error]
             [cljdoc.render.offline :as offline]
             [cljdoc.renderers.html :as html]
             [cljdoc.analysis.service :as analysis-service]
@@ -263,6 +264,16 @@
            (fn [request opts]
              (etag/add-file-etag request false)))})
 
+(def not-found-interceptor
+  {:name ::not-found-interceptor
+   :leave (fn [context]
+            (if-not (http/response? (:response context))
+              (do (log/info ::not-found-interceptor)
+                (assoc context :response {:status 404
+                                          :headers {"Content-Type" "text/html"}
+                                          :body (error/not-found-404)}))
+              context))})
+
 (defn offline-bundle []
   {:name ::offline-bundle
    :enter (fn offline-bundle [{:keys [cache-bundle] :as ctx}]
@@ -319,7 +330,8 @@
        ;; updated as they change so in these cases using file path is easier
        ;; This breaks the homepage for whatever reason
        ;; ::http/file-path "resources/public"
-       ::http/resource-path "public"}
+       ::http/resource-path "public"
+       ::http/not-found-interceptor not-found-interceptor}
       http/default-interceptors
       (update ::http/interceptors #(into [sentry/interceptor etag-interceptor] %))
       (http/create-server)


### PR DESCRIPTION
This PR addresses issue #32.

1. Add custom interceptor for handling 404 error
1. Add ns, `cljdoc.render.error`, for rendering the error page

Here's a snapshot of the 404 page:

![screenshot_2018-10-18 screenshot](https://user-images.githubusercontent.com/4307599/47192106-eaa55f80-d2ff-11e8-82b0-7c4a459e6b29.png)

On smaller mobile device (iPhone 6)
![screenshot_2018-10-18 screenshot 1](https://user-images.githubusercontent.com/4307599/47192436-36f19f00-d302-11e8-9a4f-8e2ad013af68.png)

On larger mobile device (iPhone 6 plus)
![screenshot_2018-10-18 screenshot 2](https://user-images.githubusercontent.com/4307599/47192456-4d97f600-d302-11e8-85aa-226c8e6f5e68.png)

Any feedback is welcome :) Thanks!