### PR TITLE
Create a sitemap

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -40,6 +40,7 @@
         raven-clj {:mvn/version "1.6.0-alpha2"},
         org.clojure/test.check {:mvn/version "0.9.0"},
         me.raynes/fs {:mvn/version "1.4.6"},
+        sitemap {:mvn/version "0.2.4"},
 
         ;; These deps are dependencies of shared-utils and are
         ;; duplicated in the global modules/shared-utils/deps.edn,

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -11,6 +11,7 @@
             [cljdoc.server.pedestal-util :as pu]
             [cljdoc.server.routes :as routes]
             [cljdoc.server.api :as api]
+            [cljdoc.server.sitemap :as sitemap]
             [cljdoc.storage.api :as storage]
             [cljdoc.util :as util]
             [cljdoc.util.repositories :as repos]
@@ -32,6 +33,11 @@
   (assoc ctx :response {:status 200
                         :body (str body)
                         :headers {"Content-Type" "text/html"}}))
+
+(defn ok-xml! [ctx body]
+  (assoc ctx :response {:status 200
+                        :body (str body)
+                        :headers {"Content-Type" "text/xml"}}))
 
 (def render-interceptor
   {:name  ::render
@@ -301,6 +307,7 @@
   (->> (case route-name
          :home       [{:name ::home :enter #(ok-html! % (render-home/home))}]
          :shortcuts  [{:name ::shortcuts :enter #(ok-html! % (render-meta/shortcuts))}]
+         :sitemap    [{:name ::sitemap :enter #(ok-xml! % (sitemap/sitemap %))}]
          :show-build [pu/coerce-body
                       (pu/negotiate-content #{"text/html" "application/edn" "application/json"})
                       (show-build build-tracker)]

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -307,7 +307,7 @@
   (->> (case route-name
          :home       [{:name ::home :enter #(ok-html! % (render-home/home))}]
          :shortcuts  [{:name ::shortcuts :enter #(ok-html! % (render-meta/shortcuts))}]
-         :sitemap    [{:name ::sitemap :enter #(ok-xml! % (sitemap/sitemap %))}]
+         :sitemap    [{:name ::sitemap :enter #(ok-xml! % (sitemap/sitemap storage))}]
          :show-build [pu/coerce-body
                       (pu/negotiate-content #{"text/html" "application/edn" "application/json"})
                       (show-build build-tracker)]

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -42,7 +42,8 @@
 
 (defn info-pages-routes []
   #{["/" :get nop :route-name :home]
-    ["/shortcuts" :get nop :route-name :shortcuts]})
+    ["/shortcuts" :get nop :route-name :shortcuts]}
+  #{["/sitemap.xml" :get nop :route-name :sitemap]})
 
 (defn utility-routes []
   #{["/jump/release/*project" :get nop :route-name :jump-to-project]

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -42,8 +42,8 @@
 
 (defn info-pages-routes []
   #{["/" :get nop :route-name :home]
-    ["/shortcuts" :get nop :route-name :shortcuts]}
-  #{["/sitemap.xml" :get nop :route-name :sitemap]})
+    ["/shortcuts" :get nop :route-name :shortcuts]
+    ["/sitemap.xml" :get nop :route-name :sitemap]})
 
 (defn utility-routes []
   #{["/jump/release/*project" :get nop :route-name :jump-to-project]

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -8,9 +8,10 @@
 
 (defn- query->url-entries
   [{:keys [group_id artifact_id name]}]
-  {:loc     (routes/url-for :artifact/version :path-params {:group-id    group_id
-                                                            :artifact-id artifact_id
-                                                            :version     name})
+  {:loc     (str "https://cljdoc.org"
+                 (routes/url-for :artifact/version :path-params {:group-id    group_id
+                                                                 :artifact-id artifact_id
+                                                                 :version     name}))
    :lastmod (.format (java.text.SimpleDateFormat. "yyyy-MM-dd") (java.util.Date.))})
 
 (defn build [db-spec]

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -1,24 +1,23 @@
 (ns cljdoc.server.sitemap
-  (:require [sitemap.core :refer [generate-sitemap-and-save validate-sitemap]]
+  (:require [clojure.java.io :as io]
+            [sitemap.core :refer [generate-sitemap validate-sitemap]]
             [clojure.tools.logging :as log]
             [cljdoc.config :as cfg]
             [cljdoc.storage.api :as storage]
             [cljdoc.server.routes :as routes]))
 
-
 (defn- query->url-entries
   [{:keys [group_id artifact_id name]}]
-  {:loc     (routes/url-for :artifact/version :path-params {:group-id group_id
+  {:loc     (routes/url-for :artifact/version :path-params {:group-id    group_id
                                                             :artifact-id artifact_id
-                                                            :version name})
+                                                            :version     name})
    :lastmod (.format (java.text.SimpleDateFormat. "yyyy-MM-dd") (java.util.Date.))})
 
-(defn sitemap [db-spec]
+(defn build [db-spec]
   (->>
    (storage/all-distinct-docs db-spec)
    (map query->url-entries)
-   (generate-sitemap-and-save "sitemap.xml")
-  ))
+   (generate-sitemap)))
 
 (comment
   (def db-spec
@@ -35,7 +34,7 @@
   (query->url-entries (first docs))
 
   (validate-sitemap
-   (sitemap db-spec)
+   (build db-spec)
    )
 
   )

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -1,6 +1,6 @@
 (ns cljdoc.server.sitemap
   (:require [clojure.java.io :as io]
-            [sitemap.core :refer [generate-sitemap validate-sitemap]]
+            [sitemap.core :as sitemap]
             [clojure.tools.logging :as log]
             [cljdoc.config :as cfg]
             [cljdoc.storage.api :as storage]
@@ -18,7 +18,7 @@
   (->>
    (storage/all-distinct-docs db-spec)
    (map query->url-entries)
-   (generate-sitemap)))
+   (sitemap/generate-sitemap)))
 
 (comment
   (def db-spec
@@ -34,7 +34,7 @@
 
   (query->url-entries (first docs))
 
-  (validate-sitemap
+  (sitemap/validate-sitemap
    (build db-spec)
    )
 

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -11,8 +11,7 @@
   {:loc     (str "https://cljdoc.org"
                  (routes/url-for :artifact/version :path-params {:group-id    group_id
                                                                  :artifact-id artifact_id
-                                                                 :version     name}))
-   :lastmod (.format (java.text.SimpleDateFormat. "yyyy-MM-dd") (java.util.Date.))})
+                                                                 :version     name}))})
 
 (defn- assert-valid-sitemap [sitemap]
   (if (seq (sitemap/validate-sitemap sitemap))

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -8,10 +8,11 @@
 
 (defn sitemap [db-spec]
   (generate-sitemap
-   (for [{:keys [group_id artifact_id] :as doc} (storage/all-distinct-docs db-spec)]
+   (for [{:keys [group_id artifact_id name] :as doc} (storage/all-distinct-docs db-spec)]
      {:loc
-      (routes/url-for :artifact/current :path-params {:group-id group_id
-                                                      :artifact-id artifact_id})}))
+      (routes/url-for :artifact/version :path-params {:group-id group_id
+                                                      :artifact-id artifact_id
+                                                      :version name})}))
   )
 
 (comment
@@ -20,7 +21,7 @@
         (cfg/db)
         (storage/->SQLiteStorage)))
 
-  (routes/url-for :artifact/current :path-params {:group-id "a" :artifact-id "b"})
+  (routes/url-for :artifact/version :path-params {:group-id "a" :artifact-id "b" :version "c"})
 
   (storage/all-distinct-docs db-spec)
 

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -14,11 +14,17 @@
                                                                  :version     name}))
    :lastmod (.format (java.text.SimpleDateFormat. "yyyy-MM-dd") (java.util.Date.))})
 
+(defn- assert-valid-sitemap [sitemap]
+  (if (seq (sitemap/validate-sitemap sitemap))
+    (throw (ex-info "Invalide sitemap generated" {}))
+    sitemap))
+
 (defn build [db-spec]
   (->>
    (storage/all-distinct-docs db-spec)
    (map query->url-entries)
-   (sitemap/generate-sitemap)))
+   (sitemap/generate-sitemap)
+   (assert-valid-sitemap)))
 
 (comment
   (def db-spec
@@ -38,5 +44,20 @@
    (build db-spec)
    )
 
+  (->>
+   (sitemap/generate-sitemap [{:loc "http://example.com/about"
+                       :lastmod "2014-07-00"
+                       :changefreq "monthly"
+                       :priority "0.5"}])
+   (assert-valid-sitemap)
   )
 
+  (->>
+   (sitemap/generate-sitemap [{:loc "http://example.com/about"
+                               :lastmod "2014-07-24"
+                               :changefreq "monthly"
+                               :priority "0.5"}])
+   (assert-valid-sitemap)
+   )
+
+)

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -1,0 +1,16 @@
+(ns cljdoc.server.sitemap
+  (:require [sitemap.core :refer [generate-sitemap]]
+            [clojure.tools.logging :as log]
+            [cljdoc.storage.sqlite_impl :as storage]))
+
+
+(defn sitemap [var]
+  (generate-sitemap [{:loc "http://hashobject.com/about"
+                      :lastmod "2013-05-31"
+                      :changefreq "monthly"
+                      :priority "0.8"}
+                     {:loc "http://hashobject.com/team"
+                      :lastmod "2013-06-01"
+                      :changefreq "monthly"
+                      :priority "0.9"}]))
+

--- a/src/cljdoc/storage/api.clj
+++ b/src/cljdoc/storage/api.clj
@@ -8,6 +8,7 @@
   (exists? [_ entity])
   (bundle-docs [_ version-entity])
   (bundle-group [_ group-entity])
+  (all-distinct-docs [_])
   )
 
 (defrecord SQLiteStorage [db-spec]
@@ -29,4 +30,6 @@
   (bundle-docs [_ {:keys [group-id artifact-id version] :as version-entity}]
     (sqlite/bundle-docs db-spec version-entity))
   (bundle-group [_ {:keys [group-id]}]
-    (sqlite/bundle-group db-spec group-id)))
+    (sqlite/bundle-group db-spec group-id))
+  (all-distinct-docs [_]
+    (sqlite/all-distinct-docs db-spec)))

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -100,7 +100,7 @@
 ;; API --------------------------------------------------------------------------
 
 (defn all-distinct-docs [db-spec]
-  (sql/query db-spec ["select distinct group_id, artifact_id, name from versions"]))
+  (sql/query db-spec ["select group_id, artifact_id, name from versions"]))
 
 (defn docs-available? [db-spec group-id artifact-id version-name]
   (or (sql-exists? db-spec ["select exists(select id from versions where group_id = ? and artifact_id = ? and name = ? and meta not null)"

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -100,7 +100,7 @@
 ;; API --------------------------------------------------------------------------
 
 (defn all-distinct-docs [db-spec]
-  (sql/query db-spec ["select distinct group_id, artifact_id from versions"]))
+  (sql/query db-spec ["select distinct group_id, artifact_id, name from versions"]))
 
 (defn docs-available? [db-spec group-id artifact-id version-name]
   (or (sql-exists? db-spec ["select exists(select id from versions where group_id = ? and artifact_id = ? and name = ? and meta not null)"

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -99,6 +99,9 @@
 
 ;; API --------------------------------------------------------------------------
 
+(defn all-distinct-docs [db-spec]
+  (sql/query db-spec ["select distinct group_id, artifact_id from versions"]))
+
 (defn docs-available? [db-spec group-id artifact-id version-name]
   (or (sql-exists? db-spec ["select exists(select id from versions where group_id = ? and artifact_id = ? and name = ? and meta not null)"
                             group-id artifact-id version-name])
@@ -164,6 +167,11 @@
 
 (comment
   (def data (clojure.edn/read-string (slurp "https://2941-119377591-gh.circle-artifacts.com/0/cljdoc-edn/stavka/stavka/0.4.1/cljdoc.edn")))
+
+  (def db-spec
+   (cljdoc.config/db (cljdoc.config/config)))
+
+  (all-distinct-docs db-spec)
 
   (import-api db-spec
               (select-keys data [:group-id :artifact-id :version])


### PR DESCRIPTION
Fixes #162 

Here's a summary of what this PR does:

- Add `sitemap` as a dependency
- Add a /sitemap.xml route
- Create ns cljdoc.server.sitemap
- Add a storage API `all-distinct-docs` which queries the versions table for distinct (group_id, artifact_id) pairs
- Resolve urls based on (group_id, artifact_id) pairs and transform them to sitemap.xml

Things yet to be done:
- [x] Change to absolute url
- [x] Fix tests (homepage is 404)
- [x]  Validate the sitemap
- [x] ~~Add :lastmod to sitemap~~
- [x] Change to current versioned URL
- [x] Cache the sitemap (use Cache-Control header, cache in memory, or save on disk, etc)
- [ ] ~~Use the generate-sitemap-and-save*~~

Below is what I got so far. Please feel free to give me your comments. Thanks!

![screen shot 2018-10-31 at 11 18 41 am](https://user-images.githubusercontent.com/4307599/47809752-dea59e80-dcfe-11e8-8ead-5184865e4712.png)
