### PR TITLE
only include deps of scope 'provided`, 'system' and 'test'

### DIFF
--- a/modules/analysis-runner/src/cljdoc/analysis/runner.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/runner.clj
@@ -109,8 +109,8 @@
                                                 ;; supplying :dir is necessary to avoid local deps.edn being included
                                                 ;; once -Srepro is finalized it might be useful for this purpose
                                                 :dir (.getParentFile f))
+                                 _ (print-process-result process)
                                  result (util/read-cljdoc-edn f)]
-                             (print-process-result process)
                              (when (zero? (:exit process))
                                (assert result "No data was saved in output file")
                                result))))]

--- a/modules/shared-utils/src/cljdoc/util/deps.clj
+++ b/modules/shared-utils/src/cljdoc/util/deps.clj
@@ -47,7 +47,7 @@
   file but this situation being an edge case this is a sufficient fix for now."
   [pom]
   (->> (pom/dependencies (pom/parse (slurp pom)))
-       (keep (fn [{:keys [group-id artifact-id version]}]
+       (keep (fn [{:keys [group-id artifact-id version scope]}]
                (when-not (or (.startsWith artifact-id "boot-")
                              ;; Ensure that tools.reader version is used as specified by CLJS
                              (and (= group-id "org.clojure")
@@ -55,7 +55,9 @@
                              ;; The version can be nil when pom's utilize dependencyManagement - this unsurprisingly breaks tools.deps
                              ;; Remains to be seen if this causes any issues
                              ;; http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
-                             (nil? version))
+                             (nil? version)
+                             ;; compile/runtime scopes will be included by the normal dependency resolution.
+                             (not (#{"provided" "system" "test"} scope)))
                  [(symbol group-id artifact-id) {:mvn/version version}])))
        (into {})))
 

--- a/modules/shared-utils/src/cljdoc/util/deps.clj
+++ b/modules/shared-utils/src/cljdoc/util/deps.clj
@@ -47,7 +47,9 @@
   file but this situation being an edge case this is a sufficient fix for now."
   [pom]
   (->> (pom/dependencies (pom/parse (slurp pom)))
-       (keep (fn [{:keys [group-id artifact-id version scope]}]
+       ;; compile/runtime scopes will be included by the normal dependency resolution.
+       (filter #(#{"provided" "system" "test"} (:scope %)))
+       (keep (fn [{:keys [group-id artifact-id version]}]
                (when-not (or (.startsWith artifact-id "boot-")
                              ;; Ensure that tools.reader version is used as specified by CLJS
                              (and (= group-id "org.clojure")
@@ -55,9 +57,7 @@
                              ;; The version can be nil when pom's utilize dependencyManagement - this unsurprisingly breaks tools.deps
                              ;; Remains to be seen if this causes any issues
                              ;; http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
-                             (nil? version)
-                             ;; compile/runtime scopes will be included by the normal dependency resolution.
-                             (not (#{"provided" "system" "test"} scope)))
+                             (nil? version))
                  [(symbol group-id artifact-id) {:mvn/version version}])))
        (into {})))
 


### PR DESCRIPTION
also print analyzer result before reading the cljdoc edn, because this fails when the analyzer failed.

Fixes #147 