### PR TITLE
on windows, string of URI is not a valid file,...

### DIFF
--- a/modules/analysis-runner/src/cljdoc/analysis/runner.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/runner.clj
@@ -45,7 +45,7 @@
                       (printf "Downloading remote jar...\n")
                       (copy jar-uri jar-f)
                       (.getPath jar-f))
-                    (str jar-uri))]
+                    (str (io/file jar-uri)))]
     (printf "Unpacking %s\n" jar-local)
     (unzip! jar-local target-dir)
     ;; Some projects include their `out` directories in their jars,


### PR DESCRIPTION
but io/file of URI should be valid on all plattforms.
small part of #171 