### PR TITLE
Poll CircleCI instead of relying on webhooks

### DIFF
--- a/doc/adr/0016-prefer-polling-over-webhooks.md
+++ b/doc/adr/0016-prefer-polling-over-webhooks.md
@@ -1,0 +1,49 @@
+# Prefer Polling over Webhooks
+
+## Status
+
+Accepted (related to [ADR #0008](0008-use-circleci-as-analysis-sandbox.md))
+
+## Context
+
+cljdoc uses CircleCI as a sandbox to run analysis on projects as
+outlined in [ADR #0008](0008-use-circleci-as-analysis-sandbox.md).
+
+The process currenlty works like this:
+
+1. cljdoc queues a build
+1. CircleCI eventually runs the build
+1. cljdoc is notified via a webhook
+
+This approach is nice because we don't need to constantly check the status
+of a build until it eventually finishes but it also has a few drawbacks:
+
+- Testing anything involving webhooks in a local development
+  environment is a serious pain
+- Code related to running the analysis and storing it's result are
+  spread accross multiple places making the code harder to follow and
+  maintain
+
+## Decision
+
+Move to a model where the respective analysis service (CircleCI or Local)
+exposes a blocking interface for running the analysis.
+
+For CircleCI this blocking interface will simply poll the CircleCI build until
+it reached [lifecycle `"finished"`](https://circleci.com/docs/api/v1-reference/#build).
+
+## Consequences
+
+Unsolved problems applying to both approaches:
+
+**Restarting the cljdoc server can cause a loss of state.**
+
+- Webhooks may arrive at a time the server is restarted/offline.
+- Background processes running analysis may be terminated by
+  restarting the service.
+
+**It may take longer until analysis is finished.**
+
+- We poll whether the analysis job completed every 5 seconds.
+- So in consequence, loading the result of analysis may be delayed by
+  up to 5 seconds from the moment the job finished.

--- a/modules/shared-utils/src/cljdoc/util.clj
+++ b/modules/shared-utils/src/cljdoc/util.clj
@@ -56,7 +56,9 @@
                          %))
        (pr-str)))
 
-(defn read-cljdoc-edn [file]
+(defn read-cljdoc-edn
+  [file]
+  {:pre [(some? file)]}
   (edn/read-string {:readers {'regex re-pattern}} (slurp file)))
 
 (defn git-dir [project version]

--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -3,35 +3,60 @@
             [clojure.tools.logging :as log]
             [clojure.string :as string]
             [clojure.java.shell :as sh]
+            [cheshire.core :as json]
             [cljdoc.util :as util]))
 
 (defprotocol IAnalysisService
   "Services that can run analysis of Clojure code for us
 
   Services that implement this interface will receive all relevant information
-  via their `trigger-build` method. The expectation then is that the services
-  will eventually call `/api/ingest-api` with the appropriate params.
+  via their `trigger-build` method. The result of `trigger-build` can then be
+  passed to `wait-for-build` which will block until the the build finished."
+  (trigger-build [_ {:keys [build-id project version jarpath pompath]}])
+  (wait-for-build [_ build-info]))
 
-  Initially this has been done with CircleCI but this is tricky during local
-  development (webhooks and all). A local service is now implemented for this
-  purpose."
-  (trigger-build [_ {:keys [build-id project version jarpath pompath]}]))
+;; CircleCI AnalysisService -----------------------------------------------------
+
+(declare get-circle-ci-build-artifacts get-circle-ci-build poll-circle-ci-build)
 
 (defrecord CircleCI [api-token builder-project analyzer-version]
   IAnalysisService
   (trigger-build
     [_ {:keys [build-id project version jarpath pompath]}]
     {:pre [(int? build-id) (string? project) (string? version) (string? jarpath) (string? pompath)]}
-    (http/post (str "https://circleci.com/api/v1.1/project/" builder-project "/tree/master")
-               {:accept "application/json"
-                ;; https://github.com/hiredman/clj-http-lite/issues/15
-                :form-params {"build_parameters[CLJDOC_ANALYZER_VERSION]" analyzer-version
-                              "build_parameters[CLJDOC_BUILD_ID]" build-id
-                              "build_parameters[CLJDOC_PROJECT]" project
-                              "build_parameters[CLJDOC_PROJECT_VERSION]" version
-                              "build_parameters[CLJDOC_PROJECT_JAR]" jarpath
-                              "build_parameters[CLJDOC_PROJECT_POM]" pompath}
-                :basic-auth [api-token ""]})))
+    (log/infof "Starting CircleCI analysis for %s %s %s" project version jarpath)
+    (let [build (http/post (str "https://circleci.com/api/v1.1/project/" builder-project "/tree/master")
+                           {:accept "application/json"
+                            ;; https://github.com/hiredman/clj-http-lite/issues/15
+                            :form-params {"build_parameters[CLJDOC_ANALYZER_VERSION]" analyzer-version
+                                          "build_parameters[CLJDOC_BUILD_ID]" build-id
+                                          "build_parameters[CLJDOC_PROJECT]" project
+                                          "build_parameters[CLJDOC_PROJECT_VERSION]" version
+                                          "build_parameters[CLJDOC_PROJECT_JAR]" jarpath
+                                          "build_parameters[CLJDOC_PROJECT_POM]" pompath}
+                            :basic-auth [api-token ""]})
+          build-data (-> build :body json/parse-string)]
+      {:build-num (get build-data "build_num")
+       :build-url (get build-data "build_url")
+       :project   project
+       :version   version}))
+  (wait-for-build
+    [this {:keys [project version build-num]}]
+    (assert (string? project))
+    (assert (string? version))
+    (assert (integer? build-num))
+    (let [done-build (poll-circle-ci-build this build-num)
+          success?   (contains? #{"success" "fixed"} (get done-build "status"))
+          cljdoc-edn (cljdoc.util/cljdoc-edn project version)]
+      (let [artifacts (-> (get-circle-ci-build-artifacts this build-num)
+                          :body json/parse-string)]
+        (if-let [artifact (and success?
+                               (= 1 (count artifacts))
+                               (= cljdoc-edn (get (first artifacts) "path"))
+                               (first artifacts))]
+          {:analysis-result (get artifact "url")}
+          (throw (ex-info "Analysis on CircleCI failed"
+                          {:service :circle-ci, :build done-build})))))))
 
 (defn circle-ci
   [{:keys [api-token builder-project analyzer-version]}]
@@ -43,44 +68,60 @@
 (defn circle-ci? [x]
   (instance? CircleCI x))
 
-(defn get-circle-ci-build-artifacts
+(defn- get-circle-ci-build-artifacts
   [circle-ci build-num]
   (assert (circle-ci? circle-ci) (format "not a CircleCI instance: %s" circle-ci))
   (http/get
-   (str "https://circleci.com/api/v1.1/project/" (:builder-project circle-ci) "/" build-num "/artifacts?circle-token=:token")
-   {:accept "application/json"
-    :basic-auth [(:api-token circle-ci) ""]}))
+   (str "https://circleci.com/api/v1.1/project/" (:builder-project circle-ci) "/" build-num "/artifacts")
+   {:accept "application/json", :basic-auth [(:api-token circle-ci) ""]}))
 
-(defn run-analyze-script
-  "Run ./script/analyze.sh and return the path to the file containing
-  analysis results. This is also the script that is used in the \"production\"
-  [cljdoc-builder project](https://github.com/martinklepsch/cljdoc-builder)"
-  [project version jarpath pompath]
-  (let [args ["./script/analyze.sh" project version jarpath pompath]]
-    (when-not (zero? (:exit (apply sh/sh args)))
-      (throw (Exception. (str "Error running: " (string/join " " args)))))
-    (str util/analysis-output-prefix (util/cljdoc-edn project version))))
+(defn- get-circle-ci-build
+  [circle-ci build-num]
+  (assert (circle-ci? circle-ci) (format "not a CircleCI instance: %s" circle-ci))
+  (http/get
+   (str "https://circleci.com/api/v1.1/project/" (:builder-project circle-ci) "/" build-num)
+   {:accept "application/json", :basic-auth [(:api-token circle-ci) ""]}))
 
-(defrecord Local [ingest-api-url]
+(defn- poll-circle-ci-build [circle-ci build-num]
+  (loop [n 60] ; 60 * 5s = 5min
+    (log/info "CircleCI: Polling build" build-num)
+    (let [build (-> (get-circle-ci-build circle-ci build-num)
+                    :body json/parse-string)]
+      (cond
+        (= "finished" (get build "lifecycle"))
+        build
+
+        (pos? n)
+        (do (Thread/sleep 5000)
+            (recur (dec n)))
+
+        :else
+        (throw (ex-info "Build timeout" {:build-num build-num}))))))
+
+;; Local Analysis Service -------------------------------------------------------
+
+(defrecord Local []
   IAnalysisService
   (trigger-build
     [_ {:keys [build-id project version jarpath pompath]}]
     {:pre [(int? build-id) (string? project) (string? version) (string? jarpath) (string? pompath)]}
     (future
-      (try
-        (log/infof "Starting local analysis for %s %s %s" project version jarpath)
-        (let [cljdoc-edn-file (run-analyze-script project version jarpath pompath)]
-          (log/infof "Got file from Local AnalysisService %s" cljdoc-edn-file)
-          (log/info "Posting to" ingest-api-url)
-          (http/post ingest-api-url
-                     {:form-params {:project project
-                                    :version version
-                                    :build-id build-id
-                                    :cljdoc-edn cljdoc-edn-file}
-                      :content-type "application/x-www-form-urlencoded"
-                      :basic-auth ["cljdoc" "cljdoc"]}))
-        (catch Throwable t
-          (log/errorf t "Exception while analyzing %s %s, see cljdoc.analysis.service for help" project version))))))
+      (log/infof "Starting local analysis for %s %s %s" project version jarpath)
+      ;; Run ./script/analyze.sh and return the path to the file containing
+      ;; analysis results. This is also the script that is used in the "production"
+      ;; [cljdoc-builder project](https://github.com/martinklepsch/cljdoc-builder)
+      (let [proc            (apply sh/sh ["./script/analyze.sh" project version jarpath pompath])
+            cljdoc-edn-file (str util/analysis-output-prefix (util/cljdoc-edn project version))]
+        {:analysis-result cljdoc-edn-file
+         :proc proc})))
+  (wait-for-build
+    [_ build-future]
+    (let [{:keys [analysis-result proc]} @build-future]
+      (log/infof "Got file from Local AnalysisService %s" analysis-result)
+      (if (zero? (:exit proc))
+        {:analysis-result analysis-result}
+        (throw (ex-info "Analysis with local AnalysisService failed"
+                        {:service :local, :proc proc}))))))
 
 (comment
   (def r

--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -76,6 +76,10 @@
    {:accept "application/json", :basic-auth [(:api-token circle-ci) ""]}))
 
 (defn- get-circle-ci-build
+  "Retrieve information about the build identified by `build-num`. The project
+  is retrieved from the `circle-ci` AnalysisService instance.
+
+  Also see: https://circleci.com/docs/api/v1-reference/#build"
   [circle-ci build-num]
   (assert (circle-ci? circle-ci) (format "not a CircleCI instance: %s" circle-ci))
   (http/get
@@ -124,7 +128,22 @@
                         {:service :local, :proc proc}))))))
 
 (comment
-  (def r
-    (let [b "http://repo.clojars.org/speculative/speculative/0.0.2/speculative-0.0.2"]
-      (sh/sh "./script/analyze.sh" "speculative"  "0.0.2" (str b ".jar") (str b ".pom"))))
+
+  (def p-succeed
+    {:project "bidi"
+     :version "2.1.3"
+     :jarpath "http://repo.clojars.org/bidi/bidi/2.1.3/bidi-2.1.3.jar"
+     :pompath "http://repo.clojars.org/bidi/bidi/2.1.3/bidi-2.1.3.pom"})
+
+  (def p-fail
+    {:project "com.lemondronor/ads-b"
+     :version "0.1.3"
+     :jarpath "https://repo.clojars.org/com/lemondronor/ads-b/0.1.3/ads-b-0.1.3.jar"
+     :pompath "https://repo.clojars.org/com/lemondronor/ads-b/0.1.3/ads-b-0.1.3.pom"})
+
+  (let [service (or #_(circle-ci (cljdoc.config/circle-ci))
+                    (->Local))
+        build   (trigger-build service p-fail)]
+    (wait-for-build service build))
+
   )

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -75,7 +75,7 @@
 
 (comment
   (kick-off-build!
-   {:storage (cljdoc.storage.api/->SQLiteStorage (cljdoc.config/db (cljdoc.config/config)))
+   {:storage (:cljdoc/storage integrant.repl.state/system)
     :analysis-service (:cljdoc/analysis-service integrant.repl.state/system)
     :build-tracker (:cljdoc/build-tracker integrant.repl.state/system)}
    {:project "bidi" :version "2.1.3"})

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -1,83 +1,70 @@
 (ns cljdoc.server.api
   (:require [cljdoc.analysis.service :as analysis-service]
-            [cljdoc.util.telegram :as telegram]
             [cljdoc.server.ingest :as ingest]
             [cljdoc.server.build-log :as build-log]
             [cljdoc.util :as util]
             [cljdoc.util.repositories :as repositories]
-            [cljdoc.config] ; should not be necessary but instead be passed as args
-            [cljdoc.renderers.html :as html]
-            [clojure.tools.logging :as log]
-            [clj-http.lite.client :as http]
-            [cheshire.core :as json]))
+            [clojure.tools.logging :as log]))
 
+(defn analyze-and-import-api!
+  [{:keys [analysis-service storage build-tracker]}
+   {:keys [project version jar pom build-id]}]
+  ;; More work is TBD here in order to pass the configuration
+  ;; received from a users Git repository into the analysis service
+  ;; https://github.com/cljdoc/cljdoc/issues/107
+  (let [ana-v    (:analyzer-version analysis-service)
+        ana-resp (analysis-service/trigger-build
+                  analysis-service
+                  {:project project
+                   :version version
+                   :jarpath jar
+                   :pompath pom
+                   :build-id build-id})]
 
-;; Circle CI API stuff -----------------------------------------------
-;; TODO move into separate namespace and maybe record later
+    ;; `build-url` and `ana-v` are only set for CircleCI
+    (build-log/analysis-kicked-off! build-tracker build-id (:build-url ana-resp) ana-v)
 
-(defn get-build [circle-ci-config build-num]
-  (http/get (str "https://circleci.com/api/v1.1/project/" (:builder-project circle-ci-config) "/" build-num)
-            {:accept "application/json"
-             :basic-auth [(:api-token circle-ci-config) ""]}))
-
-;; cljdoc API client functions ---------------------------------------
-
-(defn post-api-data-via-http [params]
-  (http/post (str "http://localhost:" (get-in (cljdoc.config/config) [:cljdoc/server :port]) "/api/ingest-api")
-             {:throw-exceptions false
-              :form-params params
-              :content-type "application/x-www-form-urlencoded"
-              :basic-auth ["cljdoc" "cljdoc"]})) ;TODO fix
-
-(defn test-webhook [circle-ci-config build-num]
-  (let [payload (-> (get-build circle-ci-config build-num) :body json/parse-string)]
-    (http/post (str "http://localhost:" (get-in (cljdoc.config/config) [:cljdoc/server :port]) "/api/hooks/circle-ci")
-               {:body (json/generate-string {"payload" payload})
-                :content-type "application/json"})))
+    (try
+      (let [build-result (analysis-service/wait-for-build analysis-service ana-resp)
+            file-uri     (:analysis-result build-result)
+            data         (util/read-cljdoc-edn file-uri)
+            ns-count     (let [{:strs [clj cljs]} (:codox data)]
+                           (count (set (into (map :name cljs) (map :name clj)))))]
+        (build-log/analysis-received! build-tracker build-id file-uri)
+        (ingest/ingest-cljdoc-edn storage data)
+        (build-log/api-imported! build-tracker build-id ns-count)
+        (build-log/completed! build-tracker build-id))
+      (catch Exception e
+        (build-log/failed! build-tracker build-id "analysis-job-failed")))))
 
 (defn kick-off-build!
   "Run the Git analysis for the provided `project` and kick of an
   analysis build for `project` using the provided `analysis-service`."
   [{:keys [storage build-tracker analysis-service] :as deps}
-   {:keys [project version] :as project}]
+   {:keys [project version] :as coords}]
   (let [a-uris    (repositories/artifact-uris project version)
         build-id  (build-log/analysis-requested!
                    build-tracker
                    (cljdoc.util/group-id project)
                    (cljdoc.util/artifact-id project)
                    version)
-        kick-off-job! (fn kick-off-job! []
-                        ;; More work is TBD here in order to pass the configuration
-                        ;; received from a users Git repository into the analysis service
-                        ;; https://github.com/cljdoc/cljdoc/issues/107
-                        (let [ana-resp (analysis-service/trigger-build
-                                        analysis-service
-                                        {:project project
-                                         :version version
-                                         :jarpath (:jar a-uris)
-                                         :pompath (:pom a-uris)
-                                         :build-id build-id})]
-                          (if (analysis-service/circle-ci? analysis-service)
-                            (let [build-num (-> ana-resp :body json/parse-string (get "build_num"))
-                                  job-url   (str "https://circleci.com/gh/martinklepsch/cljdoc-builder/" build-num)
-                                  ana-v     (:analyzer-version analysis-service)]
-                              (when (= 201 (:status ana-resp))
-                                (assert build-num "build number missing from CircleCI response")
-                                (build-log/analysis-kicked-off! build-tracker build-id job-url ana-v)
-                                (log/infof "Kicked of analysis job {:build-id %s :circle-url %s}" build-id job-url)))
-                              (build-log/analysis-kicked-off! build-tracker build-id nil nil))))]
+        ana-args  (merge coords a-uris {:build-id build-id})]
+
     (future
       (try
-        (if-let [scm-info (ingest/scm-info project (slurp (:pom a-uris)))]
+        ;; Store meta {} and description
+        (if-let [scm-info (ingest/scm-info (:pom a-uris))]
           (let [{:keys [error scm-url commit] :as git-result}
                 (ingest/ingest-git! storage {:project project
                                              :version version
                                              :scm-url (:url scm-info)
                                              :pom-revision (:sha scm-info)})]
-            (when error (log/warnf "Error while processing %s %s: %s" project version error))
+            (when error
+              (log/warnf "Error while processing %s %s: %s" project version error))
             (build-log/git-completed! build-tracker build-id (update git-result :error :type))
-            (kick-off-job!))
-          (kick-off-job!))
+            (analyze-and-import-api! deps ana-args))
+          (analyze-and-import-api! deps ana-args))
+
         (catch Throwable e
           ;; TODO store in column for internal exception
           (log/error e (format "Exception while processing %s %s (build %s)" project version build-id))
@@ -85,3 +72,12 @@
           (throw e))))
 
     build-id))
+
+(comment
+  (kick-off-build!
+   {:storage (cljdoc.storage.api/->SQLiteStorage (cljdoc.config/db (cljdoc.config/config)))
+    :analysis-service (:cljdoc/analysis-service integrant.repl.state/system)
+    :build-tracker (:cljdoc/build-tracker integrant.repl.state/system)}
+   {:project "bidi" :version "2.1.3"})
+
+  )

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -89,10 +89,6 @@
                          group-id artifact-id version
                          (str (.minus (Instant/now) (Duration/ofMinutes 10)))]))))
 
-(defmethod ig/init-key :cljdoc/build-tracker [_ db-spec]
-  (log/info "Starting BuildTracker")
-  (->SQLBuildTracker db-spec))
-
 (comment
   (require 'ragtime.repl 'ragtime.jdbc)
   (def config {:datastore  (ragtime.jdbc/sql-database (cljdoc.config/db))

--- a/src/cljdoc/server/ingest.clj
+++ b/src/cljdoc/server/ingest.clj
@@ -21,8 +21,9 @@
     (storage/import-api storage artifact (codox/sanitize-macros codox))))
 
 (defn scm-info
-  [project pom-str]
-  (let [pom-doc  (pom/parse pom-str)
+  [pom-url]
+  {:pre [(string? pom-url)]}
+  (let [pom-doc  (pom/parse (slurp pom-url))
         artifact (pom/artifact-info pom-doc)
         scm-info (pom/scm-info pom-doc)
         project  (str (:group-id artifact) "/" (:artifact-id artifact))

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -18,9 +18,7 @@
 
 (defn api-routes []
   #{["/api/ping" :get nop :route-name :ping]
-    ["/api/request-build2" :post nop :route-name :request-build]
-    ["/api/ingest-api" :post nop :route-name :ingest-api]
-    ["/api/hooks/circle-ci" :post nop :route-name :circle-ci-webhook]})
+    ["/api/request-build2" :post nop :route-name :request-build]})
 
 (defn build-log-routes []
   #{["/builds/:id" :get nop :route-name :show-build]

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -34,7 +34,7 @@
                        :analysis-service (ig/ref :cljdoc/analysis-service)
                        :storage          (storage/->SQLiteStorage (cfg/db env-config))}
      :cljdoc/analysis-service (case ana-service
-                                :local     [:local {:ingest-api-url (str "http://localhost:" port "/api/ingest-api")}]
+                                :local     [:local]
                                 :circle-ci [:circle-ci (cfg/circle-ci env-config)])
      :cljdoc/dogstats (cfg/statsd env-config)}))
 
@@ -42,7 +42,7 @@
   (log/infof "Starting Analysis Service %s" type)
   (case type
     :circle-ci (analysis-service/circle-ci opts)
-    :local     (analysis-service/->Local (:ingest-api-url opts))))
+    :local     (analysis-service/->Local)))
 
 (defmethod ig/init-key :cljdoc/sqlite [_ {:keys [db-spec dir]}]
   (.mkdirs (io/file dir))


### PR DESCRIPTION
See [ADR 0016](https://github.com/cljdoc/cljdoc/blob/bd8eb200eb6fe0ac8f3425a28b354d196cab32af/doc/adr/0016-prefer-polling-over-webhooks.md) for a rationale behind this change.

There's probably still some more cleanup to do before merging this.