### PR TITLE
Fix issues with wrong Clojure and ClojureScript versions

### DIFF
--- a/modules/analysis-runner/src/cljdoc/analysis/deps.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/deps.clj
@@ -126,7 +126,7 @@
                                       :mvn/repos (merge default-repos
                                                         (extra-repos pom)
                                                         repos)}
-                                     {:extra-deps {project {:local/root jar-url}}
+                                     {:extra-deps {(symbol project) {:local/root jar-url}}
                                       :verbose false})]
     {:resolved-deps resolved
      :classpath (tdeps/make-classpath resolved [] nil)}))

--- a/modules/analysis-runner/src/cljdoc/analysis/deps.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/deps.clj
@@ -75,6 +75,15 @@
                [(symbol group-id artifact-id) {:mvn/version version}]))
        (into {})))
 
+(defn clj-cljs-deps
+  [pom]
+  {:pre [(pom/jsoup? pom)]}
+  (->> (pom/dependencies pom)
+       (map (fn [{:keys [group-id artifact-id version]}]
+              [(symbol group-id artifact-id) {:mvn/version version}]))
+       (filter #(-> % first #{'org.clojure/clojure 'org.clojure/clojurescript}))
+       (into {})))
+
 (defn- extra-repos
   [pom]
   {:pre [(pom/jsoup? pom)]}
@@ -90,6 +99,7 @@
   (let [{:keys [group-id artifact-id version]} (pom/artifact-info pom)
         project (symbol group-id artifact-id)]
     (-> (extra-deps pom)
+        (merge (clj-cljs-deps pom))
         (merge (get hardcoded-deps project))
         (ensure-required-deps)
         (ensure-recent-ish)


### PR DESCRIPTION
Setting up proper tests for this would be great but for now I just wanted to get it fixed.

#### Test case for #298 

```
  (-> (resolved-and-cp
       "/Users/martinklepsch/.m2/repository/cljdoc-298/cljdoc-298/1.0.0/cljdoc-298-1.0.0.jar",
       "/Users/martinklepsch/.m2/repository/cljdoc-298/cljdoc-298/1.0.0/cljdoc-298-1.0.0.pom"
       {})
      :resolved-deps
      (get 'org.clojure/clojurescript)
      :mvn/version
      (= "1.10.520"))
```

Thanks to @mfikes for his excellent repro in #298.