### PR TITLE
Integrate build status into badge + docs pages

### DIFF
--- a/resources/migrations/007-builds-index.down.sql
+++ b/resources/migrations/007-builds-index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX builds_artifact_index;

--- a/resources/migrations/007-builds-index.up.sql
+++ b/resources/migrations/007-builds-index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX builds_artifact_index ON builds (group_id, artifact_id, version);

--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -1,4 +1,4 @@
-(ns cljdoc.renderers.html
+(ns cljdoc.render
   (:require [cljdoc.doc-tree :as doctree]
             [cljdoc.render.rich-text :as rich-text]
             [cljdoc.render.layout :as layout]

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -166,11 +166,6 @@
       :else
       [:a.f6.link.blue {:href (util/github-url :userguide/scm-faq)} "SCM info missing"])]])
 
-(defn upgrade-notice [{:keys [version] :as version-map}]
-  [:a.link {:href (routes/url-for :artifact/version :path-params version-map)}
-   [:div.bg-washed-yellow.pa2.f7.mb4.dark-gray.lh-title
-    "A newer version " [:span.blue "(" version ")"] " for this library is available"]])
-
 ;; Responsive Layout -----------------------------------------------------------
 
 (def r-main-container

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -9,7 +9,7 @@
 (defn sidebar-contents
   "Render a sidebar for a documentation page.
 
-  This function takes the same arguments as the main render functions in `cljdoc.renderer.html`
+  This function takes the same arguments as the main render functions in `cljdoc.render`
   and selected pages/namespaces will be highlighted based on the supplied `route-params`.
 
   If articles or namespaces are missing for a project there will be little messages pointing

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -62,7 +62,9 @@
                   (assoc ctx :response {:status 302, :headers {"Location" location}}))
 
                 (if cache-bundle
-                  (pu/ok-html ctx (html/render page-type path-params cache-bundle))
+                  (pu/ok-html ctx (html/render page-type path-params {:cache-bundle cache-bundle
+                                                                      :pom (::pom-info ctx)
+                                                                      :last-build (::last-build ctx)}))
                   (let [resp {:status 404
                               :headers {"Content-Type" "text/html"}
                               :body (str (render-build-req/request-build-page path-params))}]
@@ -111,12 +113,7 @@
                   bundle-params (assoc params :dependency-version-entities (:dependencies pom-data))]
               (log/info "Loading artifact cache bundle for" params (:cache-bundle ctx))
               (if (storage/exists? store params)
-                (-> ctx
-                    (assoc :cache-bundle (storage/bundle-docs store bundle-params))
-                    ;; Injecting things into the cache bundle like this is a bit of a hack and really
-                    ;; we should have one entry point that takes care of all the data sources that
-                    ;; contribute to the cache bundle.
-                    (assoc-in [:cache-bundle :version :pom] pom-data))
+                (assoc ctx :cache-bundle (storage/bundle-docs store bundle-params))
                 ctx)))})
 
 (defn last-build-loader

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -139,7 +139,8 @@
 
 (def resolve-version-interceptor
   "An interceptor that will look at `:path-params` and try to turn it into an artifact
-  entity.
+  entity or redirect of the version is specified in a meta-fasion, i.e. `CURRENT`.
+
   - If the provided version is `nil` set it to the last known release.
   - If the provided version is `CURRENT` redirect to either a version from the `referer` header
     or the last known version."
@@ -152,7 +153,6 @@
                   referer-version (some-> request
                                            (get-in [:headers "referer"])
                                            util/uri-path routes/match-route :path-params :version)
-                  _ (log/info 'repos/latest-release-version (str group-id "/" artifact-id))
                   artifact-entity {:artifact-id artifact-id
                                    :group-id group-id
                                    :version (cond

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -20,7 +20,7 @@
             [cljdoc.render.meta :as render-meta]
             [cljdoc.render.error :as error]
             [cljdoc.render.offline :as offline]
-            [cljdoc.renderers.html :as html]
+            [cljdoc.render :as html]
             [cljdoc.analysis.service :as analysis-service]
             [cljdoc.server.build-log :as build-log]
             [cljdoc.server.pedestal-util :as pu]


### PR DESCRIPTION
The badges are a useful way to provide information about the state of a project to it's authors and other users. To make it even more useful it should display information about the build status if there has been a problem.

- [x] Show if API/Git import failed in badge message
- [x] Integrate warning into docs pages if there were problems in last build 

Fixes #243 

#### Demo screenshots (docs page + badge):

<img width="1143" alt="Screenshot 2019-03-27 at 11 52 29" src="https://user-images.githubusercontent.com/97496/55070731-31556d80-5087-11e9-8ccc-e7616de248b0.png">
<img width="181" alt="Screenshot 2019-03-27 at 11 54 07" src="https://user-images.githubusercontent.com/97496/55070743-35818b00-5087-11e9-8ea7-4420d1ddea8b.png">

<img width="1143" alt="Screenshot 2019-03-27 at 11 52 41" src="https://user-images.githubusercontent.com/97496/55070745-374b4e80-5087-11e9-9e6e-7502c5c5744f.png">
<img width="173" alt="Screenshot 2019-03-27 at 11 53 48" src="https://user-images.githubusercontent.com/97496/55070749-39151200-5087-11e9-8d35-f228c1de5c5d.png">
