### PR TITLE
Responsive Documentation Pages

### DIFF
--- a/js/cljdoc.js
+++ b/js/cljdoc.js
@@ -8,8 +8,10 @@ function isProjectDocumentationPage() {
 }
 
 function initSrollIndicator() {
-  var mainScrollView = document.querySelector(".main-scroll-view");
-  var sidebarScrollView = document.querySelector(".sidebar-scroll-view");
+  var mainScrollView = document.querySelector(".js--main-scroll-view");
+  var sidebarScrollView = document.querySelector(
+    ".js--namespace-contents-scroll-view"
+  );
   var defBlockTitles = Array.from(
     document.querySelectorAll(".def-block-title")
   );
@@ -80,7 +82,7 @@ function restoreSidebarScrollPos() {
     .join("/");
 
   if (scrollPosData && page == scrollPosData.page) {
-    Array.from(document.querySelectorAll(".js--sidebar"))[0].scrollTop =
+    Array.from(document.querySelectorAll(".js--main-sidebar"))[0].scrollTop =
       scrollPosData.scrollTop;
   }
 

--- a/js/cljdoc.js
+++ b/js/cljdoc.js
@@ -2,8 +2,9 @@ function isNSPage() {
   return document.querySelector(".ns-page");
 }
 
-function isDocPage() {
-  return document.querySelector("#doc-html");
+function isProjectDocumentationPage() {
+  let pathSegs = window.location.pathname.split("/");
+  return pathSegs.length >= 5 && pathSegs[1] == "d";
 }
 
 function initSrollIndicator() {
@@ -71,46 +72,6 @@ function initToggleRaw() {
   addToggleHandlers();
 }
 
-function initDocTitle() {
-  var mainScrollView = document.querySelector(".main-scroll-view");
-  var docHtml = document.querySelector("#doc-html");
-  var docHeaders = Array.from(
-    docHtml.querySelectorAll("h1, h2, h3, h4, h5, h6")
-  );
-  var docTitle = document.querySelector("#js--doc-title");
-  var lastIndex = null;
-
-  function isBelow(container, element) {
-    var containerTop = container.getBoundingClientRect().top;
-    var elementTop = element.getBoundingClientRect().top - 1;
-    // minus one for anchors to be correct
-    return containerTop > elementTop;
-  }
-
-  function immediatelyAbove(container, elements) {
-    for (let j = 0; j < elements.length - 1; j++) {
-      if (!isBelow(container, elements[j + 1])) {
-        return j;
-      }
-    }
-    return elements.length - 1;
-  }
-
-  function changeTitle() {
-    var index = immediatelyAbove(mainScrollView, docHeaders);
-    if (index !== lastIndex) {
-      var anchor = docHeaders[index].querySelector("a");
-      var url = new URL(anchor.href);
-      docTitle.innerText = anchor.innerText;
-      docTitle.href = url.hash;
-      // set last index so it doesn't trigger super often
-      lastIndex = index;
-    }
-  }
-  mainScrollView.addEventListener("scroll", changeTitle);
-  changeTitle();
-}
-
 function restoreSidebarScrollPos() {
   var scrollPosData = JSON.parse(localStorage.getItem("sidebarScrollPos"));
   var page = window.location.pathname
@@ -147,9 +108,8 @@ function toggleMetaDialog() {
 export {
   initSrollIndicator,
   initToggleRaw,
-  initDocTitle,
   restoreSidebarScrollPos,
   toggleMetaDialog,
   isNSPage,
-  isDocPage
+  isProjectDocumentationPage
 };

--- a/js/doctree.js
+++ b/js/doctree.js
@@ -1,3 +1,7 @@
+function isDocLink(linkEl) {
+  return linkEl.pathname.startsWith("/d/");
+}
+
 export function hideNestedArticles() {
   let currentPath = location.pathname;
   let articleLinks = Array.from(document.querySelectorAll(".js--articles a"));
@@ -8,9 +12,12 @@ export function hideNestedArticles() {
     }
   }
 
-  function isDocLink(link) {
-    return link.pathname.startsWith("/d/");
-  }
-
   articleLinks.filter(isDocLink).map(hideNested);
+}
+
+export function showNestedArticles() {
+  let hiddenLinks = Array.from(
+    document.querySelectorAll(".js--articles ul.dn")
+  );
+  hiddenLinks.map(n => n.classList.remove("dn"));
 }

--- a/js/index.js
+++ b/js/index.js
@@ -2,6 +2,7 @@ import { render, h } from "preact";
 import { trackProjectOpened, Switcher } from "./switcher";
 import { hideNestedArticles } from "./doctree";
 import { App } from "./search";
+import { MobileNav } from "./mobile";
 import {
   isNSPage,
   isProjectDocumentationPage,
@@ -24,6 +25,7 @@ if (isNSPage()) {
 }
 
 if (isProjectDocumentationPage()) {
+  render(h(MobileNav), document.querySelector("#js--mobile-nav"));
   toggleMetaDialog();
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -4,10 +4,9 @@ import { hideNestedArticles } from "./doctree";
 import { App } from "./search";
 import {
   isNSPage,
-  isDocPage,
+  isProjectDocumentationPage,
   initSrollIndicator,
   initToggleRaw,
-  initDocTitle,
   restoreSidebarScrollPos,
   toggleMetaDialog
 } from "./cljdoc";
@@ -24,16 +23,12 @@ if (isNSPage()) {
   initToggleRaw();
 }
 
-if (isDocPage()) {
-  initDocTitle();
-}
-
-if (isDocPage() || isNSPage()) {
+if (isProjectDocumentationPage()) {
   toggleMetaDialog();
 }
 
 window.onbeforeunload = function() {
-  var sidebar = Array.from(document.querySelectorAll(".js--sidebar"))[0];
+  var sidebar = Array.from(document.querySelectorAll(".js--main-sidebar"))[0];
   if (sidebar) {
     var scrollTop = sidebar.scrollTop;
     var page = window.location.pathname

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -1,0 +1,46 @@
+import { Component, render, h } from "preact";
+import * as doctree from "./doctree";
+
+export class MobileNav extends Component {
+  constructor() {
+    super();
+    this.toggleNav = this.toggleNav.bind(this);
+  }
+
+  toggleNav() {
+    let mainScrollView = document.querySelector(".js--main-scroll-view");
+    let mainSidebar = document.querySelector(".js--main-sidebar");
+    let isMainContentHidden = mainScrollView.classList.contains("dn");
+    if (isMainContentHidden) {
+      mainScrollView.classList.remove("dn"); // show main scroll view / content area
+      mainSidebar.classList.replace("db", "dn"); // hide sidebar
+      doctree.hideNestedArticles();
+      this.setState({ showNav: false });
+    } else {
+      mainScrollView.classList.add("dn"); // hide main scroll view / content area
+      mainSidebar.classList.add("flex-grow-1"); // make sure nav fills width of screen
+      mainSidebar.classList.replace("dn", "db"); // show sidebar
+      doctree.showNestedArticles();
+      this.setState({ showNav: true });
+    }
+  }
+
+  render(props, state) {
+    let btnMsg = state.showNav
+      ? "Back to Content"
+      : "Tap for Articles & Namespaces";
+    let btnIcon = state.showNav ? "chevronLeft" : "list";
+    let btnSrc = "https://icon.now.sh/" + btnIcon + "/32";
+    return (
+      <div class="bg-light-gray">
+        <button
+          class="outline-0 bw0 bg-transparent w-100 tl pa2"
+          onClick={this.toggleNav}
+        >
+          <img class="dib mr2 v-mid" src={btnSrc} height="32" />
+          <span class="dib">{btnMsg}</span>
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -201,20 +201,17 @@
 
 (defn sub-namespace-overview-page
   [{:keys [ns-entity namespaces defs top-bar-component article-list-component namespace-list-component]}]
-  [:div.ns-page
-   top-bar-component
-   (layout/sidebar
-    article-list-component
-    namespace-list-component)
-   (layout/main-container
-    {:offset "16rem"}
-    [:div.w-80-ns.pv5
-     (for [mp-ns (->> namespaces
-                     (filter #(.startsWith (platf/get-field % :name) (:namespace ns-entity))))
-           :let [ns (platf/get-field mp-ns :name)
-                 ns-url-fn #(routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace %))
-                 defs (bundle/defs-for-ns defs ns)]]
-       (namespace-overview ns-url-fn mp-ns defs))])])
+  (layout/layout
+   {:top-bar top-bar-component
+    :main-sidebar-contents [article-list-component
+                            namespace-list-component]
+    :content [:div.mw7.center.pv4
+              (for [mp-ns (->> namespaces
+                               (filter #(.startsWith (platf/get-field % :name) (:namespace ns-entity))))
+                    :let [ns (platf/get-field mp-ns :name)
+                          ns-url-fn #(routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace %))
+                          defs (bundle/defs-for-ns defs ns)]]
+                (namespace-overview ns-url-fn mp-ns defs))]}))
 
 (defn add-src-uri
   [{:keys [platforms] :as mp-var} scm-base file-mapping]
@@ -239,24 +236,21 @@
         render-wiki-link (render-wiki-link-fn (:namespace ns-entity)
                                               #(routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace %)))]
     [:div.ns-page
-     top-bar-component
-     (layout/sidebar
-      upgrade-notice-component
-      article-list-component
-      namespace-list-component)
-     (layout/sidebar-two
-      (platform-support-note platf-stats)
-      (definitions-list ns-entity defs
-        {:indicate-platforms-other-than dominant-platf}))
-     (layout/main-container
-      {:offset "32rem"}
-      [:div.w-80-ns.pv4
-       [:h2 (:namespace ns-entity)]
-       (render-doc ns-data render-wiki-link)
-       (for [def defs]
-         (def-block
-           (add-src-uri def scm-base file-mapping)
-           render-wiki-link))])]))
+     (layout/layout
+      {:top-bar top-bar-component
+       :main-sidebar-contents [upgrade-notice-component
+                               article-list-component
+                               namespace-list-component]
+       :vars-sidebar-contents [(platform-support-note platf-stats)
+                               (definitions-list ns-entity defs
+                                 {:indicate-platforms-other-than dominant-platf})]
+       :content [:div.w-80-ns.pv4
+                 [:h2 (:namespace ns-entity)]
+                 (render-doc ns-data render-wiki-link)
+                 (for [def defs]
+                   (def-block
+                     (add-src-uri def scm-base file-mapping)
+                     render-wiki-link))]})]))
 
 (comment
   (:platforms --d)

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -35,7 +35,8 @@
                  (let [slug-path (-> doc-page :attrs :slug-path)]
                    [:li
                     [:a.link.blue.hover-dark-blue.dib.pa1
-                     {:href  (doc-link cache-id slug-path)
+                     {:style {:word-wrap "break-word"}
+                      :href  (doc-link cache-id slug-path)
                       :class (when (= current-page slug-path) "fw7")}
                      (:title doc-page)]
                     (doc-tree-view cache-id (:children doc-page) current-page (inc level))])))

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -42,12 +42,6 @@
           (into [:ul.list.pl2
                  {:class (when (pos? level) "f6-ns mb3")}])))))
 
-(def doc-nav
-  [:div.bb.b--black-10.ml7.ph4-ns.ph2
-   [:div.mw7.center.pv2
-    [:span "Current Section:"]
-    [:a#js--doc-title.link.blue.ml2 {:href "#"} ""]]])
-
 (defn doc-page [{:keys [top-bar-component
                         upgrade-notice-component
                         doc-tree-component
@@ -60,7 +54,6 @@
     upgrade-notice-component
     (article-list doc-tree-component)
     namespace-list-component)
-   (when doc-html doc-nav)
    (layout/main-container
     (cond-> {:offset "16rem"}
       doc-html (assoc :extra-height 34))

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -49,44 +49,38 @@
                         namespace-list-component
                         doc-scm-url
                         doc-html] :as args}]
-  [:div
-   top-bar-component
-   (layout/sidebar
-    upgrade-notice-component
-    (article-list doc-tree-component)
-    namespace-list-component)
-   (layout/main-container
-    (cond-> {:offset "16rem"}
-      doc-html (assoc :extra-height 34))
-    [:div.mw7.center
-     ;; TODO dispatch on a type parameter that becomes part of the attrs map
-     (if doc-html
-       [:div#doc-html.markdown.lh-copy.pv4
-        (hiccup/raw doc-html)
-        [:a.db.f7.tr {:href doc-scm-url} (if (= :gitlab (util/scm-provider doc-scm-url))
-                                           "Edit on GitLab"
-                                           "Edit on GitHub")]]
-       [:div.lh-copy.pv6.tc
-        #_[:pre (pr-str (dissoc args :top-bar-component :doc-tree-component :namespace-list-component))]
-        [:span.f4.serif.gray.i "Space intentionally left blank."]])])])
+  (layout/layout
+   {:top-bar top-bar-component
+    :main-sidebar-contents [upgrade-notice-component
+                            (article-list doc-tree-component)
+                            namespace-list-component]
+    :content [:div.mw7.center
+              ;; TODO dispatch on a type parameter that becomes part of the attrs map
+              (if doc-html
+                [:div#doc-html.markdown.lh-copy.pv4
+                 (hiccup/raw doc-html)
+                 [:a.db.f7.tr {:href doc-scm-url} (if (= :gitlab (util/scm-provider doc-scm-url))
+                                                    "Edit on GitLab"
+                                                    "Edit on GitHub")]]
+                [:div.lh-copy.pv6.tc
+                 #_[:pre (pr-str (dissoc args :top-bar-component :doc-tree-component :namespace-list-component))]
+                 [:span.f4.serif.gray.i "Space intentionally left blank."]])]}))
 
 (defn doc-overview [{:keys [top-bar-component
                             doc-tree-component
                             namespace-list-component
                             cache-id
                             doc-tree] :as args}]
-  [:div
-   top-bar-component
-   (layout/sidebar
-    (article-list doc-tree-component)
-    namespace-list-component)
-   (layout/main-container
-    {:offset "16rem"}
-    [:div.mw7.center.pv4
-     [:h1 (:title doc-tree)]
-     [:ol
-      (for [c (:children doc-tree)]
-        [:li.mv2
-         [:a.link.blue
-          {:href (doc-link cache-id (-> c :attrs :slug-path))}
-          (-> c :title)]])]])])
+  [:div.doc-page
+   (layout/layout
+    {:top-bar top-bar-component
+     :main-sidebar-contents [(article-list doc-tree-component)
+                             namespace-list-component]
+     :content [:div.mw7.center.pv4
+               [:h1 (:title doc-tree)]
+               [:ol
+                (for [c (:children doc-tree)]
+                  [:li.mv2
+                   [:a.link.blue
+                    {:href (doc-link cache-id (-> c :attrs :slug-path))}
+                    (-> c :title)]])]]})])

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -134,14 +134,14 @@
    [:a.dib.v-mid.link.dim.gray.f6.mr3
     {:href (routes/url-for :artifact/index :path-params cache-id)}
     (:version cache-id)]
-   [:a {:href "/"}
+   [:a.dn.dib-ns {:href "/"}
     [:span.link.dib.v-mid.mr3.pv1.ph2.ba.hover-blue.br1.ttu.fw5.f7.silver.tracked "cljdoc Beta"]]
-   [:a.silver.link.hover-blue.ttu.fw5.f7.tracked.pv1
+   [:a.dn.dib-ns.silver.link.hover-blue.ttu.fw5.f7.tracked.pv1
     {:href (util/github-url :issues)}
     "Have Feedback?"]
    [:div.tr
     {:style {:flex-grow 1}}
-    [:form.dib.mr3 {:action "/api/request-build2" :method "POST"}
+    [:form.dn.dib-ns.mr3 {:action "/api/request-build2" :method "POST"}
      [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "project" :name "project" :value (str (:group-id cache-id) "/" (:artifact-id cache-id))}]
      [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "version" :name "version" :value (:version cache-id)}]
      [:input.f7.white.hover-near-white.outline-0.bn.bg-white {:type "submit" :value "rebuild"}]]

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -96,12 +96,15 @@
 
 (defmethod render :artifact/version
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
-  (->> [:div
-        (layout/top-bar cache-id (-> cache-contents :version :scm :url))
-        (layout/sidebar
-         (articles/article-list
-          (articles/doc-tree-view cache-id (doctree/add-slug-path (-> cache-contents :version :doc)) []))
-         (api/namespace-list {} (bundle/ns-entities cache-bundle)))]
+  (->> (layout/layout
+        ;; TODO on mobile this will effectively be rendered as a blank page
+        ;; We could instead show a message and the namespace tree.
+        {:top-bar (layout/top-bar cache-id (-> cache-contents :version :scm :url))
+         :main-sidebar-contents [(articles/article-list
+                                  (articles/doc-tree-view cache-id
+                                                          (doctree/add-slug-path (-> cache-contents :version :doc))
+                                                          []))
+                                 (api/namespace-list {} (bundle/ns-entities cache-bundle))]})
        (layout/page {:title (str (util/clojars-id cache-id) " " (:version cache-id))
                      :description (layout/description cache-id)})))
 


### PR DESCRIPTION
Fixes #156 

👉 See a [video preview](https://giant.gfycat.com/EthicalGraveFairyfly.mp4). 

This makes all the main documentation pages of cljdoc responsive and introduces a special UI element that helps to switch between navigation and documentation content. The UX is largely inspired by Docusaurus ([example page](https://docusaurus.io/docs/en/adding-blog)).

This also replaces a bunch of nested `absolute` and `fixed` elements and makes heavy use of Flexbox, making the entire layout a bit easier to work with (or wieldy as some like to say).

I'd appreciate if other contributors could give this a go locally and report back any issues.

--- 

Interestingly what was hardest about this is getting the scroll behaviour right. Smooth momentum based scrolling as well as automatic collapsing of the URL bar took quite some time to figure out.