### PR TITLE
UX(docstrings): show docstring platform in margin. Closes #280.

### DIFF
--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -55,8 +55,8 @@
   (if (platf/varies? mp :doc)
     (for [p (sort (platf/platforms mp))
           :when (platf/get-field mp :doc p)]
-      [:div
-       [:span.f7.ttu.gray.db.nb2 (get {"clj" "Clojure" "cljs" "ClojureScript"} p) " docstring"]
+      [:div.relative
+       [:div.f7.gray.absolute.w3.nl5.pr2.tr.pv1 p]
        (some-> (platf/get-field mp :doc p) (docstring->html render-wiki-link))])
     (some-> (platf/get-field mp :doc) (docstring->html render-wiki-link))))
 

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -195,7 +195,7 @@
   :div.js--namespace-contents-scroll-view.w5.pa3.pa4-ns.br.b--black-10.db-ns.dn.overflow-y-scroll.flex-shrink-0)
 
 (def r-content-container
-  :div.js--main-scroll-view.db-ns.ph4-ns.ph3.flex-grow-1.overflow-y-scroll)
+  :div.js--main-scroll-view.db-ns.pr4-ns.pr3.pl5.flex-grow-1.overflow-y-scroll)
 
 (def r-top-bar-container
   "Additional wrapping to make the top bar responsive


### PR DESCRIPTION
Moved docstring platform indication into the (widened) left margin.

Before:
![image](https://user-images.githubusercontent.com/165223/54122835-711d2380-43fe-11e9-95a4-410e2d4d89ee.png)

After:
![image](https://user-images.githubusercontent.com/165223/54122780-4fbc3780-43fe-11e9-8c7f-0d0910261756.png)
