### PR TITLE
Add <link rel="canonical"> to point to recent version

### DIFF
--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -44,6 +44,9 @@
                  [:meta {:content (:description opts) :property "og:description"}]
                  [:meta {:content "https://cljdoc.org/cljdoc-logo-beta-square.png" :property "og:image"}]
 
+                 ;; Canonical URL -- TODO replace with config
+                 [:link {:rel "canonical" :href (str "https://cljdoc.org" (:canonical-url opts))}]
+
                  (when (:responsive? opts)
                    [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}])
                  [:meta {:charset "utf-8"}]

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -135,6 +135,9 @@
                    {:cache-id cache-id
                     :doc-tree (doctree/get-subtree doc-tree doc-slug-path)})))
          (layout/page {:title (str (:title doc-p) " — " (util/clojars-id cache-id) " " (:version cache-id))
+                       :canonical-url (some->> (bundle/more-recent-version cache-bundle)
+                                               (merge route-params)
+                                               (routes/url-for :artifact/doc :path-params))
                        :description (layout/description cache-id)}))))
 
 (defmethod render :artifact/namespace
@@ -165,6 +168,9 @@
                                                     :namespaces (bundle/namespaces cache-bundle)
                                                     :defs (:defs cache-contents)})))
          (layout/page {:title (str (:namespace ns-emap) " — " (util/clojars-id cache-id) " " (:version cache-id))
+                       :canonical-url (some->> (bundle/more-recent-version cache-bundle)
+                                               (merge route-params)
+                                               (routes/url-for :artifact/namespace :path-params))
                        :description (layout/description cache-id)}))))
 
 (comment


### PR DESCRIPTION
Deliberately delaying this until .org migration (#158) is done.