### PR TITLE
Fix for #203

### DIFF
--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -116,6 +116,7 @@
   (if-let [version-id (get-version-id db-spec group-id artifact-id version)]
     (let [versions-on-cljdoc (->> (get-documented-versions db-spec group-id artifact-id)
                                   (map :name)
+                                  (remove #(.endsWith % "-SNAPSHOT"))
                                   (version-clj/version-sort))]
       (->> {:cache-contents (-> (docs-cache-contents db-spec version-id)
                                 (assoc :latest (last versions-on-cljdoc)))


### PR DESCRIPTION
excluding snapshot versions from the "new version available" warning