### PR TITLE
Search: Ignore Clojure Contrib libs from Clojars

### DIFF
--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -31,7 +31,8 @@
                :versions [latestVersion]
                ;; We do not have description so fake one with g and a so
                ;; that it will match of this field too and score higher
-               :description (str "Clojure Contrib library" g "/" a)}))))
+               :description (str "Clojure Contrib library " g "/" a)
+               :origin "Maven Central"}))))
 
 (defn load-maven-central-artifacts []
   ;; GET http://search.maven.org/solrsearch/select?q=g:org.clojure -> JSON .response.docs[] = {g: group, a: artifact-id, latestVersion, versionCount
@@ -51,7 +52,13 @@
 (defn process-clojars-response [{:keys [headers body]}]
   {:pre [(instance? InputStream body)]}
   (with-open [in (io/reader (GZIPInputStream. body))]
-    (let [artifacts     (doall (map edn/read-string (line-seq in)))
+    (let [artifacts     (into []
+                              (comp
+                                (map #(-> % edn/read-string (assoc :origin "Clojars")))
+                                ;; Latest Clojure Contrib libs are in Maven Central
+                                ;; and thus should be loaded from there
+                                (filter #(not= "org.clojure" (:group-id %))))
+                              (line-seq in))
           last-modified (get headers "last-modified")]
       (log/debug (str "Downloaded " (count artifacts) " artifacts from Clojars with last-modified " last-modified))
       (reset! clojars-last-modified last-modified)
@@ -116,6 +123,7 @@
     ;; *StringField* is indexed but not tokenized, term freq. or positional info not indexed
     ;; id: We need a unique identifier for each doc so that we can use updateDocument
     (.add (StringField. "id" (artifact->id artifact) Field$Store/YES))
+    (.add (StringField. "origin" ^String (:origin artifact) Field$Store/YES))
     (.add (TextField. "artifact-id" artifact-id Field$Store/YES))
     ;; Keep also un-tokenized version of the id for RegExp searches (Better to replace with
     ;; a custom tokenizer that produces both the original + individual tokens)

--- a/src/cljdoc/server/search/search.clj
+++ b/src/cljdoc/server/search/search.clj
@@ -11,21 +11,6 @@
 (defn ^FSDirectory fsdir [index-dir] ;; BEWARE: Duplicated in artifact-indexer and search ns
   (FSDirectory/open (Paths/get index-dir (into-array String nil))))
 
-
-(defn format-results
-  "Format search results into what the frontend expects"
-  [hits-cnt docs]
-  {:count   hits-cnt
-   :results (map
-              (fn [{:keys [^Document doc score]}]
-                {:artifact-id (.get doc "artifact-id")
-                 :group-id    (.get doc "group-id")
-                 :description (.get doc "description")
-                 ;; The first version appears to be the latest so this is OK:
-                 :version (.get doc "versions")
-                 :score       score})
-              docs)})
-
 (defn tokenize
   "Split search text into tokens. It is reasonable to use the same tokenization <> analyzer
    as when indexing."
@@ -156,6 +141,21 @@
           hits             (.scoreDocs topdocs)]
       (f {:topdocs topdocs :score-docs hits :searcher searcher :query query}))))
 
+(defn format-results
+  "Format search results into what the frontend expects"
+  [hits-cnt docs]
+  {:count   hits-cnt
+   :results (map
+              (fn [{:keys [^Document doc score]}]
+                {:artifact-id (.get doc "artifact-id")
+                 :group-id    (.get doc "group-id")
+                 :description (.get doc "description")
+                 ;:origin (.get doc "origin")
+                 ;; The first version appears to be the latest so this is OK:
+                 :version (.get doc "versions")
+                 :score       score})
+              docs)})
+
 (defn search [^String index-dir ^String query-in]
   (search->results
     index-dir query-in
@@ -185,8 +185,11 @@
 
 (comment
 
+  (cljdoc.server.search.artifact-indexer/download-and-index! "data/index" :force)
+
   (search "data/index" "re-frame")
   (search "data/index" "clojure")
+  (search "data/index" "testit")
   (search "data/index" "ring")
   (search "data/index" "conc")
   (explain-top-n 3 "data/index" "clojure")


### PR DESCRIPTION
E.g. clojure at Clojars is old, 1.5 version. We only want the latest
and thus from Maven Central.