### PR TITLE
Refactor sidebar rendering

### DIFF
--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -8,22 +8,6 @@
             [clojure.string :as string]
             [hiccup2.core :as hiccup]))
 
-(defn article-list [doc-tree]
-  [:div.mb4.js--articles
-   (layout/sidebar-title "Articles")
-   [:div.mv3
-    (or doc-tree
-        [:p.f7.gray
-         [:a.blue.link {:href (util/github-url :userguide/articles)} "Articles"]
-         " are a practical way to provide additional guidance beyond
-       API documentation. To use them, please ensure you "
-         [:a.blue.link {:href (util/github-url :userguide/scm-faq)} "properly set SCM info"]
-         " in your project."])]])
-
-(defn main-list [doc-tree]
-  (when doc-tree
-    [:div.mb4 doc-tree]))
-
 (defn doc-link [cache-id slugs]
   (assert (seq slugs) "Slug path missing")
   (->> (string/join "/" slugs)
@@ -49,48 +33,28 @@
                     (doc-tree-view cache-id (:children doc-page) current-page (inc level))])))
           (into [:ul.list.ma0 {:class (if (pos? level) "f6-ns pl2" "pl0")}])))))
 
-(defn doc-page [{:keys [top-bar-component
-                        upgrade-notice-component
-                        main-list-component
-                        article-list-component
-                        namespace-list-component
-                        doc-scm-url
-                        doc-html] :as args}]
-  (layout/layout
-   {:top-bar top-bar-component
-    :main-sidebar-contents [upgrade-notice-component
-                            (main-list main-list-component)
-                            (article-list article-list-component)
-                            namespace-list-component]
-    :content [:div.mw7.center
-              ;; TODO dispatch on a type parameter that becomes part of the attrs map
-              (if doc-html
-                [:div#doc-html.markdown.lh-copy.pv4
-                 (hiccup/raw doc-html)
-                 [:a.db.f7.tr
-                  {:href doc-scm-url}
-                  (if (= :gitlab (scm/provider doc-scm-url))
-                    "Edit on GitLab"
-                    "Edit on GitHub")]]
-                [:div.lh-copy.pv6.tc
-                 #_[:pre (pr-str (dissoc args :top-bar-component :doc-tree-component :namespace-list-component))]
-                 [:span.f4.serif.gray.i "Space intentionally left blank."]])]}))
+(defn doc-page [{:keys [doc-scm-url doc-html]}]
+  [:div.mw7.center
+   ;; TODO dispatch on a type parameter that becomes part of the attrs map
+   (if doc-html
+     [:div#doc-html.markdown.lh-copy.pv4
+      (hiccup/raw doc-html)
+      [:a.db.f7.tr
+       {:href doc-scm-url}
+       (if (= :gitlab (scm/provider doc-scm-url))
+         "Edit on GitLab"
+         "Edit on GitHub")]]
+     [:div.lh-copy.pv6.tc
+      [:span.f4.serif.gray.i "Space intentionally left blank."]])])
 
-(defn doc-overview [{:keys [top-bar-component
-                            doc-tree-component
-                            namespace-list-component
-                            cache-id
-                            doc-tree] :as args}]
+(defn doc-overview
+  [{:keys [cache-id doc-tree]}]
   [:div.doc-page
-   (layout/layout
-    {:top-bar top-bar-component
-     :main-sidebar-contents [(article-list doc-tree-component)
-                             namespace-list-component]
-     :content [:div.mw7.center.pv4
-               [:h1 (:title doc-tree)]
-               [:ol
-                (for [c (:children doc-tree)]
-                  [:li.mv2
-                   [:a.link.blue
-                    {:href (doc-link cache-id (-> c :attrs :slug-path))}
-                    (-> c :title)]])]]})])
+   [:div.mw7.center.pv4
+    [:h1 (:title doc-tree)]
+    [:ol
+     (for [c (:children doc-tree)]
+       [:li.mv2
+        [:a.link.blue
+         {:href (doc-link cache-id (-> c :attrs :slug-path))}
+         (-> c :title)]])]]])

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -82,12 +82,16 @@
                  [:script {:src "/js/index.js"}]
                  (highlight-js)]]))
 
-(defn sidebar-title [title]
-  [:h4.relative.ttu.f7.fw5.mt1.mb2.tracked.gray
-   ;; .nl4 and .nr4 are negative margins based on the global padding used in the sidebar
-   [:hr.absolute.left-0.right-0.nl4.nr4.b--solid.b--black-10]
-   ;; again negative margins are used to make the background reach over the text container
-   [:span.relative.nl2.nr2.ph2.bg-white title]])
+(defn sidebar-title
+  ([title]
+   (sidebar-title title {:separator-line? true}))
+  ([title {:keys [separator-line?]}]
+   [:h4.relative.ttu.f7.fw5.mt1.mb2.tracked.gray
+    (when separator-line?
+      ;; .nl4 and .nr4 are negative margins based on the global padding used in the sidebar
+      [:hr.absolute.left-0.right-0.nl4.nr4.b--solid.b--black-10])
+    ;; again negative margins are used to make the background reach over the text container
+    [:span.relative.nl2.nr2.ph2.bg-white title]]))
 
 (defn meta-info-dialog []
   [:div

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -1,0 +1,72 @@
+(ns cljdoc.render.sidebar
+  (:require [cljdoc.util :as util]
+            [cljdoc.doc-tree :as doctree]
+            [cljdoc.render.layout :as layout]
+            [cljdoc.render.articles :as articles]
+            [cljdoc.render.api :as api]
+            [cljdoc.bundle :as bundle]))
+
+(defn sidebar-contents
+  "Render a sidebar for a documentation page.
+
+  This function takes the same arguments as the main render functions in `cljdoc.renderer.html`
+  and selected pages/namespaces will be highlighted based on the supplied `route-params`.
+
+  If articles or namespaces are missing for a project there will be little messages pointing
+  users to the relevant documentation or GitHub to open an issue."
+  [route-params {:keys [cache-id cache-contents] :as cache-bundle}]
+  (let [doc-slug-path (:doc-slug-path route-params)
+        doc-tree (doctree/add-slug-path (-> cache-contents :version :doc))
+        split-doc-tree ((juxt filter remove)
+                        #(contains? #{"Readme" "Changelog"} (:title %))
+                        doc-tree)
+        readme-and-changelog (first split-doc-tree)
+        doc-tree-with-rest (second split-doc-tree)]
+    [;; Upgrade notice
+     (if-let [newer-v (bundle/more-recent-version cache-bundle)]
+       (layout/upgrade-notice newer-v))
+
+     ;; Special documents (Readme & Changelog)
+     (when (seq readme-and-changelog)
+       [:div.mb4
+        (articles/doc-tree-view cache-id readme-and-changelog (:doc-slug-path route-params))])
+
+     ;; Remaining doctree or note if missing
+     (cond
+       ;; custom doctree has been provided and so we can assume the authors are aware of
+       ;; cljdoc's articles feature -> no further notes required
+       (seq doc-tree-with-rest)
+       [:div.mb4.js--articles
+        (layout/sidebar-title "Articles" {:separator-line? (not (empty? readme-and-changelog))})
+        [:div.mv3 (articles/doc-tree-view cache-id doc-tree-with-rest (:doc-slug-path route-params))]]
+
+       ;; only readme and changelog -> inform user about custom articles
+       (seq readme-and-changelog)
+       [:div.mb4
+        [:p.f7.gray.lh-title
+         [:a.blue.link {:href (util/github-url :userguide/articles)} "Articles"]
+         " are a practical way to provide additional guidance beyond
+       API documentation. Please refer to " [:a.blue.link {:href (util/github-url
+       :userguide/articles)} "the documentation"] " to learn more about using them."]]
+
+       ;; no articles at all -> list common problems + link to docs
+       :else
+       [:div.mb4
+        [:p.f7.gray.lh-title
+         "We couldn't find a Readme or any other articles for this project. This happens when
+         we could not find the Git repository for a project or there are no articles present in
+         a format that cljdoc supports. " [:strong "Please consult the " [:a.blue.link {:href
+         (util/github-url :userguide/articles)} "cljdoc docs"] " on how to fix this."]]])
+
+     ;; Namespace listing
+     (let [ns-entities (bundle/ns-entities cache-bundle)]
+       [:div.mb4
+        (layout/sidebar-title "Namespaces")
+        (if (seq ns-entities)
+          (api/namespace-list {:current (:namespace route-params)} ns-entities)
+          [:p.f7.gray.lh-title
+           "We couldn't find any namespaces in this artifact. Most often the reason for this is
+           that the analysis failed or that the artifact has been mispackaged and does not
+           conain any Clojure source files. The latter might be on purpose for uber-module
+           style artifacts. " "Please " [:a.blue.link {:href (util/github-url :issues)} "open
+           an issue"] " and we'll be happy to look into it."])])]))


### PR DESCRIPTION
There now is one function to render the sidebar. This function receives the same arguments as the other main rendering entry points: `route-params` and `cache-bundle`.

The small notes indicating a problem have been updated to more accurately report what is going on, specifically the following scenarios are handled:

- No articles were found at all.  
  **Causes**: No Git repo found or unsupported document types. 
  **Solution**: Point user towards relevant documentation.
- Only Readme and Changelog were found.  
  **Causes**: Articles haven’t been set up.  
  **Solution**: Point user to articles documentation
- No namespaces were found. 
  **Causes**: Failed analysis or Uber-module artifact without actual sources. 
  **Solution**: Invite users to open an issue.

The separators have also been changed slightly so that the separator for the Articles section is only shown if there is a Readme and/or Changelog article.

Fixes #250 