### PR TITLE
Track description and release date in versions table

### DIFF
--- a/resources/migrations/007-add-description-release-date-to-versions.down.sql
+++ b/resources/migrations/007-add-description-release-date-to-versions.down.sql
@@ -1,0 +1,1 @@
+-- column removal not supported in sqlite

--- a/resources/migrations/007-add-description-release-date-to-versions.up.sql
+++ b/resources/migrations/007-add-description-release-date-to-versions.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE versions ADD description;
+--;;
+ALTER TABLE versions ADD release_date;

--- a/script/import-descriptions.clj
+++ b/script/import-descriptions.clj
@@ -1,0 +1,33 @@
+(require '[cljdoc.server.api :as api]
+         '[cljdoc.util :as util]
+         '[cljdoc.config :as cfg]
+         '[clojure.java.jdbc :as sql]
+         '[clojure.pprint :as pp]
+         '[cljdoc.storage.sqlite-impl :as sqlite]
+         '[cljdoc.util.repositories :as repositories])
+
+(def db (cfg/db (cfg/config)))
+
+(defn get-versions [db]
+  (sql/query db
+             ["SELECT group_id, artifact_id, name FROM versions WHERE release_date IS NULL ORDER BY id LIMIT 100"]
+             {:row-fn #'sqlite/version-row-fn}))
+
+(defn r-info [v]
+  (let [project (str (:group-id v) "/" (:artifact-id v))
+        v-ent   (util/version-entity project (:version v))
+        a-uris  (repositories/artifact-uris project (:version v))]
+    (println (:pom a-uris))
+    (#'api/release-info (:pom a-uris))))
+
+(loop [versions (get-versions db)]
+  (println "Setting description for" (count versions) "releases")
+  (let [v-r-info (zipmap versions (map r-info versions))]
+    (time
+     (sql/with-db-transaction [tx db]
+       (doseq [[v-ent {:keys [release-date description]}] v-r-info]
+         (sqlite/store-artifact! tx v-ent description release-date)))))
+  (let [next-batch (get-versions db)]
+    (when (seq next-batch)
+      (recur next-batch))))
+

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -163,11 +163,11 @@
                                                       (-> ctx :request :form-params :project util/artifact-id)
                                                       (-> ctx :request :form-params :version))]
               (redirect-to-build-page ctx (:id running))
-              (let [build-id (api/kick-off-build!
-                              deps
-                              {:project          (-> ctx :request :form-params :project)
-                               :version          (-> ctx :request :form-params :version)})]
-                (redirect-to-build-page ctx build-id))))})
+              (let [build (api/kick-off-build!
+                           deps
+                           {:project (-> ctx :request :form-params :project)
+                            :version (-> ctx :request :form-params :version)})]
+                (redirect-to-build-page ctx (:build-id build)))))})
 
 (def request-build-validate
   ;; TODO quick and dirty for now

--- a/src/cljdoc/storage/api.clj
+++ b/src/cljdoc/storage/api.clj
@@ -11,6 +11,7 @@
             [cljdoc.storage.sqlite-impl :as sqlite]))
 
 (defprotocol IStorage
+  (import-release [_ version-entity description release-date])
   (import-api [_ version-entity codox])
   (import-doc [_ version-entity {:keys [doc-tree scm jar]}])
   (exists? [_ entity])
@@ -20,12 +21,10 @@
 
 (defrecord SQLiteStorage [db-spec]
   IStorage
+  (import-release [_ version-entity description release-date]
+    (sqlite/store-artifact! db-spec version-entity description release-date))
   (import-api [_ version-entity codox]
     (cljdoc-spec/assert :cljdoc.cljdoc-edn/codox codox)
-    (sqlite/store-artifact! db-spec
-                            (:group-id version-entity)
-                            (:artifact-id version-entity)
-                            [(:version version-entity)])
     (sqlite/import-api db-spec version-entity codox))
   (import-doc [_ version-entity {:keys [doc-tree scm jar] :as version-data}]
     (sqlite/import-doc db-spec version-entity version-data))

--- a/src/cljdoc/util/repositories.clj
+++ b/src/cljdoc/util/repositories.clj
@@ -99,13 +99,14 @@
 
 (def maven-central "http://central.maven.org/maven2/")
 (def clojars "https://repo.clojars.org/")
-(def repositories [maven-central clojars])
 
 (defn find-artifact-repository
   ([project]
-   (first (filter #(exists? % project) repositories)))
+   (cond (exists? clojars project) clojars
+         (exists? maven-central project) maven-central))
   ([project version]
-   (first (filter #(exists? % project version) repositories))))
+   (cond (exists? clojars project version) clojars
+         (exists? maven-central project version) maven-central)))
 
 (defn artifact-uris [project version]
   (if-let [repository (find-artifact-repository project version)]


### PR DESCRIPTION
Fixes #221 

This adds `description` and `release_date` columns to the `versions` table. While this information is useful in multiple situations it's mostly intended for search related functionality. That is for situations where scanning the entirety of the data is important. 

In situations where we're only concerned with metadata on a single artifact I think the approach outlined in #208 is better suited.

This PR also includes some refactoring making `cljdoc.cli` use the same documentation build flow as the regular server.