### PR TITLE
Reverse order of analysis

### DIFF
--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -8,7 +8,7 @@
 
   Services that implement this interface will receive all relevant information
   via their `trigger-build` method. The expectation then is that the services
-  will eventually call `/api/full-build` with the appropriate params.
+  will eventually call `/api/ingest-api` with the appropriate params.
 
   Initially this has been done with CircleCI but this is tricky during local
   development (webhooks and all). A local service is now implemented for this
@@ -49,7 +49,7 @@
    {:accept "application/json"
     :basic-auth [(:api-token circle-ci) ""]}))
 
-(defrecord Local [full-build-url]
+(defrecord Local [ingest-api-url]
   IAnalysisService
   (trigger-build
     [_ {:keys [build-id project version jarpath pompath]}]
@@ -59,8 +59,8 @@
         (log/infof "Starting local analysis for %s %s %s" project version jarpath)
         (let [cljdoc-edn-file (analysis/analyze-impl (symbol project) version jarpath pompath)]
           (log/infof "Got file from Local AnalysisService %s" cljdoc-edn-file)
-          (log/info "Posting to" full-build-url)
-          (http/post full-build-url
+          (log/info "Posting to" ingest-api-url)
+          (http/post ingest-api-url
                      {:form-params {:project project
                                     :version version
                                     :build-id build-id

--- a/src/cljdoc/cli.clj
+++ b/src/cljdoc/cli.clj
@@ -26,14 +26,14 @@
                             util/read-cljdoc-edn)
         storage  (storage/->SQLiteStorage (config/db (config/config)))
         scm-info (ingest/scm-info project (:pom-str analysis-result))]
-    (ingest/ingest-cljdoc-edn storage analysis-result)
     (when (or (:url scm-info) git)
       (ingest/ingest-git! storage
                           {:project project
                            :version version
                            :scm-url (:url scm-info)
                            :local-scm git
-                           :pom-revision (or rev (:sha scm-info))}))))
+                           :pom-revision (or rev (:sha scm-info))}))
+    (ingest/ingest-cljdoc-edn storage analysis-result)))
 
 (defn run [opts]
   (system/-main))

--- a/src/cljdoc/render/build_log.clj
+++ b/src/cljdoc/render/build_log.clj
@@ -149,6 +149,15 @@
          (:analysis_requested_ts build-info)
          [:h3.mt0 "Analysis Requested"])
 
+        ;; NOTE Slight mess ahead. Up until around 2018-11-08 builds
+        ;; first ran API analysis on CircleCI and only then continued
+        ;; with Git analysis. Now it's the other way around but
+        ;; covering all these cases with conditionals would have made
+        ;; this namespace even more annoying than it already is and so
+        ;; I just changed the order of the sections, ignoring that
+        ;; older builds will show stuff in an order that is not
+        ;; chronological.
+        (git-import-section build-info)
         (api-import-section build-info)
 
         (when (:error build-info)
@@ -160,8 +169,6 @@
            build-info)} "build job"] " to understand why this build
            failed and reach out if you aren't sure how to fix the issue."]
            #_[:p (cljdoc-link build-info true)]))
-
-        (git-import-section build-info)
 
         (when-not (done? build-info)
           [:script

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -19,7 +19,7 @@
 (defn api-routes []
   #{["/api/ping" :get nop :route-name :ping]
     ["/api/request-build2" :post nop :route-name :request-build]
-    ["/api/full-build" :post nop :route-name :full-build]
+    ["/api/ingest-api" :post nop :route-name :ingest-api]
     ["/api/hooks/circle-ci" :post nop :route-name :circle-ci-webhook]})
 
 (defn build-log-routes []

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -34,7 +34,7 @@
                        :analysis-service (ig/ref :cljdoc/analysis-service)
                        :storage          (storage/->SQLiteStorage (cfg/db env-config))}
      :cljdoc/analysis-service (case ana-service
-                                :local     [:local {:full-build-url (str "http://localhost:" port "/api/full-build")}]
+                                :local     [:local {:ingest-api-url (str "http://localhost:" port "/api/ingest-api")}]
                                 :circle-ci [:circle-ci (cfg/circle-ci env-config)])
      :cljdoc/dogstats (cfg/statsd env-config)}))
 
@@ -42,7 +42,7 @@
   (log/infof "Starting Analysis Service %s" type)
   (case type
     :circle-ci (analysis-service/circle-ci opts)
-    :local     (analysis-service/->Local (:full-build-url opts))))
+    :local     (analysis-service/->Local (:ingest-api-url opts))))
 
 (defmethod ig/init-key :cljdoc/sqlite [_ {:keys [db-spec dir]}]
   (.mkdirs (io/file dir))

--- a/test/cljdoc/integration_test.clj
+++ b/test/cljdoc/integration_test.clj
@@ -57,12 +57,13 @@
       (loop [i 20]
         (if (pos? i)
           (when-not (.contains (:body (pdt/response-for (service-fn @sys) :get build-uri))
-                               "Git Import Completed")
+                               "API imported successfully")
             (do (Thread/sleep 2000)
                 (recur (dec i))))
           (throw (Exception. "Import took too long"))))
 
       (t/is (true? (.contains (:body (pdt/response-for (service-fn @sys) :get build-uri)) "Git Import Completed")))
+      (t/is (true? (.contains (:body (pdt/response-for (service-fn @sys) :get build-uri)) "API imported successfully")))
 
       (t/is (= 302 (:status (pdt/response-for (service-fn @sys) :get "/d/reagent/reagent/0.8.1"))))
 


### PR DESCRIPTION
The process of building documentation can be thought of as two steps:

1. Analysing a Jar and extracting information about a projects API
2. Analysing a projects Git repository to include a README, provide correct source links etc.

So far the order above has also been the order in which those steps were executed but it turns out that under some circumstances the information from the Git repository may be relevant for the Jar analysis. Primarily users may want to further configure the Jar analysis via the `cljdoc.edn` file in their Git repository (see #107 for more details).

This PR. changes the order of the two steps above, only triggering the CircleCI job after the Git analysis has been completed (successfully or not).  