### PR TITLE
Extensible article types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,4 +110,6 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - extensible-article-types

--- a/doc/custom-articles.adoc
+++ b/doc/custom-articles.adoc
@@ -26,6 +26,6 @@ customize the configuration of cljdoc's `config.edn`:
 [source,clojure]
 ----
 {,,,
- :extension-namnespaces [com.yourproject.cljdoc-articles]}
+ :extension-namespaces [com.yourproject.cljdoc-articles]}
 ----
 

--- a/doc/custom-articles.adoc
+++ b/doc/custom-articles.adoc
@@ -1,0 +1,31 @@
+= Custom Articles
+:toc:
+
+cljdoc supports Markdown and Asciidoc out of the box but support for additional content types can be added in one of the following ways:
+
+1. Extending the cljdoc codebase itself to cover a new content type
+1. Packaging a separate jar that contains the necessary code to support additional content types
+
+The actual code will mostly be the same for both approaches, packaging and integration however will be different.
+
+*What approach to take?* If you think the content type could be beneficial to the wider cljdoc userbase it can be a part of cljdoc itself. If you want to use cljdoc on-premise in your company and have custom content types not used outside your company packaging them separately is probably the best way.
+
+== Extending cljdoc
+
+At the core adding support for new filetypes happens by extending two multimethods:
+
+- `cljdoc.doc-tree/filepath->type` is used to infer what content type a file contains based on it's path in a Git repository. For `.markdown` this function returns `:cljdoc/markdown`.
+- `cljdoc.rich-text/render-text` is used to turn the actual content into HTML.
+
+== Packaging Externally
+
+The above multimethods can also be extended from third party jars. To ensure that namespaces
+from additional jars are loaded (and thus those multimethods are extended as expected) you can
+customize the configuration of cljdoc's `config.edn`:
+
+[source,clojure]
+----
+{,,,
+ :extension-namnespaces [com.yourproject.cljdoc-articles]}
+----
+

--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -7,10 +7,19 @@
 /** Markdown / AsciiDoc ------------------------------------------------ **/
 /** Most of this should be implemented via Visitors when rendering Markdown I believe **/
 
-.markdown a, .asciidoc a {
+.cljdoc-article a {
   text-decoration: none;
   color: #357edd;
 }
+
+.cljdoc-article hr {
+    height: .25em;
+    padding: 0;
+    margin: 24px 0;
+    background-color: #e1e4e8;
+    border: 0;
+}
+
 
 .markdown a.md-anchor {
   color: black
@@ -22,14 +31,6 @@
 
 .markdown img[align="right"] {
     padding-left: 20px;
-}
-
-.markdown hr {
-    height: .25em;
-    padding: 0;
-    margin: 24px 0;
-    background-color: #e1e4e8;
-    border: 0;
 }
 
 .markdown pre, .literalblock > .content > pre, .listingblock > .content > pre {

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -104,6 +104,9 @@
 (defn maven-repositories []
   (get-in (config) [:maven-repositories]))
 
+(defn extension-namespaces [config]
+  (clojure.core/get-in config [:extension-namespaces]))
+
 (comment
   (:cljdoc/server (config))
 

--- a/src/cljdoc/doc_tree.clj
+++ b/src/cljdoc/doc_tree.clj
@@ -168,12 +168,6 @@
 
 ;; Deriving doctrees -----------------------------------------------------------
 
-(defn- supported-file-type [path]
-  (cond
-    (.endsWith path ".markdown") :markdown
-    (.endsWith path ".md")       :markdown
-    (.endsWith path ".adoc")     :asciidoc))
-
 (defn- readme? [path]
   (and (.startsWith (.toLowerCase path) "readme.")
        (filepath->type path)))

--- a/src/cljdoc/doc_tree.clj
+++ b/src/cljdoc/doc_tree.clj
@@ -66,7 +66,10 @@
     - It's stored as `:cljdoc.doc/type` in the doctree entry map
     - The contents of a file will be stored at the returned value
 
-  See [[process-toc-entry]] for the specifics."
+  See [[process-toc-entry]] for the specifics.
+
+  NOTE: I find a multimethod not perfectly appropriate here but it's straightforward to extend
+  from other artifacts and - for now - gets the job done."
   (fn [path-str]
     (second (re-find #"\.([^\.]+)$" path-str))))
 

--- a/src/cljdoc/doc_tree.clj
+++ b/src/cljdoc/doc_tree.clj
@@ -184,8 +184,8 @@
 (defn- infer-title [path file-contents]
   (or (case (filepath->type path)
         ;; NOTE infer-title will fail with non adoc/md files
-        :markdown (second (re-find #"(?m)^\s*#+\s*(.*)\s*$" file-contents))
-        :asciidoc (second (re-find #"(?m)^\s*=+\s*(.*)\s*$" file-contents)))
+        :cljdoc/markdown (second (re-find #"(?m)^\s*#+\s*(.*)\s*$" file-contents))
+        :cljdoc/asciidoc (second (re-find #"(?m)^\s*=+\s*(.*)\s*$" file-contents)))
       (first (butlast (take-last 2 (cuerdas/split path #"[/\.]"))))
       (throw (ex-info (format "No title found for %s" path)
                       {:path path :contents file-contents}))))

--- a/src/cljdoc/doc_tree.clj
+++ b/src/cljdoc/doc_tree.clj
@@ -170,16 +170,16 @@
 
 (defn- readme? [path]
   (and (.startsWith (.toLowerCase path) "readme.")
-       (filepath->type path)))
+       (try (filepath->type path) (catch Exception _ false))))
 
 (defn- changelog? [path]
   (and (some #(.startsWith (.toLowerCase path) %) ["changelog." "changes."  "history." "news." "releases."])
-       (filepath->type path)))
+       (try (filepath->type path) (catch Exception _ false))))
 
 (defn- doc? [path]
-  (and (filepath->type path)
-       (or (.startsWith path "doc/")
-           (.startsWith path "docs/"))))
+  (and (or (.startsWith path "doc/")
+           (.startsWith path "docs/"))
+       (try (filepath->type path) (catch Exception _ false))))
 
 (defn- infer-title [path file-contents]
   (or (case (filepath->type path)

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -37,10 +37,10 @@
   (assert doc-type)
   [:div.mw7.center
    (if doc-html
-     [:div#doc-html.lh-copy.pv4
+     [:div#doc-html.cljdoc-article.lh-copy.pv4
       {:class (name doc-type)}
       (hiccup/raw doc-html)
-      [:a.db.f7.tr
+      [:a.db.f7.tr.link.blue
        {:href doc-scm-url}
        (if (= :gitlab (scm/provider doc-scm-url))
          "Edit on GitLab"

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -36,7 +36,6 @@
 (defn doc-page [{:keys [doc-scm-url doc-html doc-type]}]
   (assert doc-type)
   [:div.mw7.center
-   ;; TODO dispatch on a type parameter that becomes part of the attrs map
    (if doc-html
      [:div#doc-html.lh-copy.pv4
       {:class (name doc-type)}

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -70,6 +70,16 @@
    (->> (.parse md-container input-str)
         (.render (md-renderer opts)))))
 
+(defmulti render-text
+  (fn [[type contents]]
+    type))
+
+(defmethod render-text :cljdoc/markdown [[_ content]]
+  (markdown-to-html content))
+
+(defmethod render-text :cljdoc/asciidoc [[_ content]]
+  (markdown-to-html content))
+
 (comment
   (markdown-to-html "*hello world* <code>x</code>")
 

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -81,7 +81,7 @@
   (markdown-to-html content))
 
 (defmethod render-text :cljdoc/asciidoc [[_ content]]
-  (markdown-to-html content))
+  (asciidoc-to-html content))
 
 (comment
   (markdown-to-html "*hello world* <code>x</code>")

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -71,6 +71,9 @@
         (.render (md-renderer opts)))))
 
 (defmulti render-text
+  "An extension point for the rendering of different article types.
+
+  `type` is determined by [[cljdoc.doc-tree/filepath->type]]."
   (fn [[type contents]]
     type))
 

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -44,11 +44,8 @@
                    doctree/flatten*
                    (filter #(= doc-slug-path (:slug-path (:attrs %))))
                    first)
-        doc-html (or (some-> doc-p :attrs :cljdoc/markdown rich-text/markdown-to-html)
-                     (some-> doc-p :attrs :cljdoc/asciidoc rich-text/asciidoc-to-html))
-        doc-type (cond
-                   (-> doc-p :attrs :cljdoc/markdown) :markdown
-                   (-> doc-p :attrs :cljdoc/asciidoc) :asciidoc)
+        [doc-type contents] (doctree/entry->type-and-content doc-p)
+        doc-html (rich-text/render-text [doc-type contents])
         top-bar-component (layout/top-bar cache-id (-> cache-contents :version :scm :url))
         sidebar-contents (sidebar/sidebar-contents route-params cache-bundle)]
     ;; If we can find an article for the provided `doc-slug-path` render that article,
@@ -61,7 +58,7 @@
                        {:doc-scm-url (str (-> cache-contents :version :scm :url) "/blob/"
                                           (or (-> cache-contents :version :scm :branch) "master")
                                           "/" (-> doc-p :attrs :cljdoc.doc/source-file))
-                        :doc-type doc-type
+                        :doc-type (name doc-type)
                         :doc-html (fixref/fix (-> doc-p :attrs :cljdoc.doc/source-file)
                                               doc-html
                                               {:scm (:scm (:version cache-contents))

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -26,6 +26,9 @@
 (defn system-config [env-config]
   (let [ana-service (cfg/analysis-service env-config)
         port        (cfg/get-in env-config [:cljdoc/server :port])]
+    (doseq [ns (cfg/extension-namespaces env-config)]
+      (log/info "Loading extension namespace" ns)
+      (require ns))
     (merge
      {:cljdoc/sqlite          {:db-spec (cfg/db env-config)
                                :dir     (cfg/data-dir env-config)}

--- a/test/cljdoc/doc_tree_test.clj
+++ b/test/cljdoc/doc_tree_test.clj
@@ -9,10 +9,12 @@
   (t/is (=
          [{:title "Readme"
            :attrs {:cljdoc.doc/source-file "README.md",
+                   :cljdoc.doc/type :cljdoc/markdown
                    :cljdoc/markdown "README.md",
                    :slug "readme"}
            :children [{:title "Nested"
                        :attrs {:cljdoc.doc/source-file "nested.adoc"
+                               :cljdoc.doc/type :cljdoc/asciidoc
                                :cljdoc/asciidoc "nested.adoc"
                                :slug "nested"}}]}]
          (doctree/process-toc


### PR DESCRIPTION
This PR opens up article types to be extended beyond Markdown and Asciidoc. This will be useful for experimental extensions like Cucumber feature files as described in #257 as well as proprietary formats used inside organisations with an on-premise cljdoc deployment. 

One aspect I'd particularly appreciate feedback about is the whole `filepath->type` stuff. Basing this purely on the extension seems a little too constrained and the most appropriate approach would probably be a sequence of predicates. That's not as nice as multi methods however and would require some manual state-wrangling in the form of an atom or similar. Wouldn't be the end of the world, multimethods are just state anyways but still, multimethods are more familiar and very well integrated into the language.