### PR TITLE
Improved support for modular libraries

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -56,9 +56,7 @@
          "modules/shared-utils/resources"]
  :aliases {:test
            {:extra-paths ["test"]
-            :extra-deps {lambdaisland/kaocha
-                         {:git/url "https://github.com/lambdaisland/kaocha.git"
-                          :sha "e7af8b48aadb32da9dcd7a9e5eb50fe64eae8d62"}}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-389"}}
             :main-opts ["-m" "kaocha.runner"]}
 
            :cli

--- a/deps.edn
+++ b/deps.edn
@@ -32,6 +32,7 @@
         org.clojure/core.match {:mvn/version "0.3.0-alpha5"},
         org.jsoup/jsoup {:mvn/version "1.11.3"},
         org.xerial/sqlite-jdbc {:mvn/version "3.20.0"},
+        com.layerware/hugsql {:mvn/version "0.4.9"}
         com.taoensso/tufte {:mvn/version "2.0.1"}
         com.taoensso/nippy {:mvn/version "2.14.0"}
         org.slf4j/slf4j-api {:mvn/version "1.7.25"},

--- a/doc/userguide/for-library-authors.adoc
+++ b/doc/userguide/for-library-authors.adoc
@@ -131,6 +131,30 @@ If you want to provide a different doc tree for one module, simply nest it in th
 }
 ----
 
+==== `cljdoc.include-namespaces-from-dependencies`
+
+If you want a project to include API documentation for some of it's dependencies provide an additional key `:cljdoc/include-namespaces-from-dependencies`:
+
+[source,clojure]
+----
+{:cljdoc/include-namespaces-from-dependencies
+ [metosin/reitit
+  metosin/reitit-core
+  metosin/reitit-ring
+  metosin/reitit-spec
+  metosin/reitit-schema
+  metosin/reitit-swagger
+  metosin/reitit-swagger-ui]}
+----
+
+NOTE: This can be specified on a per artifact basis as described in the previous section.
+
+NOTE: This only works if the artifact specifies a dependency on the projects listed. The
+projects POM file will be used to load API information for the correct version.
+
+WARN: If analysis for some of the specified dependencies failed or just hasn't been ran they
+will be silently ignored for now.
+
 == More Features
 
 ==== Wikilinks

--- a/doc/userguide/for-library-authors.adoc
+++ b/doc/userguide/for-library-authors.adoc
@@ -108,11 +108,11 @@ TIP: Since sometimes people forget to update the paths after moving files around
 curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
 ----
 
-=== Module Support
+== Module Support
 
 Some libraries consist of smaller submodules and cljdoc provides some facilities for library authors to make their documentaiton available in one location:
 
-==== Module specific settings
+=== Module specific settings
 
 If you want to provide a different doc tree for one module, simply nest it in the projects name, e.g.:
 
@@ -131,7 +131,7 @@ If you want to provide a different doc tree for one module, simply nest it in th
 }
 ----
 
-==== `cljdoc.include-namespaces-from-dependencies`
+=== `:cljdoc.include-namespaces-from-dependencies`
 
 If you want a project to include API documentation for some of it's dependencies provide an additional key `:cljdoc/include-namespaces-from-dependencies`:
 

--- a/doc/userguide/for-library-authors.adoc
+++ b/doc/userguide/for-library-authors.adoc
@@ -108,6 +108,29 @@ TIP: Since sometimes people forget to update the paths after moving files around
 curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
 ----
 
+=== Module Support
+
+Some libraries consist of smaller submodules and cljdoc provides some facilities for library authors to make their documentaiton available in one location:
+
+==== Module specific settings
+
+If you want to provide a different doc tree for one module, simply nest it in the projects name, e.g.:
+
+[source,clojure]
+----
+{
+  ;; used for metosin/reitit
+  ;; when building docs for metosin/reitit this will be used as if
+  ;; the doc/cljdoc.edn file contained just the value of this key
+  metosin/reitit {:cljdoc.doc/tree [["Introduction" {:file "intro.md"}]]}
+
+  ;; used for any project except metosin/reitit
+  ;; could contain an overview about all modules and a pointer
+  ;; to the overarching documentation for metosin/reitit
+  :cljdoc.doc/tree [["Overview" {:file "modules/README.md"}]]
+}
+----
+
 == More Features
 
 ==== Wikilinks

--- a/modules/shared-utils/src/cljdoc/util.clj
+++ b/modules/shared-utils/src/cljdoc/util.clj
@@ -69,7 +69,7 @@
 (defn git-dir [project version]
   (str "git-repos/" (group-id project) "/" (artifact-id project) "/" version "/"))
 
-(defn clojars-id [{:keys [group-id artifact-id] :as cache-id}]
+(defn clojars-id [{:keys [group-id artifact-id] :as artifact-entity}]
   (if (= group-id artifact-id)
     artifact-id
     (str group-id "/" artifact-id)))

--- a/modules/shared-utils/src/cljdoc/util.clj
+++ b/modules/shared-utils/src/cljdoc/util.clj
@@ -238,3 +238,6 @@
     (let [sqr  (fn sqr [x] (* x x))
           avg  (mean coll)]
       (mean (map #(sqr (- % avg)) coll)))))
+
+(defn index-by [f m]
+  (into {} (map (juxt f identity) m)))

--- a/modules/shared-utils/src/cljdoc/util/pom.clj
+++ b/modules/shared-utils/src/cljdoc/util/pom.clj
@@ -1,7 +1,6 @@
 (ns cljdoc.util.pom
   "Functions to parse POM files and extract information from them."
-  (:require [clojure.string :as string]
-            [cljdoc.util :as util])
+  (:require [clojure.string :as string])
   (:import (org.jsoup Jsoup)
            (org.jsoup.nodes Document)))
 

--- a/resources/sql/sqlite_impl.sql
+++ b/resources/sql/sqlite_impl.sql
@@ -1,0 +1,11 @@
+-- :name sql-resolve-version-ids :? :*
+-- For some reason putting WITH upfront instead of supplying (VALUES...) directly after IN is much more performant
+WITH v_ents(gid,aid,name) AS (VALUES :tuple*:version-entities)
+SELECT id, group_id, artifact_id, name FROM versions WHERE (group_id, artifact_id, name) IN v_ents
+
+-- :name sql-get-namespaces :? :*
+select version_id, name, meta from namespaces where (version_id) IN :tuple:version-ids
+
+-- :name sql-get-vars :? :*
+WITH pairs(id, ns) AS (VALUES :tuple*:ns-idents)
+SELECT name, meta FROM vars WHERE (version_id, namespace) IN pairs

--- a/src/cljdoc/analysis/git.clj
+++ b/src/cljdoc/analysis/git.clj
@@ -82,6 +82,7 @@
                                 :rev revision
                                 :branch (.. repo getRepository getBranch)}
                          version-tag (assoc :tag version-tag))
+             :config   config-edn
              :doc-tree (doctree/process-toc
                         (fn [f]
                           ;; We are intentionally relaxed here for now

--- a/src/cljdoc/analysis/git.clj
+++ b/src/cljdoc/analysis/git.clj
@@ -8,7 +8,7 @@
             [cljdoc.util.scm :as scm]
             [cljdoc.git-repo :as git]
             [cljdoc.doc-tree :as doctree]
-            [clj-http.lite.client :as http]
+            [cljdoc.user-config :as user-config]
             [clojure.edn :as edn]
             [clojure.spec.alpha :as spec]
             [clojure.tools.logging :as log]))
@@ -93,7 +93,7 @@
                           (or (git/slurp-file-at repo revision f)
                               (when (git/exists? repo "master")
                                 (git/slurp-file-at repo "master" f))))
-                        (or (:cljdoc.doc/tree config-edn)
+                        (or (user-config/doc-tree config-edn project)
                             (get-in @util/hardcoded-config
                                     [(util/normalize-project project) :cljdoc.doc/tree])
                             (doctree/derive-toc git-files)))})

--- a/src/cljdoc/bundle.clj
+++ b/src/cljdoc/bundle.clj
@@ -8,12 +8,11 @@
 (defn ns-entities
   "Return entity-maps for all namespaces in the cache-bundle"
   [{:keys [version-entity] :as cache-bundle}]
-  (let [has-defs? (fn [ns-emap]
-                    (seq (filter #(= (:namespace ns-emap) (:namespace %))
-                                 (:defs cache-bundle))))]
+  (let [nss-from-defs (set (map :namespace (:defs cache-bundle)))
+        has-defs?     (fn [ns-emap]
+                        (contains? nss-from-defs (:namespace ns-emap)))]
     (->> (:namespaces cache-bundle)
-         (map :name)
-         (map #(merge version-entity {:namespace %}))
+         (map #(merge (:version-entity %) {:namespace (:name %)}))
          (filter has-defs?)
          (map #(cljdoc.spec/assert :cljdoc.spec/namespace-entity %))
          set)))

--- a/src/cljdoc/bundle.clj
+++ b/src/cljdoc/bundle.clj
@@ -50,9 +50,8 @@
     mp-var))
 
 (defn defs-for-ns-with-src-uri
-  [cache-contents ns]
-  (let [defs         (defs-for-ns (:defs cache-contents) ns)
-        scm-info     (:scm (:version cache-contents))
+  [defs scm-info ns]
+  (let [defs         (defs-for-ns defs ns)
         blob         (or (:name (:tag scm-info)) (:commit scm-info))
         scm-base     (str (:url scm-info) "/blob/" blob "/")
         file-mapping (when (:files scm-info)

--- a/src/cljdoc/bundle.clj
+++ b/src/cljdoc/bundle.clj
@@ -7,13 +7,13 @@
 
 (defn ns-entities
   "Return entity-maps for all namespaces in the cache-bundle"
-  [{:keys [cache-contents cache-id]}]
+  [{:keys [version-entity] :as cache-bundle}]
   (let [has-defs? (fn [ns-emap]
                     (seq (filter #(= (:namespace ns-emap) (:namespace %))
-                                 (:defs cache-contents))))]
-    (->> (:namespaces cache-contents)
+                                 (:defs cache-bundle))))]
+    (->> (:namespaces cache-bundle)
          (map :name)
-         (map #(merge cache-id {:namespace %}))
+         (map #(merge version-entity {:namespace %}))
          (filter has-defs?)
          (map #(cljdoc.spec/assert :cljdoc.spec/namespace-entity %))
          set)))
@@ -22,9 +22,9 @@
   (string/lower-case (platf/get-field p :name)))
 
 (defn namespaces
-  [{:keys [cache-contents cache-id]}]
-  {:pre [(find cache-contents :namespaces)]}
-  (->> (:namespaces cache-contents)
+  [{:keys [version-entity] :as cache-bundle}]
+  {:pre [(find cache-bundle :namespaces)]}
+  (->> (:namespaces cache-bundle)
        (group-by :name)
        (vals)
        (map platf/unify-namespaces)
@@ -61,10 +61,10 @@
     (map #(add-src-uri % scm-base file-mapping) defs)))
 
 (defn more-recent-version
-  [{:keys [cache-contents cache-id]}]
-  (when (and (:latest cache-contents)
-             (not= (:version cache-id) (:latest cache-contents)))
-    (assoc cache-id :version (:latest cache-contents))))
+  [{:keys [version-entity] :as cache-bundle}]
+  (when (and (:latest cache-bundle)
+             (not= (:version version-entity) (:latest cache-bundle)))
+    (assoc version-entity :version (:latest cache-bundle))))
 
 (comment
   (defn cb [id]

--- a/src/cljdoc/bundle.clj
+++ b/src/cljdoc/bundle.clj
@@ -30,9 +30,21 @@
        (map platf/unify-namespaces)
        (sort-by platf-name)))
 
+(defn get-namespace [bundle ns]
+ (first (filter #(= ns (platf/get-field % :name)) (namespaces bundle))))
+
+(defn scm-info [bundle]
+  (-> bundle :version :scm))
+
+(defn scm-url [bundle]
+  (-> bundle scm-info :url))
+
+(defn all-defs [bundle]
+  (:defs bundle))
+
 (defn defs-for-ns
-  [all-defs ns]
-  (->> all-defs
+  [some-defs ns]
+  (->> some-defs
        (filter #(= ns (:namespace %)))
        (group-by :name)
        (vals)
@@ -50,8 +62,9 @@
     mp-var))
 
 (defn defs-for-ns-with-src-uri
-  [defs scm-info ns]
-  (let [defs         (defs-for-ns defs ns)
+  [bundle ns]
+  (let [defs         (defs-for-ns (all-defs bundle) ns)
+        scm-info     (scm-info bundle)
         blob         (or (:name (:tag scm-info)) (:commit scm-info))
         scm-base     (str (:url scm-info) "/blob/" blob "/")
         file-mapping (when (:files scm-info)

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -207,36 +207,19 @@
                defs (bundle/defs-for-ns defs ns)]]
      (namespace-overview ns-url-fn mp-ns defs))])
 
-(defn add-src-uri
-  [{:keys [platforms] :as mp-var} scm-base file-mapping]
-  {:pre [(platf/multiplatform? mp-var)]}
-  (if file-mapping
-    (->> platforms
-         (map (fn [{:keys [file line] :as p}]
-                (assoc p :src-uri (str scm-base (get file-mapping file) "#L" line))))
-         (assoc mp-var :platforms))
-    mp-var))
-
-(defn namespace-page [{:keys [ns-entity ns-data defs scm-info]}]
+(defn namespace-page [{:keys [ns-entity ns-data defs]}]
   (cljdoc.spec/assert :cljdoc.spec/namespace-entity ns-entity)
   (assert (platf/multiplatform? ns-data))
-  (let [blob             (or (:name (:tag scm-info)) (:commit scm-info))
-        scm-base         (str (:url scm-info) "/blob/" blob "/")
-        file-mapping     (when (:files scm-info)
-                           (fixref/match-files
-                            (keys (:files scm-info))
-                            (set (mapcat #(platf/all-vals % :file) defs))))
-        render-wiki-link (render-wiki-link-fn (:namespace ns-entity)
-                                              #(routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace %)))]
+  (let [render-wiki-link (render-wiki-link-fn
+                          (:namespace ns-entity)
+                          #(routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace %)))]
     [:div.ns-page
      [:div.w-80-ns.pv4
       [:h2 (:namespace ns-entity)]
       (render-doc ns-data render-wiki-link)
       (if (seq defs)
-        (for [def defs]
-          (def-block
-            (add-src-uri def scm-base file-mapping)
-            render-wiki-link))
+        (for [adef defs]
+          (def-block adef render-wiki-link))
         [:p "No vars found in this namespace."])]]))
 
 (comment

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -8,17 +8,17 @@
             [clojure.string :as string]
             [hiccup2.core :as hiccup]))
 
-(defn doc-link [cache-id slugs]
+(defn doc-link [version-entity slugs]
   (assert (seq slugs) "Slug path missing")
   (->> (string/join "/" slugs)
-       (assoc cache-id :article-slug)
+       (assoc version-entity :article-slug)
        (routes/url-for :artifact/doc :path-params)))
 
 (defn doc-tree-view
   "Render a set of nested lists representing the doctree. "
-  ([cache-id doc-bundle current-page]
-   (doc-tree-view cache-id doc-bundle current-page 0))
-  ([cache-id doc-bundle current-page level]
+  ([version-entity doc-bundle current-page]
+   (doc-tree-view version-entity doc-bundle current-page 0))
+  ([version-entity doc-bundle current-page level]
    (when (seq doc-bundle)
      (->> doc-bundle
           (map (fn [doc-page]
@@ -27,10 +27,10 @@
                     {:class (when (seq (:children doc-page)) "mv2")}
                     [:a.link.blue.hover-dark-blue.dib.pv1
                      {:style {:word-wrap "break-word"}
-                      :href  (doc-link cache-id slug-path)
+                      :href  (doc-link version-entity slug-path)
                       :class (when (= current-page slug-path) "fw7")}
                      (:title doc-page)]
-                    (doc-tree-view cache-id (:children doc-page) current-page (inc level))])))
+                    (doc-tree-view version-entity (:children doc-page) current-page (inc level))])))
           (into [:ul.list.ma0 {:class (if (pos? level) "f6-ns pl2" "pl0")}])))))
 
 (defn doc-page [{:keys [doc-scm-url doc-html doc-type]}]
@@ -49,7 +49,7 @@
       [:span.f4.serif.gray.i "Space intentionally left blank."]])])
 
 (defn doc-overview
-  [{:keys [cache-id doc-tree]}]
+  [{:keys [version-entity doc-tree]}]
   [:div.doc-page
    [:div.mw7.center.pv4
     [:h1 (:title doc-tree)]
@@ -57,5 +57,5 @@
      (for [c (:children doc-tree)]
        [:li.mv2
         [:a.link.blue
-         {:href (doc-link cache-id (-> c :attrs :slug-path))}
+         {:href (doc-link version-entity (-> c :attrs :slug-path))}
          (-> c :title)]])]]])

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -24,13 +24,13 @@
 
 (defn generic-description
   "Returns a generic description of a project."
-  [{:keys [group-id artifact-id version] :as cache-id}]
-  (format "Documentation for %s v%s on cljdoc." (util/clojars-id cache-id) version))
+  [{:keys [group-id artifact-id version] :as version-entity}]
+  (format "Documentation for %s v%s on cljdoc." (util/clojars-id version-entity) version))
 
 (defn description
   "Return a string to be used as description meta tag for a given project's documentation pages."
-  [cache-id]
-  (str (generic-description cache-id)
+  [version-entity]
+  (str (generic-description version-entity)
        " "
        "A website that builds and hosts documentation for Clojure/Script libraries."))
 
@@ -38,8 +38,8 @@
   "Return a string to be used as description meta tag for a given project's documentation pages.
 
   This description is same as the description in project's pom.xml file."
-  [cache-id artifact-desc]
-  (str (util/clojars-id cache-id) ": " artifact-desc " " (generic-description cache-id)))
+  [version-entity artifact-desc]
+  (str (util/clojars-id version-entity) ": " artifact-desc " " (generic-description version-entity)))
 
 (defn no-js-warning
   "A small development utility component that will show a warning when
@@ -134,13 +134,13 @@
     {:href (util/github-url :issues)}
     "Have Feedback?"]])
 
-(defn top-bar [cache-id scm-url]
+(defn top-bar [version-entity scm-url]
   [:nav.pv2.ph3.pv3-ns.ph4-ns.bb.b--black-10.flex.items-center.bg-white
-   [:a.dib.v-mid.link.dim.black.b.f6.mr3 {:href (routes/url-for :artifact/version :path-params cache-id)}
-    (util/clojars-id cache-id)]
+   [:a.dib.v-mid.link.dim.black.b.f6.mr3 {:href (routes/url-for :artifact/version :path-params version-entity)}
+    (util/clojars-id version-entity)]
    [:a.dib.v-mid.link.dim.gray.f6.mr3
-    {:href (routes/url-for :artifact/index :path-params cache-id)}
-    (:version cache-id)]
+    {:href (routes/url-for :artifact/index :path-params version-entity)}
+    (:version version-entity)]
    [:a.dn.dib-ns {:href "/"}
     [:span.link.dib.v-mid.mr3.pv1.ph2.ba.hover-blue.br1.ttu.fw5.f7.silver.tracked "cljdoc Beta"]]
    [:a.dn.dib-ns.silver.link.hover-blue.ttu.fw5.f7.tracked.pv1
@@ -149,8 +149,8 @@
    [:div.tr
     {:style {:flex-grow 1}}
     [:form.dn.dib-ns.mr3 {:action "/api/request-build2" :method "POST"}
-     [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "project" :name "project" :value (str (:group-id cache-id) "/" (:artifact-id cache-id))}]
-     [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "version" :name "version" :value (:version cache-id)}]
+     [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "project" :name "project" :value (str (:group-id version-entity) "/" (:artifact-id version-entity))}]
+     [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "version" :name "version" :value (:version version-entity)}]
      [:input.f7.white.hover-near-white.outline-0.bn.bg-white {:type "submit" :value "rebuild"}]]
     (cond
       (and scm-url (scm/http-uri scm-url))

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -65,7 +65,7 @@
                      (util/clojars-id version-entity) " v"
                      (:version version-entity))]
                    [:meta {:charset "utf-8"}]
-                   (->> ["assets/cljdoc.css" "assets/github-gist.min.css" "assets/tachyons.min.css"]
+                   (->> ["assets/cljdoc.css" "assets/tachyons.min.css"]
                         (map #(cond->> % sub-page? (str "../")))
                         (apply hiccup.page/include-css))]
                   [:div.sans-serif
@@ -152,7 +152,6 @@
      into
      [[["assets/cljdoc.css" (io/file (io/resource "public/cljdoc.css"))]
        ["assets/tachyons.min.css" (URL. "https://unpkg.com/tachyons@4.9.0/css/tachyons.min.css")]
-       ["assets/github-gist.min.css" (URL. "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/styles/github-gist.min.css")]
        ["assets/highlight.min.js" (URL. "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/highlight.min.js")]
        ["assets/clojure.min.js" (URL. "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/languages/clojure.min.js")]
        ["assets/clojure-repl.min.js" (URL. "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/languages/clojure-repl.min.js")]

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -105,7 +105,7 @@
    [:h1.mv0.pv3 {:id "namespaces"} "Namespaces"]
    (for [ns (bundle/namespaces cache-bundle)
          :let [defs (bundle/defs-for-ns
-                      (:defs cache-bundle)
+                      (bundle/all-defs cache-bundle)
                       (platf/get-field ns :name))]]
      (api/namespace-overview ns-url ns defs))])
 
@@ -168,10 +168,7 @@
 
       ;; Namespace Pages
       (for [ns-data (bundle/namespaces cache-bundle)
-            :let [defs (bundle/defs-for-ns-with-src-uri
-                         (:defs cache-bundle)
-                         scm-info
-                         (platf/get-field ns-data :name))]]
+            :let [defs (bundle/defs-for-ns-with-src-uri cache-bundle (platf/get-field ns-data :name))]]
         [(ns-url (platf/get-field ns-data :name))
          (->> (ns-page ns-data defs)
               (page' :namespace (platf/get-field ns-data :name)))])])))

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -63,7 +63,9 @@
        [:div.mb4
         (layout/sidebar-title "Namespaces")
         (if (seq ns-entities)
-          (api/namespace-list {:current (:namespace route-params)} ns-entities)
+          (api/namespace-list {:current (:namespace route-params)
+                               :version-entity version-entity}
+                              ns-entities)
           [:p.f7.gray.lh-title
            "We couldn't find any namespaces in this artifact. Most often the reason for this is
            that the analysis failed or that the artifact has been mispackaged and does not

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -14,9 +14,9 @@
 
   If articles or namespaces are missing for a project there will be little messages pointing
   users to the relevant documentation or GitHub to open an issue."
-  [route-params {:keys [cache-id cache-contents] :as cache-bundle}]
+  [route-params {:keys [version-entity] :as cache-bundle}]
   (let [doc-slug-path (:doc-slug-path route-params)
-        doc-tree (doctree/add-slug-path (-> cache-contents :version :doc))
+        doc-tree (doctree/add-slug-path (-> cache-bundle :version :doc))
         split-doc-tree ((juxt filter remove)
                         #(contains? #{"Readme" "Changelog"} (:title %))
                         doc-tree)
@@ -29,7 +29,7 @@
      ;; Special documents (Readme & Changelog)
      (when (seq readme-and-changelog)
        [:div.mb4
-        (articles/doc-tree-view cache-id readme-and-changelog (:doc-slug-path route-params))])
+        (articles/doc-tree-view version-entity readme-and-changelog (:doc-slug-path route-params))])
 
      ;; Remaining doctree or note if missing
      (cond
@@ -38,7 +38,7 @@
        (seq doc-tree-with-rest)
        [:div.mb4.js--articles
         (layout/sidebar-title "Articles" {:separator-line? (not (empty? readme-and-changelog))})
-        [:div.mv3 (articles/doc-tree-view cache-id doc-tree-with-rest (:doc-slug-path route-params))]]
+        [:div.mv3 (articles/doc-tree-view version-entity doc-tree-with-rest (:doc-slug-path route-params))]]
 
        ;; only readme and changelog -> inform user about custom articles
        (seq readme-and-changelog)

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -83,7 +83,10 @@
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
   (assert (:namespace route-params))
   (let [ns-emap route-params
-        defs    (bundle/defs-for-ns-with-src-uri cache-contents (:namespace ns-emap))
+        defs    (bundle/defs-for-ns-with-src-uri
+                  (:defs cache-contents)
+                  (:scm (:version cache-contents))
+                  (:namespace ns-emap))
         [[dominant-platf] :as platf-stats] (api/platform-stats defs)
         ns-data (first (filter #(= (:namespace ns-emap) (platf/get-field % :name))
                                (bundle/namespaces cache-bundle)))

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -24,29 +24,29 @@
   (format "%s not implemented, sorry" page-type))
 
 (defmethod render :artifact/version
-  [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
+  [_ route-params {:keys [version-entity] :as cache-bundle}]
   (->> (layout/layout
         ;; TODO on mobile this will effectively be rendered as a blank page
         ;; We could instead show a message and the namespace tree.
-        {:top-bar (layout/top-bar cache-id (-> cache-contents :version :scm :url))
+        {:top-bar (layout/top-bar version-entity (-> cache-bundle :version :scm :url))
          :main-sidebar-contents (sidebar/sidebar-contents route-params cache-bundle)})
-       (layout/page {:title (str (util/clojars-id cache-id) " " (:version cache-id))
+       (layout/page {:title (str (util/clojars-id version-entity) " " (:version version-entity))
                      :description (layout/artifact-description
-                                   cache-id
-                                   (-> cache-contents :version :pom :description))})))
+                                   version-entity
+                                   (-> cache-bundle :version :pom :description))})))
 
 (defmethod render :artifact/doc
-  [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
+  [_ route-params {:keys [version-entity] :as cache-bundle}]
   (assert (:doc-slug-path route-params))
   (let [doc-slug-path (:doc-slug-path route-params)
-        doc-tree (doctree/add-slug-path (-> cache-contents :version :doc))
+        doc-tree (doctree/add-slug-path (-> cache-bundle :version :doc))
         doc-p (->> doc-tree
                    doctree/flatten*
                    (filter #(= doc-slug-path (:slug-path (:attrs %))))
                    first)
         [doc-type contents] (doctree/entry->type-and-content doc-p)
         doc-html (rich-text/render-text [doc-type contents])
-        top-bar-component (layout/top-bar cache-id (-> cache-contents :version :scm :url))
+        top-bar-component (layout/top-bar version-entity (-> cache-bundle :version :scm :url))
         sidebar-contents (sidebar/sidebar-contents route-params cache-bundle)]
     ;; If we can find an article for the provided `doc-slug-path` render that article,
     ;; if there's no article then the page should display a list of all child-pages
@@ -55,43 +55,43 @@
             {:top-bar top-bar-component
              :main-sidebar-contents sidebar-contents
              :content (articles/doc-page
-                       {:doc-scm-url (str (-> cache-contents :version :scm :url) "/blob/"
-                                          (or (-> cache-contents :version :scm :branch) "master")
+                       {:doc-scm-url (str (-> cache-bundle :version :scm :url) "/blob/"
+                                          (or (-> cache-bundle :version :scm :branch) "master")
                                           "/" (-> doc-p :attrs :cljdoc.doc/source-file))
                         :doc-type (name doc-type)
                         :doc-html (fixref/fix (-> doc-p :attrs :cljdoc.doc/source-file)
                                               doc-html
-                                              {:scm (:scm (:version cache-contents))
-                                               :uri-map (fixref/uri-mapping cache-id (doctree/flatten* doc-tree))})})})
+                                              {:scm (:scm (:version cache-bundle))
+                                               :uri-map (fixref/uri-mapping version-entity (doctree/flatten* doc-tree))})})})
            (layout/layout
             {:top-bar top-bar-component
              :main-sidebar-contents sidebar-contents
              :content (articles/doc-overview
-                       {:cache-id cache-id
+                       {:version-entity version-entity
                         :doc-tree (doctree/get-subtree doc-tree doc-slug-path)})}))
 
-         (layout/page {:title (str (:title doc-p) " — " (util/clojars-id cache-id) " " (:version cache-id))
+         (layout/page {:title (str (:title doc-p) " — " (util/clojars-id version-entity) " " (:version version-entity))
                        :canonical-url (some->> (bundle/more-recent-version cache-bundle)
                                                (merge route-params)
                                                (routes/url-for :artifact/doc :path-params))
                        ;; update desctiption by extracting it from XML (:pom cache-bundle)
                        :description (layout/artifact-description
-                                     cache-id
-                                     (-> cache-contents :version :pom :description))}))))
+                                     version-entity
+                                     (-> cache-bundle :version :pom :description))}))))
 
 (defmethod render :artifact/namespace
-  [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
+  [_ route-params {:keys [version-entity] :as cache-bundle}]
   (assert (:namespace route-params))
   (let [ns-emap route-params
         defs    (bundle/defs-for-ns-with-src-uri
-                  (:defs cache-contents)
-                  (:scm (:version cache-contents))
+                  (:defs cache-bundle)
+                  (:scm (:version cache-bundle))
                   (:namespace ns-emap))
         [[dominant-platf] :as platf-stats] (api/platform-stats defs)
         ns-data (first (filter #(= (:namespace ns-emap) (platf/get-field % :name))
                                (bundle/namespaces cache-bundle)))
-        top-bar-component (layout/top-bar cache-id (-> cache-contents :version :scm :url))
-        common-params {:top-bar-component (layout/top-bar cache-id (-> cache-contents :version :scm :url))}]
+        top-bar-component (layout/top-bar version-entity (-> cache-bundle :version :scm :url))
+        common-params {:top-bar-component (layout/top-bar version-entity (-> cache-bundle :version :scm :url))}]
     (->> (if ns-data
            (layout/layout
             {:top-bar top-bar-component
@@ -107,14 +107,14 @@
              :main-sidebar-contents (sidebar/sidebar-contents route-params cache-bundle)
              :content (api/sub-namespace-overview-page {:ns-entity ns-emap
                                                         :namespaces (bundle/namespaces cache-bundle)
-                                                        :defs (:defs cache-contents)})}))
-         (layout/page {:title (str (:namespace ns-emap) " — " (util/clojars-id cache-id) " " (:version cache-id))
+                                                        :defs (:defs cache-bundle)})}))
+         (layout/page {:title (str (:namespace ns-emap) " — " (util/clojars-id version-entity) " " (:version version-entity))
                        :canonical-url (some->> (bundle/more-recent-version cache-bundle)
                                                (merge route-params)
                                                (routes/url-for :artifact/namespace :path-params))
                        :description (layout/artifact-description
-                                     cache-id
-                                     (-> cache-contents :version :pom :description))}))))
+                                     version-entity
+                                     (-> cache-bundle :version :pom :description))}))))
 
 (comment
 
@@ -129,7 +129,7 @@
 
   (namespace-hierarchy (map :name namespaces))
 
-  (-> (doctree/add-slug-path (-> (:cache-contents cljdoc.bundle/cache) :version :doc))
+  (-> (doctree/add-slug-path (-> (:cache-bundle cljdoc.bundle/cache) :version :doc))
       first)
 
   )

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -33,7 +33,7 @@
        (layout/page {:title (str (util/clojars-id cache-id) " " (:version cache-id))
                      :description (layout/artifact-description
                                    cache-id
-                                   (-> cache-contents :version :pom pom/parse pom/artifact-info :description))})))
+                                   (-> cache-contents :version :pom :description))})))
 
 (defmethod render :artifact/doc
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
@@ -77,7 +77,7 @@
                        ;; update desctiption by extracting it from XML (:pom cache-bundle)
                        :description (layout/artifact-description
                                      cache-id
-                                     (-> cache-contents :version :pom pom/parse pom/artifact-info :description))}))))
+                                     (-> cache-contents :version :pom :description))}))))
 
 (defmethod render :artifact/namespace
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
@@ -114,7 +114,7 @@
                                                (routes/url-for :artifact/namespace :path-params))
                        :description (layout/artifact-description
                                      cache-id
-                                     (-> cache-contents :version :pom pom/parse pom/artifact-info :description))}))))
+                                     (-> cache-contents :version :pom :description))}))))
 
 (comment
 

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -83,7 +83,7 @@
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
   (assert (:namespace route-params))
   (let [ns-emap route-params
-        defs    (bundle/defs-for-ns (:defs cache-contents) (:namespace ns-emap))
+        defs    (bundle/defs-for-ns-with-src-uri cache-contents (:namespace ns-emap))
         [[dominant-platf] :as platf-stats] (api/platform-stats defs)
         ns-data (first (filter #(= (:namespace ns-emap) (platf/get-field % :name))
                                (bundle/namespaces cache-bundle)))
@@ -96,8 +96,7 @@
              :vars-sidebar-contents (when (seq defs)
                                       [(api/platform-support-note platf-stats)
                                        (api/definitions-list ns-emap defs {:indicate-platforms-other-than dominant-platf})])
-             :content (api/namespace-page {:scm-info (:scm (:version cache-contents))
-                                           :ns-entity ns-emap
+             :content (api/namespace-page {:ns-entity ns-emap
                                            :ns-data ns-data
                                            :defs defs})})
            (layout/layout

--- a/src/cljdoc/server/ingest.clj
+++ b/src/cljdoc/server/ingest.clj
@@ -53,6 +53,7 @@
           :scm          (merge (:scm git-analysis)
                                {:url scm-url
                                 :commit (-> git-analysis :scm :rev)})
+          :config       (:config git-analysis)
           :doc-tree     (:doc-tree git-analysis)})
 
         {:scm-url scm-url

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -55,7 +55,7 @@
             (let [path-params (-> ctx :request :path-params)
                   page-type   (-> ctx :route :route-name)]
               (if-let [first-article-slug (and (= page-type :artifact/version)
-                                               (-> cache-bundle :cache-contents :version :doc first :attrs :slug))]
+                                               (-> cache-bundle :version :doc first :attrs :slug))]
                 ;; instead of rendering a mostly white page we
                 ;; redirect to the README/first listed article
                 (let [location (routes/url-for :artifact/doc :params (assoc path-params :article-slug first-article-slug))]
@@ -101,7 +101,7 @@
                 :cljdoc/index   (index-pages/full-index (::releases ctx)))))])
 
 (def ^:private pom-path
-  [:cache-bundle :cache-contents :version :pom])
+  [:cache-bundle :version :pom])
 
 (defn artifact-data-loader
   "Return an interceptor that loads all data from `store` that is
@@ -318,14 +318,14 @@
   for the project that has been injected into the context by [[artifact-data-loader]]."
   {:name ::offline-bundle
    :enter (fn offline-bundle [{:keys [cache-bundle] :as ctx}]
-            (log/info "Bundling" (str (-> cache-bundle :cache-id :artifact-id) "-"
-                                      (-> cache-bundle :cache-id :version) ".zip"))
+            (log/info "Bundling" (str (-> cache-bundle :version-entity :artifact-id) "-"
+                                      (-> cache-bundle :version-entity :version) ".zip"))
             (->> (if cache-bundle
                    {:status 200
                     :headers {"Content-Type" "application/zip, application/octet-stream"
                               "Content-Disposition" (format "attachment; filename=\"%s\""
-                                                            (str (-> cache-bundle :cache-id :artifact-id) "-"
-                                                                 (-> cache-bundle :cache-id :version) ".zip"))}
+                                                            (str (-> cache-bundle :version-entity :artifact-id) "-"
+                                                                 (-> cache-bundle :version-entity :version) ".zip"))}
                     :body (offline/zip-stream cache-bundle)}
                    {:status 404
                     :headers {}

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -129,7 +129,7 @@
                                          (util/clojars-id params)
                                          (:version params)))]
               (assoc-in ctx pom-path {:description (-> pom-parsed pom/artifact-info :description)
-                                      :dependencies (-> pom-parsed pom/dependencies)})))})
+                                      :dependencies (-> pom-parsed pom/dependencies-with-versions)})))})
 
 (defn- resolve-version [path-params referer]
   (assert (= "CURRENT" (:version path-params)))

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -106,7 +106,7 @@
 (defn artifact-data-loader
   "Return an interceptor that loads all data from `store` that is
   relevant for the artifact identified via the entity map in `:path-params`."
-  [store cache]
+  [store]
   {:name  ::artifact-data-loader
    :enter (fn artifact-data-loader-inner [ctx]
             (let [params (-> ctx :request :path-params)
@@ -169,7 +169,7 @@
   (->> [(version-resolve-redirect)
         (when (= :artifact/doc route-name) doc-slug-parser)
         (pom-loader cache)
-        (artifact-data-loader storage cache)
+        (artifact-data-loader storage)
         render-interceptor]
        (keep identity)
        (vec)))
@@ -365,7 +365,8 @@
          :artifact/version   (view storage cache route-name)
          :artifact/namespace (view storage cache route-name)
          :artifact/doc       (view storage cache route-name)
-         :artifact/offline-bundle [(artifact-data-loader storage cache)
+         :artifact/offline-bundle [(pom-loader cache)
+                                   (artifact-data-loader storage)
                                    offline-bundle]
 
          :artifact/current-via-short-id [(jump-interceptor)]

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -110,11 +110,12 @@
   {:name  ::artifact-data-loader
    :enter (fn artifact-data-loader-inner [ctx]
             (let [params (-> ctx :request :path-params)
-                  pom-data (get-in ctx pom-path)]
+                  pom-data (get-in ctx pom-path)
+                  bundle-params (assoc params :dependency-version-entities (:dependencies pom-data))]
               (log/info "Loading artifact cache bundle for" params)
               (if (storage/exists? store params)
                 (-> ctx
-                    (assoc :cache-bundle (storage/bundle-docs store params))
+                    (assoc :cache-bundle (storage/bundle-docs store bundle-params))
                     (assoc-in pom-path pom-data))
                 ctx)))})
 

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -99,6 +99,8 @@
 
   (integrant.repl/set-prep! #(system-config (cfg/config)))
 
+  (taoensso.tufte/add-basic-println-handler! {})
+
   (integrant.repl/go)
 
   (do (integrant.repl/halt)

--- a/src/cljdoc/storage/api.clj
+++ b/src/cljdoc/storage/api.clj
@@ -27,7 +27,7 @@
                             (:artifact-id version-entity)
                             [(:version version-entity)])
     (sqlite/import-api db-spec version-entity codox))
-  (import-doc [_ version-entity {:keys [doc-tree scm jar] :as version-data}]
+  (import-doc [_ version-entity {:keys [doc-tree scm jar config] :as version-data}]
     (sqlite/import-doc db-spec version-entity version-data))
   (exists? [_ version-entity]
     (sqlite/docs-available? db-spec

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -21,6 +21,7 @@
   to the mix."
   (:require [cljdoc.spec]
             [cljdoc.util :as util]
+            [cljdoc.user-config :as user-config]
             [clojure.set :as cset]
             [clojure.java.io :as io]
             [clojure.java.jdbc :as sql]
@@ -173,7 +174,8 @@
     (if-not primary-resolved
       (throw (Exception. (format "Could not find version %s" v)))
       (let [version-data (or (get-version db-spec (:id primary-resolved)) {})
-            wanted?      (->> version-data :config :cljdoc/include-namespaces-from-dependencies (map util/normalize-project) set)
+            include-cfg  (user-config/include-namespaces-from-deps (:config version-data) (util/clojars-id v))
+            wanted?      (set (map util/normalize-project include-cfg))
             extra-deps   (filter #(wanted? (str (:group-id %) "/" (:artifact-id %))) resolved-versions)
             namespaces   (set (get-namespaces db-spec (conj extra-deps primary-resolved)))]
         (-> {:version    version-data

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -128,10 +128,9 @@
 (defn bundle-docs
   [db-spec {:keys [group-id artifact-id version] :as v}]
   (if-let [version-id (get-version-id db-spec group-id artifact-id version)]
-    (->> {:cache-contents (-> (docs-cache-contents db-spec version-id)
-                              (assoc :latest (latest-release-version db-spec v)))
-          :cache-id       {:group-id group-id, :artifact-id artifact-id, :version version}}
-         (cljdoc.spec/assert :cljdoc.spec/cache-bundle))
+    (-> (docs-cache-contents db-spec version-id)
+        (assoc :latest (latest-release-version db-spec v))
+        (assoc :version-entity {:group-id group-id, :artifact-id artifact-id, :version version}))
     (throw (Exception. (format "Could not find version %s" v)))))
 
 (defn import-api [db-spec

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -84,13 +84,6 @@
        (version-clj/version-sort)
        (last)))
 
-(defn- docs-cache-contents [db-spec version-id]
-  {:version    (p :get-version (or (get-version db-spec version-id) {}))
-   :group      {}
-   :artifact   {}
-   :namespaces (p :get-namespaces (set (get-namespaces db-spec version-id)))
-   :defs       (p :get-vars (set (get-vars db-spec version-id)))})
-
 (defn- sql-exists?
   "A small helper to deal with the complex keys that sqlite returns for exists queries."
   [db-spec sqlvec]
@@ -128,7 +121,11 @@
 (defn bundle-docs
   [db-spec {:keys [group-id artifact-id version] :as v}]
   (if-let [version-id (get-version-id db-spec group-id artifact-id version)]
-    (-> (docs-cache-contents db-spec version-id)
+    (-> {:version    (p :get-version (or (get-version db-spec version-id) {}))
+         :group      {}
+         :artifact   {}
+         :namespaces (p :get-namespaces (set (get-namespaces db-spec version-id)))
+         :defs       (p :get-vars (set (get-vars db-spec version-id)))}
         (assoc :latest (latest-release-version db-spec v))
         (assoc :version-entity {:group-id group-id, :artifact-id artifact-id, :version version}))
     (throw (Exception. (format "Could not find version %s" v)))))

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -155,11 +155,11 @@
 
 (defn import-doc [db-spec
                   {:keys [group-id artifact-id version]}
-                  {:keys [doc-tree scm jar]}]
+                  {:keys [jar scm doc-tree config]}]
   {:pre [(string? group-id) (string? artifact-id) (string? version)]}
   (store-artifact! db-spec group-id artifact-id [version])
   (let [version-id (get-version-id db-spec group-id artifact-id version)]
-    (update-version-meta! db-spec version-id {:jar jar :scm scm, :doc doc-tree})))
+    (update-version-meta! db-spec version-id {:jar jar :scm scm, :doc doc-tree, :config config})))
 
 (comment
   (def data (clojure.edn/read-string (slurp "https://2941-119377591-gh.circle-artifacts.com/0/cljdoc-edn/stavka/stavka/0.4.1/cljdoc.edn")))

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -119,15 +119,22 @@
         (sql-exists? db-spec ["select exists(select id from vars where version_id = ?)" v-id]))))
 
 (defn bundle-docs
-  [db-spec {:keys [group-id artifact-id version] :as v}]
+  ;; TODO add `dependency-version-entities` argument
+  [db-spec {:keys [group-id artifact-id version namespace] :as v}]
   (if-let [version-id (get-version-id db-spec group-id artifact-id version)]
     (-> {:version    (p :get-version (or (get-version db-spec version-id) {}))
-         :group      {}
-         :artifact   {}
+         ;; TODO integrate namespaces from dependencies
          :namespaces (p :get-namespaces (set (get-namespaces db-spec version-id)))
-         :defs       (p :get-vars (set (get-vars db-spec version-id)))}
-        (assoc :latest (latest-release-version db-spec v))
-        (assoc :version-entity {:group-id group-id, :artifact-id artifact-id, :version version}))
+         ;; TODO only load defs for namespace that is being requested
+         ;; Maybe skip this initially because all vars are needed for overview page
+         :defs       (p :get-vars (set (get-vars db-spec version-id)))
+         ;; TODO add scm-info for the rendered namespace
+         ;; -----
+
+         :latest (latest-release-version db-spec v)
+         :version-entity {:group-id group-id
+                          :artifact-id artifact-id
+                          :version version}})
     (throw (Exception. (format "Could not find version %s" v)))))
 
 (defn import-api [db-spec

--- a/src/cljdoc/user_config.clj
+++ b/src/cljdoc/user_config.clj
@@ -1,0 +1,39 @@
+(ns cljdoc.user-config
+  "Users can provide configuration via a file `doc/cljdoc.edn` in their Git repository.
+
+  This namespace defines functions to query the contents of this file."
+  (:require [cljdoc.util :as util]))
+
+(defn get-project-specific
+  [config-edn project]
+  (some->> config-edn
+           (filter (fn [[k _]]
+                     (and
+                      (symbol? k)
+                      (or (= k (symbol (util/group-id project)))
+                          (= k (symbol (util/group-id project) (util/artifact-id project)))))))
+           (first)
+           (val)))
+
+(defn get-project
+  [config-edn project]
+  (or (get-project-specific config-edn project)
+      (->> config-edn
+           (remove (fn [[k v]] (symbol? k)))
+           (into {}))))
+
+(defn doc-tree [config-edn project]
+  (:cljdoc.doc/tree (get-project config-edn project)))
+
+(defn include-namespaces-from-deps [config-edn project]
+  (:cljdoc/include-namespaces-from-dependencies (get-project config-edn project)))
+
+(comment
+  (def d
+    '{metosin/reitit {:cljdoc.doc/tree [["Introduction" {:file "intro.md"}]]}
+     :cljdoc.doc/tree [["Overview" {:file "modules/README.md"}]]})
+
+  (get-project d "metosin/reitit")
+
+
+  )

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -26,13 +26,13 @@
   (or (.startsWith s "https://cljdoc.org")
       (.startsWith s "https://cljdoc.xyz")))
 
-(defn uri-mapping [cache-id docs]
+(defn uri-mapping [version-entity docs]
   (->> docs
        (map (fn [d]
               [(-> d :attrs :cljdoc.doc/source-file)
                (->> (-> d :attrs :slug-path)
                     (clojure.string/join "/")
-                    (assoc cache-id :article-slug)
+                    (assoc version-entity :article-slug)
                     (routes/url-for :artifact/doc :path-params))]))
        (into {})))
 

--- a/test/cljdoc/analysis/git_test.clj
+++ b/test/cljdoc/analysis/git_test.clj
@@ -2,7 +2,7 @@
   (:require [cljdoc.analysis.git :as git-ana]
             [clojure.test :as t]))
 
-(t/deftest version-tag-test
+(t/deftest ^:slow version-tag-test
   (let [analysis (git-ana/analyze-git-repo "metosin/reitit" "0.1.1" "https://github.com/metosin/reitit" nil)]
     (t/is (= "0.1.1" (-> analysis :scm :tag :name)))
     ;; This will fail if the tag is modified (it shouldn't be)

--- a/test/cljdoc/integration_test.clj
+++ b/test/cljdoc/integration_test.clj
@@ -1,4 +1,4 @@
-(ns cljdoc.integration-test
+(ns ^:slow cljdoc.integration-test
   (:require [cljdoc.server.system :as sys]
             [cljdoc.util :as util]
             [io.pedestal.test :as pdt]

--- a/tests.edn
+++ b/tests.edn
@@ -1,2 +1,2 @@
-#kaocha
-{:reporter kaocha.report.progress/report}
+#kaocha/v1 {:reporter kaocha.report.progress/report
+            :plugins [:kaocha.plugin/notifier]}


### PR DESCRIPTION
Fixes #24 
Fixes #198 

This PR significantly improves cljdoc's usability with regards to libraries consisting of multiple modules/separate jars. Notably the following features are added:

#### `doc/cljdoc.edn` can target multiple artifacts

If a repository contains the code for multiple artifacts it might be desirable to provide different doc trees for those artifacts. This can be used to point users to the "ubermodule" documentation or to provide more detailed documentation on a module.

#### Namespaces from dependencies can be included

Ubermodule libraries often don't contain any actual code and rely on dependencies to import functionality. Users can now provide a `:cljdoc/include-namespaces-from-dependencies` key to include APIs from dependencies in the documentation of an artifact.

💡  For details on how to use those features, check the [changes to the user guide](https://github.com/cljdoc/cljdoc/blob/multi-module-docs/doc/userguide/for-library-authors.adoc#module-support) part of this PR.

🗣 As usual, feedback is very welcome :)

<img width="1436" alt="screenshot 2019-02-01 at 20 25 49" src="https://user-images.githubusercontent.com/97496/52144798-92e8f500-265f-11e9-8521-341642c03556.png">




