### PR TITLE
Global Index Page + Navigator JS Component

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -2,6 +2,7 @@ import { render, h } from "preact";
 import { trackProjectOpened, Switcher } from "./switcher";
 import { App } from "./search";
 import { MobileNav } from "./mobile";
+import { Navigator } from "./navigator";
 import {
   isNSPage,
   isProjectDocumentationPage,
@@ -19,6 +20,11 @@ render(h(Switcher), document.querySelector("#cljdoc-switcher"));
 const searchNode = document.querySelector("#cljdoc-search");
 if (searchNode) {
   render(h(App, { initialValue: searchNode.dataset.initialValue }), searchNode);
+}
+
+const navigatorNode = document.querySelector("#js--cljdoc-navigator");
+if (navigatorNode) {
+  render(h(Navigator), navigatorNode);
 }
 
 if (isNSPage()) {

--- a/js/navigator.js
+++ b/js/navigator.js
@@ -1,0 +1,67 @@
+// A small component to navigate users to documentation pages based on clojars ID and version inputs
+
+import { Component, render, h } from "preact";
+
+class Navigator extends Component {
+  constructor() {
+    super();
+    this.navigate = this.navigate.bind(this);
+  }
+
+  navigate() {
+    let clojarsId = this.clojarsIdInput.value;
+    let version = this.versionInput.value;
+
+    if (0 != clojarsId.length) {
+      if (clojarsId.includes("/")) {
+        window.location.href = "/d/" + clojarsId + "/" + version;
+      } else {
+        window.location.href =
+          "/d/" + clojarsId + "/" + clojarsId + "/" + version;
+      }
+    }
+  }
+
+  render(props, state) {
+    return (
+      <div>
+        <div class="cf nl2 nr2">
+          <fieldset class="fl w-50-ns pa2 bn mh0">
+            <label class="b db mb3">
+              Group ID / Artifact ID
+              <span class="normal ml2 gray f6">may be identical</span>
+            </label>
+            <input
+              class="w-90 pa2 b--blue br2 ba no-outline"
+              autocorrect="off"
+              autocapitalize="none"
+              onKeyUp={e => (e.keyCode == 13 ? this.navigate() : null)}
+              ref={node => (this.clojarsIdInput = node)}
+              placeholder="e.g. 're-frame' or 'ring/ring-core'"
+            />
+          </fieldset>
+          <fieldset class="fl w-50-ns pa2 bn mh0">
+            <label class="b db mb3">
+              Version
+              <span class="normal ml2 gray f6">optional</span>
+            </label>
+            <input
+              class="w-90 pa2 b--blue br2 ba no-outline"
+              onKeyUp={e => (e.keyCode == 13 ? this.navigate() : null)}
+              ref={node => (this.versionInput = node)}
+              placeholder="e.g. '1.0.2'"
+            />
+          </fieldset>
+        </div>
+        <input
+          class="bg-blue white bn pv2 ph3 br2"
+          type="button"
+          onClick={this.navigate}
+          value="Go to Documentation"
+        />
+      </div>
+    );
+  }
+}
+
+export { Navigator };

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -35,7 +35,8 @@
     ["/download/:group-id/:artifact-id/:version" :get nop :route-name :artifact/offline-bundle]})
 
 (defn index-routes []
-  #{["/versions/:group-id" :get nop :route-name :group/index]
+  #{["/versions" :get nop :route-name :cljdoc/index]
+    ["/versions/:group-id" :get nop :route-name :group/index]
     ["/versions/:group-id/:artifact-id" :get nop :route-name :artifact/index]})
 
 (defn open-search-routes []


### PR DESCRIPTION
This PR adds two things (in one commit, sorry about that):

1. A global index page under `/versions`
    - **Rationale:** cljdoc is now used internally at a company (cool! 🎉) and discoverability of documentation has been an issue. By having a global index this should be a solved problem. The global index is probably less useful in the live cljdoc instance (due to sheer amount of libs) but the code has been fairly minimal so I think it's ok to have it.
1. A small JS component that allows you to enter a project and a version and jump to the documentation for the specified project
    - **Rationale:** cljdoc's search is pretty buggy and Clojars specific at this point and memorising the URL pattern `/d/$group-id/$artifact-id/$version` imposes additional mental load on people trying to find docs. This component should make it easier to jump to documentation. Maybe it'll temporarily replace the search on the front page later on.

<img width="837" alt="screenshot 2019-03-01 at 10 27 32" src="https://user-images.githubusercontent.com/97496/53628935-a199dc00-3c0c-11e9-969c-21345f19cb65.png">

**Feedback / thoughts welcome!**