### PR TITLE
Remove margin from homepage and 404 page on mobile

### DIFF
--- a/src/cljdoc/render/error.clj
+++ b/src/cljdoc/render/error.clj
@@ -6,7 +6,7 @@
 
 (defn not-found-404 []
   (->> [:div.pt4
-        [:div.mt5.mt6-l.mw7.center.pa4.pa0-l
+        [:div.mt5-ns.mt6-l.mw7.center.pa4.pa0-l
          [:p.f2-ns.f3.mv3.w-90-l.lh-copy "We couldn't find anything here..."]
          [:p.lh-copy.i "What library are you looking for? Find it here 👇"]
          (home/search-app)]]

--- a/src/cljdoc/render/home.clj
+++ b/src/cljdoc/render/home.clj
@@ -25,7 +25,7 @@
 
 (defn home []
   (->> [:div.pt4
-        [:div.mt5.mw7.center.pa4.pa0-l
+        [:div.mt5-ns.mw7.center.pa4.pa0-l
          [:h1.ma0
           [:span.dn "cljdoc beta"]
           [:img {:src "/cljdoc-logo-beta.svg" :alt "cljdoc logo" :width "150px"}]]
@@ -37,7 +37,7 @@
           [:a.link.blue.nowrap {:href "/d/compojure/compojure/1.6.1"} "compojure"] ", "
           [:a.link.blue.nowrap {:href "/d/clojure.java-time/clojure.java-time/0.3.2"} "clojure.java-time"] "."]]
 
-        [:div.mt5.bg-white
+        [:div.mt5-ns.bg-white
          (into [:div.dt-l.dt--fixed.bb.bt.b--light-gray.lh-copy]
                (map feature-block
                     [{:title "Automated Docs"


### PR DESCRIPTION
Improves the mobile styling for #156 in a small way.

Before/after

Before | After
:------:|:--------:
<img width="405" alt="screenshot of google chrome 23-10-18 10-31-03 am" src="https://user-images.githubusercontent.com/811954/47321308-ee930200-d6b0-11e8-9aef-acd163069814.png"> | <img width="400" alt="screenshot of google chrome 23-10-18 10-31-10 am" src="https://user-images.githubusercontent.com/811954/47321313-f488e300-d6b0-11e8-8b5f-d5dce4dc8932.png">
