### PR TITLE
Bold artifact coordinates for request-build-page

### DIFF
--- a/src/cljdoc/render/build_req.clj
+++ b/src/cljdoc/render/build_req.clj
@@ -9,7 +9,7 @@
         (layout/top-bar-generic)
         [:div.pa4-ns.pa2
          [:h1 "Want to build some documentation?"]
-         [:p "We currently don't have documentation built for " (util/clojars-id route-params) " v" (:version route-params)]
+         [:p "We currently don't have documentation built for " [:b (util/clojars-id route-params)] " version " [:b (:version route-params)]]
          (if (repositories/find-artifact-repository (util/clojars-id route-params) (:version route-params))
            [:form.pv3 {:action "/api/request-build2" :method "POST"}
             [:input.pa2.mr2.br2.ba.outline-0.blue {:type "text" :id "project" :name "project" :value (str (:group-id route-params) "/" (:artifact-id route-params))}]


### PR DESCRIPTION
This makes it clearer which parts cljdoc is using for searching and can help show people why they might have gone wrong. Adding the "v" in front of the version by itself looks slightly confusing. It's not obvious that it was added in the formatting, but wasn't included in the search.

<img width="828" alt="screenshot of google chrome 23-10-18 9-38-47 am" src="https://user-images.githubusercontent.com/811954/47320246-5fd0b600-d6ad-11e8-8d1f-74b2fc82d756.png">
