### PR TITLE
automate code format checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
 
       - run: clojure -Spath
 
+      - run: ./script/code-format.sh check
+
       - run: ./script/cljdoc ingest --project bidi --version 2.1.3
       - run: ./.circleci/run_if_changed.sh modules/analysis-runner/ "cd modules/analysis-runner/; clojure extended-test.clj"
 

--- a/.cljfmt/indentation.edn
+++ b/.cljfmt/indentation.edn
@@ -1,0 +1,2 @@
+;; for defaults see: https://github.com/weavejester/cljfmt/blob/master/cljfmt/resources/cljfmt/indents/clojure.clj
+{defcache  [[:block 2] [:inner 1]]}

--- a/deps.edn
+++ b/deps.edn
@@ -68,6 +68,10 @@
             :extra-deps {cli-matic {:mvn/version "0.1.14"}}
             :main-opts ["-m"  "cljdoc.cli"]}
 
+           :code-format
+           {:extra-deps {cljfmt {:mvn/version "0.6.4"}}
+            :main-opts [ "-m" "cljfmt.main"  "--indents" "./.cljfmt/indentation.edn"]}
+
            :jar-deploy
            {:extra-deps {com.workframe/garamond {:git/url "https://github.com/martinklepsch/garamond.git"
                                                  :sha "a7e3a346b9c51d0fb0e73ca4ea47a150004ca6d1"}

--- a/modules/analysis-runner/src/cljdoc/analysis/deps.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/deps.clj
@@ -72,7 +72,7 @@
        (remove #(and (= (:group-id %) "org.clojure")
                      (= (:artifact-id %) "tools.reader")))
        (map (fn [{:keys [group-id artifact-id version]}]
-               [(symbol group-id artifact-id) {:mvn/version version}]))
+              [(symbol group-id artifact-id) {:mvn/version version}]))
        (into {})))
 
 (defn clj-cljs-deps
@@ -133,7 +133,6 @@
 
 (defn print-tree [resolved-deps]
   (tdeps/print-tree resolved-deps))
-
 
 (comment
   (deps "/Users/martin/.m2/repository/manifold/manifold/0.1.6/manifold-0.1.6.pom" 'manifold/manifold "0.1.6")

--- a/modules/cli/src/cljdoc/cli.clj
+++ b/modules/cli/src/cljdoc/cli.clj
@@ -78,7 +78,6 @@
                   :opts        []
                   :runs        run}]})
 
-
 (defn -main
   [& args]
   (cli-matic/run-cmd args CONFIGURATION))

--- a/modules/deploy/src/cljdoc/deploy.clj
+++ b/modules/deploy/src/cljdoc/deploy.clj
@@ -142,9 +142,9 @@
 (defmacro with-nomad [{:keys [ip ssh-key]} & body]
   `(let [jsch#    (JSch.)
          session# (.getSession jsch# "root" ~ip)]
-    (.addIdentity jsch# ~ssh-key)
-    (JSch/setConfig "StrictHostKeyChecking" "no")
-    (.connect session# 5000)
+     (.addIdentity jsch# ~ssh-key)
+     (JSch/setConfig "StrictHostKeyChecking" "no")
+     (.connect session# 5000)
      (try
        (.setPortForwardingL session# 8500 "localhost" 8500)
        (.setPortForwardingL session# 4646 "localhost" 4646)
@@ -182,6 +182,4 @@
   (with-nomad ip
     (nomad-get "/v1/deployments")
     (deploy!
-     (or "0.0.1160-blue-green-8b4cdad" "0.0.1151-blue-green-c329ed1")))
-
-  )
+     (or "0.0.1160-blue-green-8b4cdad" "0.0.1151-blue-green-c329ed1"))))

--- a/modules/shared-utils/src/cljdoc/spec.cljc
+++ b/modules/shared-utils/src/cljdoc/spec.cljc
@@ -72,6 +72,8 @@
 
 ;; Docs-cache: this is intended for a specific
 ;; versioned artifact, e.g. [re-frame 0.10.5]
+
+
 (s/def ::defs (s/coll-of ::def-full :gen-max 2))
 (s/def ::namespaces (s/coll-of map? :gen-max 2))
 (s/def ::latest ::version)
@@ -103,6 +105,7 @@
 ;; codox -------------------------------------------------------------
 ;; A spec for Codox namespace analysis data
 
+
 (s/def :cljdoc.codox.public/name symbol? #_(s/or :a string? :b symbol?))
 (s/def :cljdoc.codox.public/file string?)
 (s/def :cljdoc.codox.public/line int?)
@@ -133,6 +136,7 @@
 
 ;; cljdoc.edn ---------------------------------------------------------
 
+
 (s/def :cljdoc.cljdoc-edn/codox
   (s/map-of ::platform (s/coll-of :cljdoc.codox/namespace)))
 
@@ -144,6 +148,7 @@
 
 
 ;; grimoire -----------------------------------------------------------
+
 
 (s/def :cljdoc.grimoire/def
   ;; like codox output but without name
@@ -164,10 +169,10 @@
 (s/def :artifact/origin #{:clojars :maven-central})
 (s/def :artifact/versions (s/coll-of ::version))
 (s/def ::artifact (s/keys
-                    :req-un [::artifact-id ::group-id]
-                    :opt-un [:artifact/description
-                             :artifact/versions
-                             :artifact/origin]))
+                   :req-un [::artifact-id ::group-id]
+                   :opt-un [:artifact/description
+                            :artifact/versions
+                            :artifact/origin]))
 
 ;; utilities ----------------------------------------------------------
 
@@ -194,7 +199,6 @@
 
   (gen/sample (s/gen ::namespace))
   (gen/sample (s/gen :cache/artifact))
-
 
   (def x
     {:name "bidi.bidi"

--- a/script/code-format.sh
+++ b/script/code-format.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+COMMAND=check
+if [ $# -eq 1 ]; then
+  COMMAND=$1
+fi
+
+if [[ ! $COMMAND =~ (check|fix) ]]; then
+   echo "usage $0 command"
+   echo ""
+   echo "where command can be:"
+   echo "check - reports on code formatting violations (default)"
+   echo "fix   - fixes code formatting violations"
+fi
+
+echo "--[${COMMAND}ing code]--"
+clojure -A:code-format $COMMAND src test modules

--- a/src/cljdoc/analysis/git.clj
+++ b/src/cljdoc/analysis/git.clj
@@ -116,6 +116,4 @@
 (comment
   (def r (analyze-git-repo "metosin/reitit" "0.2.5" "https://github.metosin/reitit" nil))
 
-  (spec/explain (:ret (spec/get-spec `analyze-git-repo)) r)
-
-  )
+  (spec/explain (:ret (spec/get-spec `analyze-git-repo)) r))

--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -169,6 +169,4 @@
   (let [service (or #_(circle-ci (cljdoc.config/circle-ci))
                     (->Local))
         build   (trigger-build service p-fail)]
-    (wait-for-build service build))
-
-  )
+    (wait-for-build service build)))

--- a/src/cljdoc/bundle.clj
+++ b/src/cljdoc/bundle.clj
@@ -30,7 +30,7 @@
        (sort-by platf-name)))
 
 (defn get-namespace [bundle ns]
- (first (filter #(= ns (platf/get-field % :name)) (namespaces bundle))))
+  (first (filter #(= ns (platf/get-field % :name)) (namespaces bundle))))
 
 (defn scm-info [bundle]
   (-> bundle :version :scm))
@@ -83,6 +83,4 @@
     (cljdoc.storage.api/bundle-docs (cljdoc.storage.api/->GrimoireStorage (clojure.java.io/file "data" "grimoire")) id))
 
   (->> (cb {:group-id "re-frame" :artifact-id "re-frame" :version "0.10.5"})
-       namespaces)
-
-  )
+       namespaces))

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -110,7 +110,6 @@
 (defn enable-artifact-indexer? [config]
   (not (clojure.core/get-in config [:cljdoc/server :disable-artifact-indexer??])))
 
-
 (comment
   (:cljdoc/server (config))
 

--- a/src/cljdoc/doc_tree.clj
+++ b/src/cljdoc/doc_tree.clj
@@ -42,7 +42,6 @@
                    :cljdoc/asciidoc
                    :cljdoc/markdown]))
 
-
 (spec/def ::children
   (spec/coll-of ::entry))
 
@@ -225,8 +224,8 @@
           (->> (filter #(doc? (:path %)) files)
                (sort-by :path)
                (mapv (fn [{:keys [path object-loader]}]
-                      [(infer-title path (slurp object-loader))
-                       {:file path}]))))))
+                       [(infer-title path (slurp object-loader))
+                        {:file path}]))))))
 
 (comment
 

--- a/src/cljdoc/git_repo.clj
+++ b/src/cljdoc/git_repo.clj
@@ -39,8 +39,8 @@
       (.setConfig session  "StrictHostKeyChecking" "no"))
     ;; This could be used to specify keys explicitly
     #_(createDefaultJSch [fs]
-      (doto (proxy-super createDefaultJSch fs)
-        (.addIdentity "/Users/martinklepsch/.ssh/martinklepsch-lambdawerk2")))))
+                         (doto (proxy-super createDefaultJSch fs)
+                           (.addIdentity "/Users/martinklepsch/.ssh/martinklepsch-lambdawerk2")))))
 
 (defn clonable?
   "A rough heuristic to evaluate whether a repository can be cloned.
@@ -280,5 +280,4 @@
 
   (.getName (find-tag r "1.2.0"))
 
-  (read-file-at r (.getName (find-tag r "1.2.0")))
-  )
+  (read-file-at r (.getName (find-tag r "1.2.0"))))

--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -122,6 +122,4 @@
   (namespace-hierarchy (map :name namespaces))
 
   (-> (doctree/add-slug-path (-> (:cache-bundle cljdoc.bundle/cache) :version :doc))
-      first)
-
-  )
+      first))

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -38,8 +38,8 @@
     (when doc-str
       (-> doc-str
           (rich-text/markdown-to-html
-            {:escape-html? true
-             :render-wiki-link (comp render-wiki-link parse-wiki-link)})
+           {:escape-html? true
+            :render-wiki-link (comp render-wiki-link parse-wiki-link)})
           hiccup/raw))]
    [:pre.lh-copy.bg-near-white.code.pa3.br2.f6.overflow-x-scroll.dn.raw
     doc-str]])
@@ -115,7 +115,7 @@
   (let [keyed-namespaces (ns-tree/index-by :namespace namespaces)
         from-dependency? (fn from-dependency? [ns-entity]
                            (or (not= (:group-id version-entity) (:group-id ns-entity))
-                               (not= (:artifact-id version-entity) (:artifact-id ns-entity)))) ]
+                               (not= (:artifact-id version-entity) (:artifact-id ns-entity))))]
     [:div
      [:ul.list.pl0
       (for [[ns level _ leaf?] (ns-tree/namespace-hierarchy (keys keyed-namespaces))
@@ -241,6 +241,4 @@
     (< 1 (count (set (map :doc platforms)))))
 
   (platf/varies? --d :doc)
-  (platf/get-field --d :name)
-
-  )
+  (platf/get-field --d :name))

--- a/src/cljdoc/render/build_log.clj
+++ b/src/cljdoc/render/build_log.clj
@@ -181,8 +181,9 @@
                                           [:pre.lh-copy.bg-near-white.code.pa3.br2.f6.overflow-x-scroll
                                            (zp/zprint-str (ex-data ex) {:width 70})])))
            (when (:analysis_job_uri build-info)
-             [:p.lh-copy "Please see the " [:a.link.blue {:href (:analysis_job_uri build-info)}
-                                            "build job"] " to understand why this build failed and reach out if you aren't
+             [:p.lh-copy "Please see the "
+              [:a.link.blue {:href (:analysis_job_uri build-info)} "build job"]
+              " to understand why this build failed and reach out if you aren't
               sure how to fix the issue."])
            #_[:p (cljdoc-link build-info true)]))
 

--- a/src/cljdoc/render/build_log.clj
+++ b/src/cljdoc/render/build_log.clj
@@ -182,7 +182,7 @@
                                            (zp/zprint-str (ex-data ex) {:width 70})])))
            (when (:analysis_job_uri build-info)
              [:p.lh-copy "Please see the " [:a.link.blue {:href (:analysis_job_uri build-info)}
-              "build job"] " to understand why this build failed and reach out if you aren't
+                                            "build job"] " to understand why this build failed and reach out if you aren't
               sure how to fix the issue."])
            #_[:p (cljdoc-link build-info true)]))
 
@@ -192,8 +192,8 @@
 
         ;; [:p [:code [:pre (with-out-str (clojure.pprint/pprint build-info))]]] ;DEBUG
         [:p.lh-copy.dark-gray "Having trouble? Please reach out via "
-        [:a.link.blue {:href
-        "https://clojurians.slack.com/messages/C8V0BQ0M6/"} "Slack"] "
+         [:a.link.blue {:href
+                        "https://clojurians.slack.com/messages/C8V0BQ0M6/"} "Slack"] "
         or " [:a.link.blue {:href (util/github-url :issues)} "open an
         issue on GitHub"] ". Thanks!"]]
 
@@ -295,4 +295,4 @@
                    (map build-aggregates)
                    (build-analytics))])
 
-   (layout/page {:title "cljdoc builds"})))
+       (layout/page {:title "cljdoc builds"})))

--- a/src/cljdoc/render/error.clj
+++ b/src/cljdoc/render/error.clj
@@ -4,7 +4,6 @@
             [cljdoc.render.home :as home]
             [cljdoc.render.search :as search]))
 
-
 (defn not-found-404 []
   (->> [:div.pt4
         [:div.mt5-ns.mt6-l.mw7.center.pa4.pa0-l

--- a/src/cljdoc/render/index_pages.clj
+++ b/src/cljdoc/render/index_pages.clj
@@ -109,7 +109,7 @@
            [:h1.mt5 "All documented artifacts on cljdoc:"]
            (for [[group-id versions-for-group] (sort-by key (group-by :group-id versions))]
              [:div.cf
-              [:h2 group-id [:span.gray.fw3.ml3.f5 "Group ID"] ]
+              [:h2 group-id [:span.gray.fw3.ml3.f5 "Group ID"]]
               [:div.nl2.nr2
                (for [[a-id versions-for-artifact] (group-by :artifact-id versions-for-group)
                      :let [latest (first (sort-by-version versions-for-artifact))]]

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -11,7 +11,7 @@
 (defn highlight-js-customization []
   [:script
    (hiccup/raw
-     "hljs.registerLanguage('cljs', function (hljs) { return hljs.getLanguage('clj') });
+    "hljs.registerLanguage('cljs', function (hljs) { return hljs.getLanguage('clj') });
       hljs.initHighlightingOnLoad();")])
 
 (defn highlight-js []
@@ -84,8 +84,8 @@
 
                  [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
                  (hiccup.page/include-css
-                   "https://unpkg.com/tachyons@4.9.0/css/tachyons.min.css"
-                   "/cljdoc.css")]
+                  "https://unpkg.com/tachyons@4.9.0/css/tachyons.min.css"
+                  "/cljdoc.css")]
                 [:body
                  [:div.sans-serif
                   contents]

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -137,16 +137,15 @@
         scm-info     (-> cache-bundle :version :scm)
         flat-doctree (-> doc-tree doctree/flatten*)
         uri-map (->> flat-doctree
-                       (map (fn [d]
-                              [(-> d :attrs :cljdoc.doc/source-file)
-                               (article-url (-> d :attrs :slug-path))]))
-                       (into {}))
+                     (map (fn [d]
+                            [(-> d :attrs :cljdoc.doc/source-file)
+                             (article-url (-> d :attrs :slug-path))]))
+                     (into {}))
         page'   (fn [type title contents]
                   (page {:version-entity version-entity
                          :scm-url (-> cache-bundle :version :scm :url)
                          type title}
                         contents))]
-
 
     (reduce
      into
@@ -215,7 +214,6 @@
                  (instance? hiccup.util.RawString v) (.getBytes (str v))
                  :else (throw (Exception. (str "Unsupported value " (class v)))))]))
        (fs-compression/zip "offline-docs.zip"))
-
 
   (slurp (URL. "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/highlight.min.js"))
 

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -29,7 +29,6 @@
       (extensions md-extensions)
       (build)))
 
-
 (defn- md-renderer
   "Create a Markdown renderer."
   [{:keys [escape-html?
@@ -42,34 +41,34 @@
       (escapeHtml (boolean escape-html?))
       ;; Resolve wikilinks
       (linkResolverFactory
-        (reify LinkResolverFactory
-          (getAfterDependents [_this] nil)
-          (getBeforeDependents [_this] nil)
-          (affectsGlobalScope [_this] false)
-          (^LinkResolver create [_this ^LinkResolverContext _ctx]
-            (reify LinkResolver
-              (resolveLink [_this _node _ctx link]
-                (if (= (.getLinkType link) WikiLinkExtension/WIKI_LINK)
-                  (ResolvedLink. LinkType/LINK
-                                 ((or render-wiki-link identity) (.getUrl link))
-                                 nil
-                                 LinkStatus/UNCHECKED)
-                  link))))))
+       (reify LinkResolverFactory
+         (getAfterDependents [_this] nil)
+         (getBeforeDependents [_this] nil)
+         (affectsGlobalScope [_this] false)
+         (^LinkResolver create [_this ^LinkResolverContext _ctx]
+           (reify LinkResolver
+             (resolveLink [_this _node _ctx link]
+               (if (= (.getLinkType link) WikiLinkExtension/WIKI_LINK)
+                 (ResolvedLink. LinkType/LINK
+                                ((or render-wiki-link identity) (.getUrl link))
+                                nil
+                                LinkStatus/UNCHECKED)
+                 link))))))
       ;; Wrap wikilinks content in <code>
       (nodeRendererFactory
        (reify DelegatingNodeRendererFactory
          (getDelegates [_this]
            #{WikiLinkNodeRenderer$Factory})
          (create [_this _options]
-          (reify NodeRenderer
-            (getNodeRenderingHandlers [_this]
-              #{(NodeRenderingHandler.
-                 WikiLink
-                 (reify CustomNodeRenderer
-                   (render [_this node ctx html]
-                     (let [resolved-link (.resolveLink ctx WikiLinkExtension/WIKI_LINK (.. node getLink unescape) nil)
-                           url (.getUrl resolved-link)]
-                       (.raw html (str "<a href=\"" url "\"><code>" (.. node getLink) "</code></a>"))))))})))))
+           (reify NodeRenderer
+             (getNodeRenderingHandlers [_this]
+               #{(NodeRenderingHandler.
+                  WikiLink
+                  (reify CustomNodeRenderer
+                    (render [_this node ctx html]
+                      (let [resolved-link (.resolveLink ctx WikiLinkExtension/WIKI_LINK (.. node getLink unescape) nil)
+                            url (.getUrl resolved-link)]
+                        (.raw html (str "<a href=\"" url "\"><code>" (.. node getLink) "</code></a>"))))))})))))
       (extensions md-extensions)
       (build)))
 
@@ -107,7 +106,5 @@
   (markdown-to-html "*hello world* [[link]]" {:escape-html? true
                                               :render-wiki-link (constantly "???")})
 
-  (asciidoc-to-html "ifdef::env-cljdoc[]\nCLJDOC\nendif::[]\nifndef::env-cljdoc[]\nNOT_CLJDOC\nendif::[]")
-
-  )
+  (asciidoc-to-html "ifdef::env-cljdoc[]\nCLJDOC\nendif::[]\nifndef::env-cljdoc[]\nNOT_CLJDOC\nendif::[]"))
 

--- a/src/cljdoc/render/search.clj
+++ b/src/cljdoc/render/search.clj
@@ -11,7 +11,6 @@
      [:a.link {:href "https://github.com/cljdoc/cljdoc/issues/308"} "search improvements issue"]
      " to help us make it better!"]]))
 
-
 (defn search-page [context]
   (->> [:div
         (layout/top-bar-generic)

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -76,8 +76,9 @@
         [:p.f7.gray.lh-title
          [:a.blue.link {:href (util/github-url :userguide/articles)} "Articles"]
          " are a practical way to provide additional guidance beyond
-       API documentation. Please refer to " [:a.blue.link {:href (util/github-url
-                                                                  :userguide/articles)} "the documentation"] " to learn more about using them."]]
+       API documentation. Please refer to "
+         [:a.blue.link {:href (util/github-url :userguide/articles)} "the documentation"]
+         " to learn more about using them."]]
 
        ;; no articles at all -> list common problems + link to docs
        :else
@@ -85,8 +86,10 @@
         [:p.f7.gray.lh-title
          "We couldn't find a Readme or any other articles for this project. This happens when
          we could not find the Git repository for a project or there are no articles present in
-         a format that cljdoc supports. " [:strong "Please consult the " [:a.blue.link {:href
-                                                                                        (util/github-url :userguide/articles)} "cljdoc docs"] " on how to fix this."]]])
+         a format that cljdoc supports. "
+         [:strong "Please consult the "
+          [:a.blue.link {:href (util/github-url :userguide/articles)} "cljdoc docs"]
+          " on how to fix this."]]])
 
      ;; Namespace listing
      (let [ns-entities (bundle/ns-entities cache-bundle)]

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -77,7 +77,7 @@
          [:a.blue.link {:href (util/github-url :userguide/articles)} "Articles"]
          " are a practical way to provide additional guidance beyond
        API documentation. Please refer to " [:a.blue.link {:href (util/github-url
-       :userguide/articles)} "the documentation"] " to learn more about using them."]]
+                                                                  :userguide/articles)} "the documentation"] " to learn more about using them."]]
 
        ;; no articles at all -> list common problems + link to docs
        :else
@@ -86,7 +86,7 @@
          "We couldn't find a Readme or any other articles for this project. This happens when
          we could not find the Git repository for a project or there are no articles present in
          a format that cljdoc supports. " [:strong "Please consult the " [:a.blue.link {:href
-         (util/github-url :userguide/articles)} "cljdoc docs"] " on how to fix this."]]])
+                                                                                        (util/github-url :userguide/articles)} "cljdoc docs"] " on how to fix this."]]])
 
      ;; Namespace listing
      (let [ns-entities (bundle/ns-entities cache-bundle)]

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -87,6 +87,4 @@
         :analysis-service (:cljdoc/analysis-service integrant.repl.state/system)
         :build-tracker (:cljdoc/build-tracker integrant.repl.state/system)}
        {:project "bidi" :version "2.1.3"})
-      :job deref)
-
-  )
+      :job deref))

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -106,7 +106,6 @@
                               "limit 1")
                          group-id artifact-id version]))))
 
-
 (defn api-import-successful? [build]
   (and (:api_imported_ts build)
        (nil? (:error build))))
@@ -151,9 +150,7 @@
 
   (analysis-requested! bt "bidi" "bidi" "2.1.3")
 
-  (track-analysis-kick-off! db 2 "xxx")
-
-  )
+  (track-analysis-kick-off! db 2 "xxx"))
 
 
 ;; insert into builds (group_id, artifact_id, version, analysis_triggered_ts) values ('xxx', 'aaa', '1.0.0', datetime('now'));

--- a/src/cljdoc/server/clojars_stats.clj
+++ b/src/cljdoc/server/clojars_stats.clj
@@ -93,6 +93,4 @@
   (tt/cancel! (::poll-job clojars-stats))
   (tt/cancel! (::clean-job clojars-stats)))
 
-(comment
-
-  )
+(comment)

--- a/src/cljdoc/server/ingest.clj
+++ b/src/cljdoc/server/ingest.clj
@@ -70,6 +70,4 @@
       (pom/parse)
       (pom/artifact-info))
 
-  (ingest-cljdoc-edn (io/file "data") edn)
-
-  )
+  (ingest-cljdoc-edn (io/file "data") edn))

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -152,8 +152,8 @@
                   group-id        (or group-id (util/group-id project))
                   current?        (= "CURRENT" version)
                   referer-version (some-> request
-                                           (get-in [:headers "referer"])
-                                           util/uri-path routes/match-route :path-params :version)
+                                          (get-in [:headers "referer"])
+                                          util/uri-path routes/match-route :path-params :version)
                   artifact-entity {:artifact-id artifact-id
                                    :group-id group-id
                                    :version (cond

--- a/src/cljdoc/server/release_monitor.clj
+++ b/src/cljdoc/server/release_monitor.clj
@@ -69,15 +69,15 @@
         ;; wants to check that his new release appeared on Cljdoc; we will re-fetch
         ;; all Clojars artifact at the next scheduled period, when we will also get
         ;; past versions and description
-        #(sc/index-artifact
-           searcher
-           {:artifact-id (:artifact_id %)
-            :group-id (:group_id %)
+       #(sc/index-artifact
+         searcher
+         {:artifact-id (:artifact_id %)
+          :group-id (:group_id %)
             ;; NOTE: Ideally we would include also the old versions;
             ;; but they will be re-added once the full re-import runs anyway
-            :origin :clojars
-            :versions [(:version %)]})
-        releases))))
+          :origin :clojars
+          :versions [(:version %)]})
+       releases))))
 
 (defn build-queuer-job-fn [db-spec dry-run?]
   (when-let [to-build (oldest-not-built db-spec)]

--- a/src/cljdoc/server/search/api.clj
+++ b/src/cljdoc/server/search/api.clj
@@ -38,12 +38,12 @@
    6. Include '-raw' fields for group, artifact so that we can boost exact matches.
   "
   (:require
-    [cljdoc.server.search.search :as search]
-    [cljdoc.server.search.artifact-indexer :as indexer]
-    [tea-time.core :as tt]
-    [clojure.spec.alpha :as s]
-    [clojure.tools.logging :as log]
-    [integrant.core :as ig])
+   [cljdoc.server.search.search :as search]
+   [cljdoc.server.search.artifact-indexer :as indexer]
+   [tea-time.core :as tt]
+   [clojure.spec.alpha :as s]
+   [clojure.tools.logging :as log]
+   [integrant.core :as ig])
   (:import (java.util.concurrent TimeUnit)))
 
 (defprotocol ISearcher

--- a/src/cljdoc/server/search/search.clj
+++ b/src/cljdoc/server/search/search.clj
@@ -27,9 +27,9 @@
          attr                (.addAttribute stream org.apache.lucene.analysis.tokenattributes.CharTermAttribute)]
      (.reset stream)
      (take-while
-       identity
-       (repeatedly
-         #(when (.incrementToken stream) (str attr)))))))
+      identity
+      (repeatedly
+       #(when (.incrementToken stream) (str attr)))))))
 
 (def search-fields [:artifact-id :group-id :group-id-packages :description])
 
@@ -95,12 +95,12 @@
   [field token]
   (let [t (term field token)]
     (boolean-query
-      (TermQuery. t)
-      (BoostQuery.
-        (doto (PrefixQuery. t)
-          #_(.setRewriteMethod ScoringRewrite/SCORING_BOOLEAN_REWRITE))
+     (TermQuery. t)
+     (BoostQuery.
+      (doto (PrefixQuery. t)
+        #_(.setRewriteMethod ScoringRewrite/SCORING_BOOLEAN_REWRITE))
         ;; Give a prefix less weight than an exact match
-        0.5))))
+      0.5))))
 
 (defn single-token->query [field ^String token match-mode]
   (case match-mode
@@ -109,14 +109,14 @@
 
 (defn field-and-token->query [field token match-mode full-match-text]
   (-> (boolean-query
-        (single-token->query field token match-mode)
+       (single-token->query field token match-mode)
         ;; Add an exact-match query to boost exact matches of the
         ;; whole name so that "re-frame" -> "re-frame:re-frame" comes first
         ;; FIXME This works for group OR artifact-id but breaks for `group/artifact` (x group-id-packages search looks at just the group => use same tokenization? Or split manually at `/`?)
-        (when-let [raw-fld (and full-match-text (raw-field field))]
-          (TermQuery. (term raw-fld full-match-text))))
+       (when-let [raw-fld (and full-match-text (raw-field field))]
+         (TermQuery. (term raw-fld full-match-text))))
       (BoostQuery.
-        (get boosts field))))
+       (get boosts field))))
 
 (defn token->query
   "Create a Lucene Query from a tokenized search string.
@@ -126,8 +126,8 @@
   [token match-mode full-match-text]
   (->> search-fields
        (map
-         #(field-and-token->query
-            % token match-mode full-match-text))
+        #(field-and-token->query
+          % token match-mode full-match-text))
        (apply boolean-query)))
 
 (defn ^Query parse-query [^String query-text]
@@ -137,8 +137,8 @@
                          (take (count tokens))
                          reverse)]
     (->> (map
-           #(token->query %1 %2 (when multitoken? query-text))
-           tokens match-modes)
+          #(token->query %1 %2 (when multitoken? query-text))
+          tokens match-modes)
          (apply boolean-query BooleanClause$Occur/MUST))))
 
 (defn search->results
@@ -163,27 +163,27 @@
   [hits-cnt docs]
   {:count   hits-cnt
    :results (map
-              (fn [{:keys [^Document doc score]}]
-                {:artifact-id (.get doc "artifact-id")
-                 :group-id    (.get doc "group-id")
-                 :description (.get doc "description")
+             (fn [{:keys [^Document doc score]}]
+               {:artifact-id (.get doc "artifact-id")
+                :group-id    (.get doc "group-id")
+                :description (.get doc "description")
                  ;:origin (.get doc "origin")
                  ;; The first version appears to be the latest so this is OK:
-                 :version (.get doc "versions")
-                 :score       score})
-              docs)})
+                :version (.get doc "versions")
+                :score       score})
+             docs)})
 
 (defn search [^String index-dir ^String query-in]
   (search->results
-    index-dir query-in
-    #(format-results
-       (-> (:topdocs %) (.-totalHits) (.-value))
-       (doall
-         (map
-           (fn [^ScoreDoc h]
-             {:score (.score h)
-              :doc (.doc (:searcher %) (.-doc h))})
-           (:score-docs %))))))
+   index-dir query-in
+   #(format-results
+     (-> (:topdocs %) (.-totalHits) (.-value))
+     (doall
+      (map
+       (fn [^ScoreDoc h]
+         {:score (.score h)
+          :doc (.doc (:searcher %) (.-doc h))})
+       (:score-docs %))))))
 
 (defn suggest
   "Provides suggestions for auto-completing the search terms the user is typing.
@@ -196,15 +196,15 @@
   [index-dir query-in]
   (let [suggestions
         (search->results
-          index-dir query-in 5
-          #(->> (:score-docs %)
-                (mapv
-                  (fn [^ScoreDoc h]
-                    (let [doc (.doc (:searcher %) (.-doc h))]
-                      (str
-                        (.get doc "group-id")
-                        "/"
-                        (.get doc "artifact-id")))))))]
+         index-dir query-in 5
+         #(->> (:score-docs %)
+               (mapv
+                (fn [^ScoreDoc h]
+                  (let [doc (.doc (:searcher %) (.-doc h))]
+                    (str
+                     (.get doc "group-id")
+                     "/"
+                     (.get doc "artifact-id")))))))]
     [query-in suggestions]))
 
 (defn explain-top-n
@@ -214,13 +214,13 @@
   ([index-dir query-in] (explain-top-n 5 index-dir query-in))
   ([n index-dir query-in]
    (search->results
-     index-dir query-in
-     (fn [{:keys [searcher score-docs ^Query query]}]
-       (run!
-         #(println
-            (.get (.doc searcher (.-doc %)) "id")
-            (.explain searcher query (.-doc %)))
-         (take n score-docs))))))
+    index-dir query-in
+    (fn [{:keys [searcher score-docs ^Query query]}]
+      (run!
+       #(println
+         (.get (.doc searcher (.-doc %)) "id")
+         (.explain searcher query (.-doc %)))
+       (take n score-docs))))))
 
 (comment
 

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -39,29 +39,23 @@
   (routes/url-for :artifact/version :path-params {:group-id "a" :artifact-id "b" :version "c"})
 
   (def docs
-    (storage/all-distinct-docs db-spec)
-    )
+    (storage/all-distinct-docs db-spec))
 
   (query->url-entries (first docs))
 
   (sitemap/validate-sitemap
-   (build db-spec)
-   )
+   (build db-spec))
 
   (->>
    (sitemap/generate-sitemap [{:loc "http://example.com/about"
-                       :lastmod "2014-07-00"
-                       :changefreq "monthly"
-                       :priority "0.5"}])
-   (assert-valid-sitemap)
-  )
+                               :lastmod "2014-07-00"
+                               :changefreq "monthly"
+                               :priority "0.5"}])
+   (assert-valid-sitemap))
 
   (->>
    (sitemap/generate-sitemap [{:loc "http://example.com/about"
                                :lastmod "2014-07-24"
                                :changefreq "monthly"
                                :priority "0.5"}])
-   (assert-valid-sitemap)
-   )
-
-)
+   (assert-valid-sitemap)))

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -122,7 +122,6 @@
     (integrant.repl/set-prep! #(system-config (cfg/config)))
     (integrant.repl/go))
 
-
   (require '[integrant.repl]
            '[clojure.spec.test.alpha :as st])
 

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -113,7 +113,7 @@
 
 (defnp ^:private get-vars [db-spec namespaces-with-resolved-version-entities]
   (let [ns-idents (->> namespaces-with-resolved-version-entities
-                      (map (fn [ns] [(-> ns :version-entity :id) (:name ns)])))]
+                       (map (fn [ns] [(-> ns :version-entity :id) (:name ns)])))]
     (assert (seq ns-idents))
     (sql-get-vars db-spec {:ns-idents ns-idents}
                   {}
@@ -224,7 +224,7 @@
   (def data (clojure.edn/read-string (slurp "https://2941-119377591-gh.circle-artifacts.com/0/cljdoc-edn/stavka/stavka/0.4.1/cljdoc.edn")))
 
   (def db-spec
-   (cljdoc.config/db (cljdoc.config/config)))
+    (cljdoc.config/db (cljdoc.config/config)))
 
   (all-distinct-docs db-spec)
 
@@ -234,6 +234,4 @@
 
   (store-artifact! db-spec (:group-id data) (:artifact-id data) [(:version data)])
 
-  (get-version-id db-spec (:group-id data) (:artifact-id data) (:version data))
-
-  )
+  (get-version-id db-spec (:group-id data) (:artifact-id data) (:version data)))

--- a/src/cljdoc/user_config.clj
+++ b/src/cljdoc/user_config.clj
@@ -31,9 +31,6 @@
 (comment
   (def d
     '{metosin/reitit {:cljdoc.doc/tree [["Introduction" {:file "intro.md"}]]}
-     :cljdoc.doc/tree [["Overview" {:file "modules/README.md"}]]})
+      :cljdoc.doc/tree [["Overview" {:file "modules/README.md"}]]})
 
-  (get-project d "metosin/reitit")
-
-
-  )
+  (get-project d "metosin/reitit"))

--- a/src/cljdoc/util/datetime.clj
+++ b/src/cljdoc/util/datetime.clj
@@ -21,5 +21,4 @@
 (comment
 
   (day-suffix 21)
-  (->analytics-format "2018-10-17T20:58:21.491730Z")
-  )
+  (->analytics-format "2018-10-17T20:58:21.491730Z"))

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -114,6 +114,7 @@
 ;; Some utilities to find which file in a git repository corresponds
 ;; to a file where a `def` is coming from --------------------------
 
+
 (defn- find-full-filepath
   "Take a list of filepaths, one subpath and find the best matching full path.
 
@@ -146,7 +147,6 @@
 
   (println (Jsoup/parse hs))
 
-
   (fix fp hs fo)
 
   (rebase "doc/coercion/coercion.md" "../ring/coercion.md")
@@ -166,6 +166,4 @@
                     (.startsWith (.get % "src") "https://")))
        (map #(doto % (.put "src" (fix-image (.get % "src") fix-opts)))))
 
-  (.get (.attributes (first (.select doc "a"))) "href")
-
-  )
+  (.get (.attributes (first (.select doc "a"))) "href"))

--- a/src/cljdoc/util/scm.clj
+++ b/src/cljdoc/util/scm.clj
@@ -5,13 +5,13 @@
             [lambdaisland.uri :as uri]))
 
 (defn owner [scm-url]
-  (get (string/split (:path (uri/uri scm-url)) #"/" ) 1))
+  (get (string/split (:path (uri/uri scm-url)) #"/") 1))
 
 (defn repo [scm-url]
-  (get (string/split (:path (uri/uri scm-url)) #"/" ) 2))
+  (get (string/split (:path (uri/uri scm-url)) #"/") 2))
 
 (defn coordinate [scm-url]
-  (->> (string/split (:path (uri/uri scm-url)) #"/" )
+  (->> (string/split (:path (uri/uri scm-url)) #"/")
        (filter seq)
        (string/join "/")))
 

--- a/src/cljdoc/util/sentry.clj
+++ b/src/cljdoc/util/sentry.clj
@@ -35,8 +35,8 @@
 (defn capture [{:keys [req ex]}]
   (if (cfg/sentry-dsn)
     (let [payload (cond-> {:release (cfg/version)}
-                             ex  (interfaces/stacktrace ex app-namespaces)
-                             req (interfaces/http req identity))
+                    ex  (interfaces/stacktrace ex app-namespaces)
+                    req (interfaces/http req identity))
           sentry-response (raven/capture (cfg/sentry-dsn) payload)]
       (when-not (= 200 (:status sentry-response))
         (log/errorf "Failed to log error to Sentry %s %s"

--- a/src/cljdoc/util/sqlite_cache.clj
+++ b/src/cljdoc/util/sqlite_cache.clj
@@ -181,9 +181,7 @@
 
   (def memoized-artifact-uris
     (memo-sqlite cljdoc.util.repositories/artifact-uris
-                  db-artifact-uris))
+                 db-artifact-uris))
 
   (time (memoized-artifact-uris 'bidi "2.0.9-SNAPSHOT"))
-  (time (memoized-artifact-uris 'com.bhauman/spell-spec "0.1.0"))
-
-  )
+  (time (memoized-artifact-uris 'com.bhauman/spell-spec "0.1.0")))

--- a/src/cljdoc/util/telegram.clj
+++ b/src/cljdoc/util/telegram.clj
@@ -64,7 +64,5 @@
   ;; 10024 :sparkles:
   ;; 65039 :warning:
 
-  (.codePointAt "️" 0)
-
-  )
+  (.codePointAt "️" 0))
 

--- a/test/cljdoc/analysis/git_test.clj
+++ b/test/cljdoc/analysis/git_test.clj
@@ -10,6 +10,4 @@
              (-> analysis :scm :tag :commit)))))
 
 (comment
-  (t/run-tests)
-
-  )
+  (t/run-tests))

--- a/test/cljdoc/integration_test.clj
+++ b/test/cljdoc/integration_test.clj
@@ -87,7 +87,6 @@
         (str)
         (string/includes? "metosin/muuntaja: Clojure library for format encoding, decoding and content-negotiation Documentation for metosin/muuntaja v0.6.4 on cljdoc.")))))
 
-
 (comment
   (def s (ig/init (sys/system-config (test-config))))
 
@@ -95,6 +94,4 @@
 
   (t/run-tests)
 
-  (ig/halt! @sys)
-
-  )
+  (ig/halt! @sys))

--- a/test/cljdoc/migration_test.clj
+++ b/test/cljdoc/migration_test.clj
@@ -6,25 +6,23 @@
 
 (t/deftest migration-names-test
   (let [names (reduce
-                (fn [names file]
-                  (let [base (fs/base-name (.getPath file))]
-                    (update names (first (str/split base #"-")) (fnil conj #{}) base)))
-                {}
-                (fs/list-dir (io/resource "migrations")))]
+               (fn [names file]
+                 (let [base (fs/base-name (.getPath file))]
+                   (update names (first (str/split base #"-")) (fnil conj #{}) base)))
+               {}
+               (fs/list-dir (io/resource "migrations")))]
     (t/is (every?
-            true?
-            (map-indexed
-              (fn [i prefix]
-                (let [base (-> prefix
-                               names
-                               first
-                               (str/replace #"\.(up|down)\.sql$" ""))
-                      expected-names (set (map #(str base "." % ".sql") ["up" "down"]))]
-                  (and (= (inc i) (try (Long/parseLong prefix) (catch Exception e)))
-                       (= (names prefix) expected-names))))
-              (sort (keys names)))))))
+           true?
+           (map-indexed
+            (fn [i prefix]
+              (let [base (-> prefix
+                             names
+                             first
+                             (str/replace #"\.(up|down)\.sql$" ""))
+                    expected-names (set (map #(str base "." % ".sql") ["up" "down"]))]
+                (and (= (inc i) (try (Long/parseLong prefix) (catch Exception e)))
+                     (= (names prefix) expected-names))))
+            (sort (keys names)))))))
 
 (comment
-  (t/run-tests)
-
-  )
+  (t/run-tests))

--- a/test/cljdoc/util_test.clj
+++ b/test/cljdoc/util_test.clj
@@ -25,7 +25,7 @@
             :jar "https://repo.clojars.org/bidi/bidi/2.0.9-SNAPSHOT/bidi-2.0.9-20160426.224252-1.jar"})))
 
 (t/deftest latest-release-test
-  (t/is (= "0.0.4" (repositories/latest-release-version 'org/clojure/math.numeric-tower))))
+  (t/is (= "0.0.4" (repositories/latest-release-version "org/clojure/math.numeric-tower"))))
 
 (t/deftest normalize-git-url-test
   (t/is (= (util/normalize-git-url "git@github.com:clojure/clojure.git")
@@ -46,17 +46,16 @@
                                                                        "/doc/basics/route-syntax/even-more")))
   (t/is (= "walk-through/asd" (util/relativize-path "/doc/introduction" "/doc/introduction/walk-through/asd")))
   (t/is (= "../.." (util/relativize-path "/doc/introduction/walk-through/asd" "/doc/introduction")))
-  (t/is (= ".." (util/relativize-path "/doc/introduction/walk-through" "/doc/introduction")))
-  )
+  (t/is (= ".." (util/relativize-path "/doc/introduction/walk-through" "/doc/introduction"))))
 (t/deftest replant-ns-test
   (t/is (= "my.app.routes" (util/replant-ns "my.app.core" "routes")))
   (t/is (= "my.app.api.routes" (util/replant-ns "my.app.core" "api.routes")))
   (t/is (= "my.app.api.handlers" (util/replant-ns "my.app.core" "my.app.api.handlers"))))
 
 (t/deftest serialize-read-cljdoc-edn
-    (t/is (= "{:or #regex \"^Test*\"}" (util/serialize-cljdoc-edn {:or #"^Test*"})))
+  (t/is (= "{:or #regex \"^Test*\"}" (util/serialize-cljdoc-edn {:or #"^Test*"})))
     ;; we need to compare the resulting string as two regex are equal (= #"" #"") => false
-    (t/is (= (str {:or #"^Test*"}) (str (util/read-cljdoc-edn (StringReader. "{:or #regex \"^Test*\"}"))))))
+  (t/is (= (str {:or #"^Test*"}) (str (util/read-cljdoc-edn (StringReader. "{:or #regex \"^Test*\"}"))))))
 
 (t/deftest day-suffix-test
   (t/is (= "st" (dt/day-suffix 1)))
@@ -67,8 +66,5 @@
 (t/deftest analytics-format-test
   (t/is (= "Wed, Oct 17th" (dt/->analytics-format "2018-10-17T20:58:21.491730Z"))))
 
-
 (comment
-  (t/run-tests)
-
-  )
+  (t/run-tests))


### PR DESCRIPTION
Adds new `script/code-format.sh` that uses cljfmt to check for code format violations in cljdoc code base. This script is used in the circleci build to fail the build on any violations. It is also intended to be used by developers with the `check` command to verify and the `fix` command to reformat.

The only formatting that might surprise folks, is lack of 2-space indentation in some cases.  Please review the commit diffs in this PR to get a feel for this.  Personally, I've no problem with this, but these things are subjective.

I recommend we give this a go and respond to developer feedback and adjust as necessary.