### PR TITLE
Use single monospace font style everywhere

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -1,3 +1,9 @@
+/** HTML elements **/
+
+code, pre {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+}
+
 /** Tachyons style helpers ---------------------------------- **/
 
 .f7 {
@@ -34,8 +40,6 @@
 }
 
 .markdown pre, .literalblock > .content > pre, .listingblock > .content > pre {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
-    monospace;
   padding: 1rem;
   background-color: rgb(246, 248, 250);
   border-radius: 3px;
@@ -44,8 +48,6 @@
 }
 
 .markdown code, .asciidoc :not(.highlight) > code {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
-    monospace;
   padding: 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
@@ -54,8 +56,6 @@
 }
 
 .markdown pre code {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
-    monospace;
   padding: 0;
   font-size: 100%;
   background-color: transparent;


### PR DESCRIPTION
Since this is a quick change, I'm creating a PR instead of asking first. It is subjective, but using a single monospace font everywhere looks nicer to my eyes. We should probably update the screenshot on home page, maybe I missed some other monospace usage as well.

Feel free to close this, if it doesn't fit into your vision of cljdoc design.