### PR TITLE
Refactoring: Use kick-off-build! for cli invocations as well

### DIFF
--- a/modules/shared-utils/src/cljdoc/util.clj
+++ b/modules/shared-utils/src/cljdoc/util.clj
@@ -28,6 +28,11 @@
 (defn normalize-project [project]
   (str (group-id project) "/" (artifact-id project)))
 
+(defn version-entity [project version]
+  {:group-id (group-id project)
+   :artifact-id (artifact-id project)
+   :version version})
+
 (defn codox-edn [project version]
   ;; TODO maybe delete, currently not used (like other codox stuff)
   (str "codox-edn/" project "/" version "/codox.edn"))

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -163,11 +163,11 @@
                                                       (-> ctx :request :form-params :project util/artifact-id)
                                                       (-> ctx :request :form-params :version))]
               (redirect-to-build-page ctx (:id running))
-              (let [build-id (api/kick-off-build!
-                              deps
-                              {:project          (-> ctx :request :form-params :project)
-                               :version          (-> ctx :request :form-params :version)})]
-                (redirect-to-build-page ctx build-id))))})
+              (let [build (api/kick-off-build!
+                           deps
+                           {:project (-> ctx :request :form-params :project)
+                            :version (-> ctx :request :form-params :version)})]
+                (redirect-to-build-page ctx (:build-id build)))))})
 
 (def request-build-validate
   ;; TODO quick and dirty for now

--- a/src/cljdoc/util/repositories.clj
+++ b/src/cljdoc/util/repositories.clj
@@ -99,13 +99,14 @@
 
 (def maven-central "http://central.maven.org/maven2/")
 (def clojars "https://repo.clojars.org/")
-(def repositories [maven-central clojars])
 
 (defn find-artifact-repository
   ([project]
-   (first (filter #(exists? % project) repositories)))
+   (cond (exists? clojars project) clojars
+         (exists? maven-central project) maven-central))
   ([project version]
-   (first (filter #(exists? % project version) repositories))))
+   (cond (exists? clojars project version) clojars
+         (exists? maven-central project version) maven-central)))
 
 (defn artifact-uris [project version]
   (if-let [repository (find-artifact-repository project version)]


### PR DESCRIPTION
This unifies are documentation builds are carried out regardless of whether they were initiated from the CLI (`cljdoc.cli`) or the Web UI.