### PR TITLE
Handle {:doc false} when rendering doc string

### DIFF
--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -34,11 +34,13 @@
 (defn docstring->html [doc-str render-wiki-link]
   [:div
    [:div.lh-copy.markdown
-    (-> doc-str
-        (rich-text/markdown-to-html
-         {:escape-html? true
-          :render-wiki-link (comp render-wiki-link parse-wiki-link)})
-        hiccup/raw)]
+    ;; If someone sets `{:doc false}`, there will be no docstring
+    (when doc-str
+      (-> doc-str
+          (rich-text/markdown-to-html
+            {:escape-html? true
+             :render-wiki-link (comp render-wiki-link parse-wiki-link)})
+          hiccup/raw))]
    [:pre.lh-copy.bg-near-white.code.pa3.br2.f6.overflow-x-scroll.dn.raw
     doc-str]])
 


### PR DESCRIPTION
I came across this broken page:
https://cljdoc.org/d/buddy/buddy-core/1.5.0/api/buddy.core.mac

![Screen Shot 2019-03-23 at 14 54 00](https://user-images.githubusercontent.com/738978/54866972-8473ab80-4d7b-11e9-9b0d-ab24343e10cf.png)


After being able to reproduce the same issue locally, I discovered what was causing the error:

The function [here](https://github.com/funcool/buddy-core/blob/master/src/buddy/core/mac.clj#L70) has a strange definition with a doc string which is then overwritten with `{:doc false}`.

I think cljdoc should handle `{:doc false}` in general.

Not sure what is the best way to handle it but with the fix, the page renders and the missing doc string looks like this:

![Screen Shot 2019-03-23 at 14 50 11](https://user-images.githubusercontent.com/738978/54866985-97867b80-4d7b-11e9-95fc-e37e194d129e.png)

And raw mode:

![Screen Shot 2019-03-23 at 14 50 21](https://user-images.githubusercontent.com/738978/54866987-99503f00-4d7b-11e9-960e-99fd3f4b7df5.png)
