### PR TITLE
Get POM XML from local repo

### DIFF
--- a/src/cljdoc/util/repositories.clj
+++ b/src/cljdoc/util/repositories.clj
@@ -132,10 +132,9 @@
 (defn get-pom-xml
   "Fetches contents of pom.xml for a particular artifact version."
   [project version]
-  (-> (artifact-uris project version)
-      :pom
-      http/get
-      :body))
+  (if-let [local-pom (:pom (local-uris project version))]
+    (slurp local-pom)
+    (-> (artifact-uris project version) :pom http/get :body)))
 
 (comment
   (find-artifact-repository "org.clojure/clojure" "1.9.0")


### PR DESCRIPTION
Update `get-pom-xml` function to check if POM file exists locally.
Fetch it locally if exists otherwise check on Maven Central.

fixes #258