### PR TITLE
Various analysis runner improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ jobs:
 
     working_directory: ~/repo
 
-    environment:
-      BOOT_JVM_OPTIONS: -Xmx2048m # Customize the JVM maximum heap limit
-
     steps:
       - checkout
       - restore_cache:
@@ -34,6 +31,7 @@ jobs:
 
       - run: ./script/cljdoc ingest --project bidi --version 2.1.3
       - run: ./script/analyze.sh bidi 2.1.3 ~/.m2/repository/bidi/bidi/2.1.3/bidi-2.1.3.jar ~/.m2/repository/bidi/bidi/2.1.3/bidi-2.1.3.pom
+      - run: ./.circleci/run_if_changed.sh modules/analysis-runner/ "cd modules/analysis-runner/; clojure extended-test.clj"
 
       - run: clojure -A:test
       - store_test_results:

--- a/.circleci/run_if_changed.sh
+++ b/.circleci/run_if_changed.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ dir=$1
+ testCommand=$2
+ branch=$(git rev-parse --abbrev-ref HEAD)
+
+ if git diff --name-only origin/master...$branch  | grep "^${dir}" ; then
+   echo "$dir HAS BEEN MODIFIED"
+   eval $testCommand
+ else
+   echo "NO"
+ fi

--- a/modules/analysis-runner/deps.edn
+++ b/modules/analysis-runner/deps.edn
@@ -2,5 +2,6 @@
  ;; These deps are dependencies of shared-utils and are
  ;; duplicated in the global deps.edn, updates should be
  ;; done in both places. More context in main deps.edn.
- :deps {org.jsoup/jsoup {:mvn/version "1.11.3"}
+ :deps {org.clojure/tools.deps.alpha {:mvn/version "0.5.460"}
+        org.jsoup/jsoup {:mvn/version "1.11.3"}
         version-clj {:mvn/version "0.1.2"}}}

--- a/modules/analysis-runner/extended-test.clj
+++ b/modules/analysis-runner/extended-test.clj
@@ -1,0 +1,41 @@
+(require '[clojure.java.shell :as sh]
+         '[clojure.string :as string]
+         '[clojure.pprint])
+
+(def candidates
+  [;; depends on ring/ring-core which requires [javax.servlet/servlet-api "2.5"]
+   ["metosin/compojure-api" "2.0.0-alpha27" "http://repo.clojars.org/metosin/compojure-api/2.0.0-alpha27/compojure-api-2.0.0-alpha27"]
+   ;; depends on tools.namepspace 0.3.0-alpha4, cljdoc explicitly declared 0.2.11
+   ["iced-nrepl" "0.2.5" "https://repo.clojars.org/iced-nrepl/iced-nrepl/0.2.5/iced-nrepl-0.2.5"]
+   ;; known to work
+   ["bidi" "2.1.3" "http://repo.clojars.org/bidi/bidi/2.1.3/bidi-2.1.3"]
+   ;; had some issues with older ClojureScript and analysis env
+   ["orchestra" "2018.11.07-1" "http://repo.clojars.org/orchestra/orchestra/2018.11.07-1/orchestra-2018.11.07-1"]
+   ;; might have had some issues related to old versions of core.async in the past
+   ["manifold" "0.1.8" "http://repo.clojars.org/manifold/manifold/0.1.8/manifold-0.1.8"]])
+
+(def sep
+  "\n---------------------------------------------------------------------------")
+
+(defn exit [results]
+  (clojure.pprint/print-table results)
+  (shutdown-agents)
+  (if (some false? (map :success? results))
+    (System/exit 1)
+    (System/exit 0)))
+
+(->> (for [[project version url-base] candidates]
+       (let [args ["clojure" "-m" "cljdoc.analysis.runner" project version (str url-base ".jar") (str url-base ".pom")]
+             _ (do (println "Analyzing" project version) (println (string/join " " args) sep))
+             {:keys [exit out]} (apply sh/sh args)]
+         (when-not (zero? exit)
+           (println "Analysis failed for" project version sep)
+           (println out)
+           (println sep))
+
+         {:project project
+          :version version
+          :success? (zero? exit)}))
+     (sort-by :success?)
+     (exit))
+

--- a/modules/analysis-runner/extended-test.clj
+++ b/modules/analysis-runner/extended-test.clj
@@ -12,7 +12,9 @@
    ;; had some issues with older ClojureScript and analysis env
    ["orchestra" "2018.11.07-1" "http://repo.clojars.org/orchestra/orchestra/2018.11.07-1/orchestra-2018.11.07-1"]
    ;; might have had some issues related to old versions of core.async in the past
-   ["manifold" "0.1.8" "http://repo.clojars.org/manifold/manifold/0.1.8/manifold-0.1.8"]])
+   ["manifold" "0.1.8" "http://repo.clojars.org/manifold/manifold/0.1.8/manifold-0.1.8"]
+   ;; https://dev.clojure.org/jira/browse/CLJS-2964
+   ["speculative" "0.0.3-SNAPSHOT" "http://repo.clojars.org/speculative/speculative/0.0.3-SNAPSHOT/speculative-0.0.3-20181116.104047-47"]])
 
 (def sep
   "\n---------------------------------------------------------------------------")

--- a/modules/analysis-runner/src/cljdoc/analysis/deps.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/deps.clj
@@ -53,7 +53,9 @@
   other more test-focused dependencies are kept out."
   [{:keys [group-id artifact-id]}]
   (contains? #{'javax.servlet/javax.servlet-api
-               'org.clojure/core.async}
+               'org.clojure/core.async
+               ;; https://dev.clojure.org/jira/browse/CLJS-2964
+               'org.clojure/test.check}
              (symbol group-id artifact-id)))
 
 (defn- extra-deps

--- a/modules/analysis-runner/src/cljdoc/analysis/deps.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/deps.clj
@@ -1,4 +1,4 @@
-(ns cljdoc.util.deps
+(ns cljdoc.analysis.deps
   (:require [clojure.java.io :as io]
             [version-clj.core :as v]
             [cljdoc.util :as util]

--- a/modules/shared-utils/src/cljdoc/util.clj
+++ b/modules/shared-utils/src/cljdoc/util.clj
@@ -32,6 +32,15 @@
   ;; TODO maybe delete, currently not used (like other codox stuff)
   (str "codox-edn/" project "/" version "/codox.edn"))
 
+(def analysis-output-prefix
+  "The -main of `cljdoc.analysis.runner` will write files to this directory.
+
+  Be careful when changing it since that path is also hardcoded in the
+  [cljdoc-builder](https://github.com/martinklepsch/cljdoc-builder)
+  CircleCI configuration"
+  ;; ---
+  "/tmp/cljdoc/analysis-out/")
+
 (defn cljdoc-edn
   [project version]
   {:pre [(some? project) (string? version)]}

--- a/modules/shared-utils/src/cljdoc/util/pom.clj
+++ b/modules/shared-utils/src/cljdoc/util/pom.clj
@@ -1,9 +1,13 @@
 (ns cljdoc.util.pom
   (:require [clojure.string :as string])
-  (:import (org.jsoup Jsoup)))
+  (:import (org.jsoup Jsoup)
+           (org.jsoup.nodes Document)))
 
 (defn parse [pom-str]
   (Jsoup/parse pom-str))
+
+(defn jsoup? [x]
+  (instance? Document x))
 
 (defn text [^Jsoup doc sel]
   (when-let [t (some-> (.select doc sel) (first) (.ownText))]


### PR DESCRIPTION
This improves the situation around the analysis runner in a few ways:

- It's more decoupled from the rest of the server code. Previously the local analysis service would call `analyze-impl`. Now it shells out which will launch another `clojure` process. This is only for development but allows a cleaner separation of dependencies etc.
- A testing script that runs the analysis runner in various project and reports the results in a nice table. Thanks `clojure.pprint`!
- Some more scripts to run that testing script whenever the analysis runner changed.
- More docstrings in the analysis-runner related namespaces
- The classpath is now computed within the analysis runner and passed to `clojure` via `-Scp`. This should make things faster and allow us to further customise the resolved deps should we need to. This also allows us to print the entire tree of dependencies before analysis.

@IamDrowsy requesting a review from you since you are the only other person that touched this code. Don't worry if it's too overwhelming but if it isn't I'd appreciate your feedback 🙂 