### PR TITLE
Inform users if a newer release is available

### DIFF
--- a/modules/shared-utils/src/cljdoc/spec.cljc
+++ b/modules/shared-utils/src/cljdoc/spec.cljc
@@ -75,9 +75,10 @@
 ;; versioned artifact, e.g. [re-frame 0.10.5]
 (s/def ::defs (s/coll-of ::def-full :gen-max 2))
 (s/def ::namespaces (s/coll-of map? :gen-max 2))
+(s/def ::latest ::version)
 
 (s/def ::docs-cache
-  (s/keys :req-un [::defs ::namespaces]))
+  (s/keys :req-un [::defs ::namespaces ::latest]))
 
 (s/def ::artifacts (s/coll-of string?))
 (s/def ::versions (s/coll-of (s/keys :req-un [::version ::artifact-id])))

--- a/src/cljdoc/bundle.clj
+++ b/src/cljdoc/bundle.clj
@@ -38,6 +38,11 @@
        (map platf/unify-defs)
        (sort-by platf-name)))
 
+(defn more-recent-version
+  [{:keys [cache-contents cache-id]}]
+  (when-not (= (:version cache-id) (:latest cache-contents))
+    (assoc cache-id :version (:latest cache-contents))))
+
 (comment
   (defn cb [id]
     (cljdoc.storage.api/bundle-docs (cljdoc.storage.api/->GrimoireStorage (clojure.java.io/file "data" "grimoire")) id))

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -226,7 +226,7 @@
          (assoc mp-var :platforms))
     mp-var))
 
-(defn namespace-page [{:keys [ns-entity ns-data defs scm-info top-bar-component article-list-component namespace-list-component]}]
+(defn namespace-page [{:keys [ns-entity ns-data defs scm-info top-bar-component upgrade-notice-component article-list-component namespace-list-component]}]
   (cljdoc.spec/assert :cljdoc.spec/namespace-entity ns-entity)
   (assert (platf/multiplatform? ns-data))
   (let [[[dominant-platf] :as platf-stats] (platform-stats defs)
@@ -241,6 +241,7 @@
     [:div.ns-page
      top-bar-component
      (layout/sidebar
+      upgrade-notice-component
       article-list-component
       namespace-list-component)
      (layout/sidebar-two

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -45,6 +45,7 @@
     [:a#js--doc-title.link.blue.ml2 {:href "#"} ""]]])
 
 (defn doc-page [{:keys [top-bar-component
+                        upgrade-notice-component
                         doc-tree-component
                         namespace-list-component
                         doc-scm-url
@@ -52,6 +53,7 @@
   [:div
    top-bar-component
    (layout/sidebar
+    upgrade-notice-component
     (article-list doc-tree-component)
     namespace-list-component)
    (when doc-html doc-nav)

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -112,3 +112,8 @@
        [:img.v-mid.mr2 {:src (str "https://icon.now.sh/" (name (util/scm-provider scm-url)))}]
        [:span.dib (util/scm-coordinate scm-url)]]
       [:a.f6.link.blue {:href (util/github-url :userguide/scm-faq)} "SCM info missing"])]])
+
+(defn upgrade-notice [{:keys [version] :as version-map}]
+  [:a.link {:href (routes/url-for :artifact/version :path-params version-map)}
+   [:div.bg-washed-yellow.pa2.f7.mb4.dark-gray.lh-title
+    "A newer version " [:span.blue "(" version ")"] " for this library is available"]])


### PR DESCRIPTION
While the proper way would have been to check the latest release with `repo.clojars.org`
I decided to just check what's in the database. This avoids the network roundtrip and
through the automatic building of releases things should be somewhat in sync anyways.

This also has the added benefit of only showing the notice when docs have been successfully
built saving the user from clicking and then being asked to run the build (which may fail).

Fixes #161