### PR TITLE
Minor fixes for PR #227

### DIFF
--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -112,7 +112,7 @@
         namespaces  (ns-tree/index-by :namespace namespaces)]
     [:div.mb4
      (layout/sidebar-title "Namespaces")
-     [:ul.list.pl2
+     [:ul.list.pl0
       (for [[ns level _ leaf?] (ns-tree/namespace-hierarchy (keys namespaces))
             :let [style {:margin-left (str (* (dec level) 10) "px")}]]
         [:li

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -11,21 +11,18 @@
 (defn article-list [doc-tree]
   [:div.mb4.js--articles
    (layout/sidebar-title "Articles")
-   (or doc-tree
-       [:p.pl2.f7.gray
-        [:a.blue.link {:href (util/github-url :userguide/articles)} "Articles"]
-        " are a practical way to provide additional guidance beyond
+   [:div.mv3
+    (or doc-tree
+        [:p.f7.gray
+         [:a.blue.link {:href (util/github-url :userguide/articles)} "Articles"]
+         " are a practical way to provide additional guidance beyond
        API documentation. To use them, please ensure you "
-        [:a.blue.link {:href (util/github-url :userguide/scm-faq)} "properly set SCM info"]
-        " in your project."])])
+         [:a.blue.link {:href (util/github-url :userguide/scm-faq)} "properly set SCM info"]
+         " in your project."])]])
 
 (defn main-list [doc-tree]
   (when doc-tree
-    [:div.mb4
-     (update doc-tree 0 #(-> %
-                             (name)
-                             (clojure.string/replace ".pl2" ".pl0")
-                             (keyword)))]))
+    [:div.mb4 doc-tree]))
 
 (defn doc-link [cache-id slugs]
   (assert (seq slugs) "Slug path missing")
@@ -50,8 +47,7 @@
                       :class (when (= current-page slug-path) "fw7")}
                      (:title doc-page)]
                     (doc-tree-view cache-id (:children doc-page) current-page (inc level))])))
-          (into [:ul.list.pl2
-                 {:class (when (pos? level) "f6-ns")}])))))
+          (into [:ul.list.ma0 {:class (if (pos? level) "f6-ns pl2" "pl0")}])))))
 
 (defn doc-page [{:keys [top-bar-component
                         upgrade-notice-component

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -83,7 +83,11 @@
                  (highlight-js)]]))
 
 (defn sidebar-title [title]
-  [:h4.ttu.f7.fw5.mt1.mb2.tracked.gray title])
+  [:h4.relative.ttu.f7.fw5.mt1.mb2.tracked.gray
+   ;; .nl4 and .nr4 are negative margins based on the global padding used in the sidebar
+   [:hr.absolute.left-0.right-0.nl4.nr4.b--solid.b--black-10]
+   ;; again negative margins are used to make the background reach over the text container
+   [:span.relative.nl2.nr2.ph2.bg-white title]])
 
 (defn meta-info-dialog []
   [:div


### PR DESCRIPTION
- Remove the indentation of article and namespace trees relative to their sidebar titles
- Introduce some better visual separation between sidebar sections
- Minor code improvements to the way `main-list` and `article-list` work

<img width="1374" alt="screenshot 2018-12-05 at 21 16 20" src="https://user-images.githubusercontent.com/97496/49542713-9d447800-f8d6-11e8-9892-d876abe56005.png">

@dawran6 The destination of this PR is your branch (#227) so you can just merge it if you like it 🙂   