### PR TITLE
add clj-kondo linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
 
       - run: clojure -Spath
 
+      - run: ./script/lint.sh
+
       - run: ./script/cljdoc ingest --project bidi --version 2.1.3
       - run: ./.circleci/run_if_changed.sh modules/analysis-runner/ "cd modules/analysis-runner/; clojure extended-test.clj"
 

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,7 @@
+{ ;; there's a fair bit of old test code in comment blocks that does not lint, skip it for now
+ :skip-comments true
+ :linters {;; I don't personally see a problem with using (not (empty? x)) instead of (seq x)
+           :not-empty? false}
+ :lint-as {taoensso.tufte/defnp clojure.core/defn
+           clojure.core.cache/defcache clojure.core/defrecord
+           clojure.java.jdbc/with-db-transaction clojure.core/let}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,7 +1,6 @@
 { ;; there's a fair bit of old test code in comment blocks that does not lint, skip it for now
  :skip-comments true
- :linters {;; I don't personally see a problem with using (not (empty? x)) instead of (seq x)
-           :not-empty? false}
  :lint-as {taoensso.tufte/defnp clojure.core/defn
            clojure.core.cache/defcache clojure.core/defrecord
-           clojure.java.jdbc/with-db-transaction clojure.core/let}}
+           clojure.java.jdbc/with-db-transaction clojure.core/let}
+ :output {:include-files ["^src" "^test" "^modules"]}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -3,4 +3,5 @@
  :lint-as {taoensso.tufte/defnp clojure.core/defn
            clojure.core.cache/defcache clojure.core/defrecord
            clojure.java.jdbc/with-db-transaction clojure.core/let}
+ :linters {:unused-binding {:exclude-destructured-keys-in-fn-args true}}
  :output {:include-files ["^src" "^test" "^modules"]}}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ project.clj
 .cpcache
 .DS_Store
 .cache
+.clj-kondo/.cache
 node_modules
 .envrc
 resources-compiled

--- a/deps.edn
+++ b/deps.edn
@@ -61,7 +61,7 @@
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo {:mvn/version "2019.07.24-alpha"}}
+           {:extra-deps {clj-kondo {:mvn/version "2019.07.31-alpha"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :cli

--- a/deps.edn
+++ b/deps.edn
@@ -60,6 +60,10 @@
             :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-529"}}
             :main-opts ["-m" "kaocha.runner"]}
 
+           :clj-kondo
+           {:extra-deps {clj-kondo {:mvn/version "2019.07.24-alpha"}}
+            :main-opts ["-m" "clj-kondo.main"]}
+
            :cli
            {:extra-paths ["modules/cli/src"]
             :extra-deps {cli-matic {:mvn/version "0.3.8"}}

--- a/modules/analysis-runner/src/cljdoc/analysis/deps.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/deps.clj
@@ -1,6 +1,5 @@
 (ns cljdoc.analysis.deps
-  (:require [clojure.java.io :as io]
-            [version-clj.core :as v]
+  (:require [version-clj.core :as v]
             [cljdoc.util :as util]
             [cljdoc.util.pom :as pom]
             [clojure.tools.deps.alpha :as tdeps]))

--- a/modules/analysis-runner/src/cljdoc/analysis/deps.clj
+++ b/modules/analysis-runner/src/cljdoc/analysis/deps.clj
@@ -96,7 +96,7 @@
   Jsoup document `pom`."
   [pom]
   {:pre [(pom/jsoup? pom)]}
-  (let [{:keys [group-id artifact-id version]} (pom/artifact-info pom)
+  (let [{:keys [group-id artifact-id]} (pom/artifact-info pom)
         project (symbol group-id artifact-id)]
     (-> (extra-deps pom)
         (merge (clj-cljs-deps pom))

--- a/modules/cli/src/cljdoc/cli.clj
+++ b/modules/cli/src/cljdoc/cli.clj
@@ -26,7 +26,7 @@
        (-> (merge (repositories/local-uris project version) args)
            (cset/rename-keys {:git :scm-url, :rev :scm-rev})))))))
 
-(defn offline-bundle [{:keys [project version output] :as args}]
+(defn offline-bundle [{:keys [project version output] :as _args}]
   (let [sys           (select-keys (system/system-config (config/config))
                                    [:cljdoc/storage :cljdoc/sqlite])
         sys           (ig/init sys)

--- a/modules/cli/src/cljdoc/cli.clj
+++ b/modules/cli/src/cljdoc/cli.clj
@@ -41,7 +41,7 @@
         (log/fatalf "%s@%s could not be found in storage" project version)
         (System/exit 1)))))
 
-(defn run [opts]
+(defn run [_opts]
   (system/-main))
 
 (def CONFIGURATION
@@ -82,5 +82,3 @@
 (defn -main
   [& args]
   (cli-matic/run-cmd args CONFIGURATION))
-
-

--- a/modules/deploy/src/cljdoc/deploy.clj
+++ b/modules/deploy/src/cljdoc/deploy.clj
@@ -14,7 +14,6 @@
             [clojure.pprint :as pp]
             [clojure.java.shell :as sh]
             [clojure.string :as string]
-            [clojure.edn :as edn]
             [clj-http.client :as http]
             [cheshire.core :as json]
             [clojure.tools.logging :as log]
@@ -58,17 +57,17 @@
   (str "http://localhost:8500" path))
 
 (defmethod aero/reader 'nomad/seconds
-  [_ tag value]
+  [_ _tag value]
   (* value 1000000000))
 
 (defmethod aero/reader 'env!
-  [_ tag envvar]
+  [_ _tag envvar]
   (if-some [v (System/getenv (str envvar))]
     v
     (throw (Exception. (format "Could not find env var for %s" envvar)))))
 
 (defmethod aero/reader `opt
-  [{::keys [opts]} tag value]
+  [{::keys [opts]} _tag value]
   (or (get opts value)
       (throw (ex-info (str "Could not find deploy opt for " value)
                       {:opts opts}))))

--- a/modules/shared-utils/src/cljdoc/spec.cljc
+++ b/modules/shared-utils/src/cljdoc/spec.cljc
@@ -174,7 +174,7 @@
 (defn assert [spec v]
   (if (s/get-spec spec)
     (s/assert spec v)
-    (throw (Exception. (format "No spec found for %s" spec)))))
+    (throw (Exception. (str "No spec found for " spec)))))
 
 (comment
   (require '[clojure.spec.gen.alpha :as gen])
@@ -208,5 +208,3 @@
              :type :var}]})
 
   (s/valid? ::namespace x))
-
-

--- a/modules/shared-utils/src/cljdoc/util.clj
+++ b/modules/shared-utils/src/cljdoc/util.clj
@@ -69,7 +69,7 @@
 (defn git-dir [project version]
   (str "git-repos/" (group-id project) "/" (artifact-id project) "/" version "/"))
 
-(defn clojars-id [{:keys [group-id artifact-id] :as artifact-entity}]
+(defn clojars-id [{:keys [group-id artifact-id] :as _artifact-entity}]
   (if (= group-id artifact-id)
     artifact-id
     (str group-id "/" artifact-id)))

--- a/script/lint.sh
+++ b/script/lint.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
 #
-# Temporary lint script
 # We can turf this script (or at least get more raw) when either of the following is true:
 # 1) We decide to stop employing unused destructured keys as documentation
 # 2) clj-kondo supports ignoring this specific use of unused bindings
 #
+# Reasonable shortcut:
+# cljdocs has a few small sub-projects under modules, we could lint those separately but
+# instead we are linting all cljdoc source at once.
 
 set -eou pipefail
 
@@ -30,9 +32,20 @@ function is_unused_destructured_key_warning() {
 
 function lint() {
     local out_file=$1
-    shift
+    local lint_args
+    if [ ! -d .clj-kondo/.cache ]; then
+        echo "--[linting and building cache]--"
+        # classpath with tests paths
+        local classpath="$(clojure -R:test -C:test -Spath)"
+        # include modules - but exclude shared-utils as it is already included in deps.edn
+        local modules_paths=$(find modules -name "*" -depth 1 | grep -v "shared-utils")
+        lint_args="$classpath $modules_paths --cache"
+    else
+        echo "--[linting]--"
+        lint_args="src test modules"
+    fi
     set +e
-    clojure -A:clj-kondo --lint $@ &> ${out_file}
+    clojure -A:clj-kondo --lint ${lint_args} &> ${out_file}
     local exit_code=$?
     set -e
     if [ ${exit_code} -ne 0 ] && [ ${exit_code} -ne 2 ] && [ ${exit_code} -ne 3 ]; then
@@ -43,23 +56,15 @@ function lint() {
 }
 
 SCRATCH_DIR=$(mktemp -d -t clj-kondo.out.XXXXXXXXXX)
-
 function cleanup() {
     rm -rf $SCRATCH_DIR
 }
-
 trap cleanup EXIT
 
 EXIT_CODE=0
 SUPPRESSED_COUNT=0
 
-if [ ! -d .clj-kondo/.cache ]; then
-    echo "--[initializing clj-kondo cache]--"
-    lint $SCRATCH_DIR/cache.out $(clojure -Spath) --cache
-fi
-
-echo "--[linting]--"
-lint $SCRATCH_DIR/lint.out src test modules
+lint $SCRATCH_DIR/lint.out
 while read lint_line; do
     if [[ $lint_line =~ ^linting[[:space:]]took ]]; then
         echo $lint_line

--- a/script/lint.sh
+++ b/script/lint.sh
@@ -1,37 +1,12 @@
 #!/usr/bin/env bash
 
-#
-# We can turf this script (or at least get more raw) when either of the following is true:
-# 1) We decide to stop employing unused destructured keys as documentation
-# 2) clj-kondo supports ignoring this specific use of unused bindings
-#
 # Reasonable shortcut:
 # cljdocs has a few small sub-projects under modules, we could lint those separately but
 # instead we are linting all cljdoc source at once.
 
 set -eou pipefail
 
-function line_at() {
-    local filename=$1
-    local line_num=$2
-    cat ${filename} | head -${line_num} | tail -1
-}
-
-function is_unused_destructured_key_warning() {
-    local lint_line=$@
-    local result="false"
-    IFS=: read filename line_num col_num level msg <<< ${lint_line}
-    if [[ ${level} =~ [[:space:]]*warning ]] && [[ ${msg} =~ [[:space:]]*unused[[:space:]]binding ]]; then
-        local file_line=$(line_at $filename $line_num)
-        if [[ ${file_line} =~ :keys ]]; then
-            result="true"
-        fi
-    fi
-    echo $result
-}
-
 function lint() {
-    local out_file=$1
     local lint_args
     if [ ! -d .clj-kondo/.cache ]; then
         echo "--[linting and building cache]--"
@@ -45,39 +20,13 @@ function lint() {
         lint_args="src test modules"
     fi
     set +e
-    clojure -A:clj-kondo --lint ${lint_args} &> ${out_file}
+    clojure -A:clj-kondo --lint ${lint_args}
     local exit_code=$?
     set -e
     if [ ${exit_code} -ne 0 ] && [ ${exit_code} -ne 2 ] && [ ${exit_code} -ne 3 ]; then
-        cat ${out_file}
         echo "** clj-kondo exited with unexpected exit code: ${exit_code}"
-        exit ${exit_code}
     fi
+    exit ${exit_code}
 }
 
-SCRATCH_DIR=$(mktemp -d -t clj-kondo.out.XXXXXXXXXX)
-function cleanup() {
-    rm -rf $SCRATCH_DIR
-}
-trap cleanup EXIT
-
-EXIT_CODE=0
-SUPPRESSED_COUNT=0
-
-lint $SCRATCH_DIR/lint.out
-while read lint_line; do
-    if [[ $lint_line =~ ^linting[[:space:]]took ]]; then
-        echo $lint_line
-    elif  [ "$(is_unused_destructured_key_warning ${lint_line})" == "true" ]; then
-        SUPPRESSED_COUNT=$((SUPPRESSED_COUNT+1))
-    else
-        EXIT_CODE=1
-        echo $lint_line
-    fi
-done < $SCRATCH_DIR/lint.out
-
-if [ ${SUPPRESSED_COUNT} -gt 0 ]; then
-    echo "(suppressed ${SUPPRESSED_COUNT} unused descructured key warnings)"
-fi
-
-exit ${EXIT_CODE}
+lint

--- a/script/lint.sh
+++ b/script/lint.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+#
+# Temporary lint script
+# We can turf this script (or at least get more raw) when either of the following is true:
+# 1) We decide to stop employing unused destructured keys as documentation
+# 2) clj-kondo supports ignoring this specific use of unused bindings
+#
+
+set -eou pipefail
+
+function line_at() {
+    local filename=$1
+    local line_num=$2
+    cat ${filename} | head -${line_num} | tail -1
+}
+
+function is_unused_destructured_key_warning() {
+    local lint_line=$@
+    local result="false"
+    IFS=: read filename line_num col_num level msg <<< ${lint_line}
+    if [[ ${level} =~ [[:space:]]*warning ]] && [[ ${msg} =~ [[:space:]]*unused[[:space:]]binding ]]; then
+        local file_line=$(line_at $filename $line_num)
+        if [[ ${file_line} =~ :keys ]]; then
+            result="true"
+        fi
+    fi
+    echo $result
+}
+
+function lint() {
+    local out_file=$1
+    shift
+    set +e
+    clojure -A:clj-kondo --lint $@ &> ${out_file}
+    local exit_code=$?
+    set -e
+    if [ ${exit_code} -ne 0 ] && [ ${exit_code} -ne 2 ] && [ ${exit_code} -ne 3 ]; then
+        cat ${out_file}
+        echo "** clj-kondo exited with unexpected exit code: ${exit_code}"
+        exit ${exit_code}
+    fi
+}
+
+SCRATCH_DIR=$(mktemp -d -t clj-kondo.out.XXXXXXXXXX)
+
+function cleanup() {
+    rm -rf $SCRATCH_DIR
+}
+
+trap cleanup EXIT
+
+EXIT_CODE=0
+SUPPRESSED_COUNT=0
+
+if [ ! -d .clj-kondo/.cache ]; then
+    echo "--[initializing clj-kondo cache]--"
+    lint $SCRATCH_DIR/cache.out $(clojure -Spath) --cache
+fi
+
+echo "--[linting]--"
+lint $SCRATCH_DIR/lint.out src test modules
+while read lint_line; do
+    if [[ $lint_line =~ ^linting[[:space:]]took ]]; then
+        echo $lint_line
+    elif  [ "$(is_unused_destructured_key_warning ${lint_line})" == "true" ]; then
+        SUPPRESSED_COUNT=$((SUPPRESSED_COUNT+1))
+    else
+        EXIT_CODE=1
+        echo $lint_line
+    fi
+done < $SCRATCH_DIR/lint.out
+
+if [ ${SUPPRESSED_COUNT} -gt 0 ]; then
+    echo "(suppressed ${SUPPRESSED_COUNT} unused descructured key warnings)"
+fi
+
+exit ${EXIT_CODE}

--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -1,7 +1,6 @@
 (ns cljdoc.analysis.service
   (:require [clj-http.lite.client :as http]
             [clojure.tools.logging :as log]
-            [clojure.string :as string]
             [clojure.java.io :as io]
             [clojure.java.shell :as sh]
             [cheshire.core :as json]
@@ -64,16 +63,16 @@
     (assert (integer? build-num))
     (let [done-build (poll-circle-ci-build this build-num)
           success?   (contains? #{"success" "fixed"} (get done-build "status"))
-          cljdoc-edn (cljdoc.util/cljdoc-edn project version)]
-      (let [artifacts (-> (get-circle-ci-build-artifacts this build-num)
-                          :body json/parse-string)]
+          cljdoc-edn (cljdoc.util/cljdoc-edn project version)
+          artifacts (-> (get-circle-ci-build-artifacts this build-num)
+                        :body json/parse-string)]
         (if-let [artifact (and success?
                                (= 1 (count artifacts))
                                (= cljdoc-edn (get (first artifacts) "path"))
                                (first artifacts))]
           {:analysis-result (get artifact "url")}
           (throw (ex-info "Analysis on CircleCI failed"
-                          {:service :circle-ci, :build done-build})))))))
+                          {:service :circle-ci, :build done-build}))))))
 
 (defn circle-ci
   [{:keys [api-token builder-project analyzer-version] :as args}]

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -5,7 +5,7 @@
             [aero.core :as aero]))
 
 (defmethod aero/reader 'slurp
-  [_ tag value]
+  [_ _tag value]
   (aero/deferred
     (try (.trim (slurp (io/resource value)))
          (catch Exception e
@@ -121,5 +121,3 @@
 
   (clojure.pprint/pprint
    (aero/read-config (io/resource "config.edn") {:profile :default})))
-
-

--- a/src/cljdoc/doc_tree.clj
+++ b/src/cljdoc/doc_tree.clj
@@ -86,8 +86,7 @@
   ;; Otherwise the line below will throw an exception (intentionally so)
   (let [entry-type (some-> attrs :file filepath->type)
         file (-> attrs :file)
-        ;; TODO: Something is amiss here, slurp! is not used!
-        _slurp! (fn [file] (or (slurp-fn file)
+        slurp! (fn [file] (or (slurp-fn file)
                               (throw (Exception. (format "Could not read contents of %s" file)))))]
     (cond-> {:title title}
 
@@ -95,7 +94,7 @@
       (assoc-in [:attrs :cljdoc.doc/source-file] (:file attrs))
 
       entry-type
-      (assoc-in [:attrs entry-type] (slurp-fn (:file attrs)))
+      (assoc-in [:attrs entry-type] (slurp! (:file attrs)))
 
       entry-type
       (assoc-in [:attrs :cljdoc.doc/type] entry-type)

--- a/src/cljdoc/doc_tree.clj
+++ b/src/cljdoc/doc_tree.clj
@@ -86,7 +86,8 @@
   ;; Otherwise the line below will throw an exception (intentionally so)
   (let [entry-type (some-> attrs :file filepath->type)
         file (-> attrs :file)
-        slurp! (fn [file] (or (slurp-fn file)
+        ;; TODO: Something is amiss here, slurp! is not used!
+        _slurp! (fn [file] (or (slurp-fn file)
                               (throw (Exception. (format "Could not read contents of %s" file)))))]
     (cond-> {:title title}
 

--- a/src/cljdoc/git_repo.clj
+++ b/src/cljdoc/git_repo.clj
@@ -50,7 +50,7 @@
   [uri]
   (let [lscmd (LsRemoteCommand. nil)]
     (. lscmd (setRemote uri))
-    (try (do (.call lscmd) true)
+    (try (.call lscmd) true
          (catch Exception _ false))))
 
 (defn clone [uri target-dir]
@@ -207,34 +207,14 @@
 (extend ObjectLoader
   io/IOFactory
   (assoc io/default-streams-impl
-         :make-input-stream (fn [x opts] (.openStream x))
-         :make-reader (fn [x opts] (io/reader (.openStream x)))))
+         :make-input-stream (fn [x _opts] (.openStream x))
+         :make-reader (fn [x _opts] (io/reader (.openStream x)))))
 
 (defn read-cljdoc-config
   [repo rev]
   {:pre [(some? repo) (string? rev) (seq rev)]}
   (or (cljdoc.git-repo/slurp-file-at repo rev "doc/cljdoc.edn")
       (cljdoc.git-repo/slurp-file-at repo rev "docs/cljdoc.edn")))
-
-(defn patch-level-info
-  ;; Non API documentation should be updated with new Git revisions,
-  ;; not only once tagged releases are published to Clojars
-  ;; Some versioning scheme is required for this Non-API documentation
-  ;; After recent discussion with @arrdem I'm thinking the following
-  ;; version identifier might be best:
-  ;;
-  ;;     {:version "2.0.0" :patch-level 2}
-  ;;
-  ;; Where this means two changes have been made since the version
-  ;; 2.0.0 has been tagged. Whether the patch-level is increased
-  ;; with every commit or only with commits that modified the resulting
-  ;; doc-bundle is to be decided.
-  ;; TODO probably this should be captured in an ADR
-  [^Git repo]
-
-  ;; Seems like we need to walk the git commits here to retrieve tags in order
-  ;; https://stackoverflow.com/questions/31836087/list-all-tags-in-current-branch-with-jgit
-  )
 
 (comment
   (def r (->repo (io/file "data/git-repos/fulcrologic/fulcro/2.5.4/")))

--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -7,17 +7,11 @@
             [cljdoc.render.api :as api]
             [cljdoc.util :as util]
             [cljdoc.util.fixref :as fixref]
-            [cljdoc.util.pom :as pom]
             [cljdoc.bundle :as bundle]
-            [cljdoc.platforms :as platf]
             [cljdoc.spec]
-            [cljdoc.server.routes :as routes]
-            [version-clj.core :as v]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [clojure.java.io :as io]))
+            [cljdoc.server.routes :as routes]))
 
-(defmulti render (fn [page-type route-params cache-bundle] page-type))
+(defmulti render (fn [page-type _route-params _cache-bundle] page-type))
 
 (defmethod render :default
   [page-type _ _]
@@ -84,8 +78,7 @@
         defs    (bundle/defs-for-ns-with-src-uri cache-bundle (:namespace ns-emap))
         [[dominant-platf] :as platf-stats] (api/platform-stats defs)
         ns-data (bundle/get-namespace cache-bundle (:namespace ns-emap))
-        top-bar-component (layout/top-bar version-entity (bundle/scm-url cache-bundle))
-        common-params {:top-bar-component (layout/top-bar version-entity (bundle/scm-url cache-bundle))}]
+        top-bar-component (layout/top-bar version-entity (bundle/scm-url cache-bundle))]
     (->> (if ns-data
            (layout/layout
             {:top-bar top-bar-component

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -1,9 +1,7 @@
 (ns cljdoc.render.api
   "Functions related to rendering API documenation"
   (:require [cljdoc.render.rich-text :as rich-text]
-            [cljdoc.render.layout :as layout]
             [cljdoc.util.ns-tree :as ns-tree]
-            [cljdoc.util.fixref :as fixref]
             [cljdoc.util :as util]
             [cljdoc.bundle :as bundle]
             [cljdoc.platforms :as platf]
@@ -118,7 +116,7 @@
                                (not= (:artifact-id version-entity) (:artifact-id ns-entity)))) ]
     [:div
      [:ul.list.pl0
-      (for [[ns level _ leaf?] (ns-tree/namespace-hierarchy (keys keyed-namespaces))
+      (for [[ns level _ _leaf?] (ns-tree/namespace-hierarchy (keys keyed-namespaces))
             :let [style {:margin-left (str (* (dec level) 10) "px")}
                   nse (get keyed-namespaces ns)]]
         [:li
@@ -168,7 +166,7 @@
       [node (str "Mostly " (humanize-supported-platforms dominant-platf) " forms.")
        [:br] " Exceptions indicated."])))
 
-(defn definitions-list [ns-entity defs {:keys [indicate-platforms-other-than]}]
+(defn definitions-list [_ns-entity defs {:keys [indicate-platforms-other-than]}]
   [:div.pb4
    [:ul.list.pl0
     (for [def defs

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -1,9 +1,6 @@
 (ns cljdoc.render.articles
   "HTML fragments related to rendering articles and article-trees"
-  (:require [cljdoc.render.layout :as layout]
-            [cljdoc.doc-tree :as doctree]
-            [cljdoc.util :as util]
-            [cljdoc.util.scm :as scm]
+  (:require [cljdoc.util.scm :as scm]
             [cljdoc.server.routes :as routes]
             [clojure.string :as string]
             [hiccup2.core :as hiccup]))

--- a/src/cljdoc/render/error.clj
+++ b/src/cljdoc/render/error.clj
@@ -1,7 +1,5 @@
 (ns cljdoc.render.error
-  (:require [cljdoc.util :as util]
-            [cljdoc.render.layout :as layout]
-            [cljdoc.render.home :as home]
+  (:require [cljdoc.render.layout :as layout]
             [cljdoc.render.search :as search]))
 
 

--- a/src/cljdoc/render/index_pages.clj
+++ b/src/cljdoc/render/index_pages.clj
@@ -49,7 +49,7 @@
              [:div
               [:h3 "Other artifacts under the " (:group-id artifact-entity) " group"]
               [:ol.list.pl0.pv3
-               (for [[artifact-id version-entities] (sort-by first others)
+               (for [[_artifact-id version-entities] (sort-by first others)
                      :let [latest (first (sort-by-version version-entities))
                            a-text (str (:group-id latest) "/" (:artifact-id latest))]]
                  [:li.dib.mr3.mb3
@@ -77,8 +77,7 @@
 
 (defn group-index
   [group-entity versions]
-  (let [group-id (:group-id group-entity)
-        big-btn-link :a.db.link.blue.ph3.pv2.bg-lightest-blue.hover-dark-blue.br2]
+  (let [group-id (:group-id group-entity)]
     (->> [:div
           (layout/top-bar-generic)
           [:div.pa4-ns.pa2
@@ -88,7 +87,7 @@
              [:div
               [:span.db "Known artifacts and versions under the group " group-id]
               [:ol.list.pl0.pv3.nl2.nr2.cf
-               (for [[a-id versions] (->> (group-by :artifact-id versions)
+               (for [[_a-id versions] (->> (group-by :artifact-id versions)
                                           (sort-by first))
                      :let [latest (first (sort-by-version versions))]]
                  (artifact-grid-cell latest))]])]]
@@ -101,17 +100,16 @@
 
 (defn full-index
   [versions]
-  (let [big-btn-link :a.db.link.blue.ph3.pv2.bg-lightest-blue.hover-dark-blue.br2]
-    (->> [:div
-          (layout/top-bar-generic)
-          [:div.pa4-ns.pa2
-           [:div#js--cljdoc-navigator]
-           [:h1.mt5 "All documented artifacts on cljdoc:"]
-           (for [[group-id versions-for-group] (sort-by key (group-by :group-id versions))]
-             [:div.cf
-              [:h2 group-id [:span.gray.fw3.ml3.f5 "Group ID"] ]
-              [:div.nl2.nr2
-               (for [[a-id versions-for-artifact] (group-by :artifact-id versions-for-group)
-                     :let [latest (first (sort-by-version versions-for-artifact))]]
-                 (artifact-grid-cell latest))]])]]
-         (layout/page {:title "all documented artifacts — cljdoc"}))))
+  (->> [:div
+        (layout/top-bar-generic)
+        [:div.pa4-ns.pa2
+         [:div#js--cljdoc-navigator]
+         [:h1.mt5 "All documented artifacts on cljdoc:"]
+         (for [[group-id versions-for-group] (sort-by key (group-by :group-id versions))]
+           [:div.cf
+            [:h2 group-id [:span.gray.fw3.ml3.f5 "Group ID"] ]
+            [:div.nl2.nr2
+             (for [[_a-id versions-for-artifact] (group-by :artifact-id versions-for-group)
+                   :let [latest (first (sort-by-version versions-for-artifact))]]
+               (artifact-grid-cell latest))]])]]
+       (layout/page {:title "all documented artifacts — cljdoc"})))

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -4,7 +4,6 @@
             [cljdoc.config :as config]
             [cljdoc.util :as util]
             [cljdoc.util.scm :as scm]
-            [clojure.string :as string]
             [hiccup2.core :as hiccup]
             [hiccup.page]))
 

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -1,5 +1,4 @@
 (ns cljdoc.render.rich-text
-  (:require [clojure.string :as string])
   (:import (org.asciidoctor Asciidoctor$Factory Options)
            (com.vladsch.flexmark.parser Parser)
            (com.vladsch.flexmark.html HtmlRenderer LinkResolverFactory LinkResolver CustomNodeRenderer)
@@ -90,7 +89,7 @@
   "An extension point for the rendering of different article types.
 
   `type` is determined by [[cljdoc.doc-tree/filepath->type]]."
-  (fn [[type contents]]
+  (fn [[type _contents]]
     type))
 
 (defmethod render-text :cljdoc/markdown [[_ content]]

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -42,8 +42,7 @@
   If articles or namespaces are missing for a project there will be little messages pointing
   users to the relevant documentation or GitHub to open an issue."
   [route-params {:keys [version-entity] :as cache-bundle} last-build]
-  (let [doc-slug-path (:doc-slug-path route-params)
-        doc-tree (doctree/add-slug-path (-> cache-bundle :version :doc))
+  (let [doc-tree (doctree/add-slug-path (-> cache-bundle :version :doc))
         split-doc-tree ((juxt filter remove)
                         #(contains? #{"Readme" "Changelog"} (:title %))
                         doc-tree)

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -66,7 +66,7 @@
        ;; cljdoc's articles feature -> no further notes required
        (seq doc-tree-with-rest)
        [:div.mb4.js--articles
-        (layout/sidebar-title "Articles" {:separator-line? (not (empty? readme-and-changelog))})
+        (layout/sidebar-title "Articles" {:separator-line? (seq readme-and-changelog)})
         [:div.mv3 (articles/doc-tree-view version-entity doc-tree-with-rest (:doc-slug-path route-params))]]
 
        ;; only readme and changelog -> inform user about custom articles

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -65,7 +65,7 @@
                  (storage/import-doc storage (util/version-entity project version) {})
                  ;; Git analysis may derive the revision via tags but a URL is always required.
                  (if scm-url
-                   (let [{:keys [error scm-url commit] :as git-result}
+                   (let [{:keys [error] :as git-result}
                          (ingest/ingest-git! storage {:project project
                                                       :version version
                                                       :scm-url scm-url

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -35,7 +35,7 @@
         (ingest/ingest-cljdoc-edn storage data)
         (build-log/api-imported! build-tracker build-id ns-count)
         (build-log/completed! build-tracker build-id))
-      (catch Exception e
+      (catch Exception _e
         (build-log/failed! build-tracker build-id "analysis-job-failed")))))
 
 (defn kick-off-build!

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -35,7 +35,8 @@
         (ingest/ingest-cljdoc-edn storage data)
         (build-log/api-imported! build-tracker build-id ns-count)
         (build-log/completed! build-tracker build-id))
-      (catch Exception _e
+      (catch Exception e
+        (log/errorf e "analysis job failed for project: %s, version: %s, build-id: %s" project version build-id)
         (build-log/failed! build-tracker build-id "analysis-job-failed")))))
 
 (defn kick-off-build!

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -1,7 +1,5 @@
 (ns cljdoc.server.build-log
-  (:require [integrant.core :as ig]
-            [clojure.java.jdbc :as sql]
-            [clojure.tools.logging :as log]
+  (:require [clojure.java.jdbc :as sql]
             [cljdoc.util.telegram :as telegram]
             [taoensso.nippy :as nippy])
   (:import (java.time Instant Duration)))

--- a/src/cljdoc/server/ingest.clj
+++ b/src/cljdoc/server/ingest.clj
@@ -37,7 +37,7 @@
 
 (defn ingest-git!
   "Analyze the git repository `repo` and store the result in `storage`"
-  [storage {:keys [project version scm-url local-scm pom-revision] :as repo}]
+  [storage {:keys [project version scm-url local-scm pom-revision] :as _repo}]
   {:pre [(string? scm-url)]}
   (let [git-analysis (ana-git/analyze-git-repo project version (or local-scm scm-url) pom-revision)]
     (if (:error git-analysis)

--- a/src/cljdoc/server/ingest.clj
+++ b/src/cljdoc/server/ingest.clj
@@ -1,14 +1,12 @@
 (ns cljdoc.server.ingest
   "A collection of small helpers to ingest data provided via API analysis
   or Git repositories into the database (see [[cljdoc.storage.api]])"
-  (:require [clojure.java.io :as io]
-            [cljdoc.util :as util]
+  (:require [cljdoc.util :as util]
             [cljdoc.analysis.git :as ana-git]
             [cljdoc.util.pom :as pom]
             [cljdoc.util.codox :as codox]
             [clojure.tools.logging :as log]
             [cljdoc.storage.api :as storage]
-            [cljdoc.server.routes :as routes]
             [cljdoc.spec]))
 
 (defn ingest-cljdoc-edn
@@ -28,7 +26,6 @@
         artifact (pom/artifact-info pom-doc)
         scm-info (pom/scm-info pom-doc)
         project  (str (:group-id artifact) "/" (:artifact-id artifact))
-        version  (:version artifact)
         scm-url  (some-> (or (:url scm-info)
                              (if (util/gh-url? (:url artifact))
                                (:url artifact))

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -305,8 +305,8 @@
                                  artifact-id (util/clojars-id params)
                                  group-id group-id)
                    release (try (repos/latest-release-version project)
-                                (catch Exception _e
-                                  (log/warnf "Could not find release for %s" project)))]
+                                (catch Exception e
+                                  (log/warnf e "Could not find release for %s" project)))]
                (->> (if release
                       {:status 302
                        :headers {"Location" (routes/url-for :artifact/version

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -21,14 +21,12 @@
             [cljdoc.render.error :as error]
             [cljdoc.render.offline :as offline]
             [cljdoc.render :as html]
-            [cljdoc.analysis.service :as analysis-service]
             [cljdoc.server.build-log :as build-log]
             [cljdoc.server.pedestal-util :as pu]
             [cljdoc.server.routes :as routes]
             [cljdoc.server.api :as api]
             [cljdoc.server.search.api :as search-api]
             [cljdoc.server.sitemap :as sitemap]
-            [cljdoc.server.ingest :as ingest]
             [cljdoc.storage.api :as storage]
             [cljdoc.util :as util]
             [cljdoc.util.pom :as pom]
@@ -38,7 +36,6 @@
             [clojure.string :as string]
             [co.deps.ring-etag-middleware :as etag]
             [integrant.core :as ig]
-            [cheshire.core :as json]
             [io.pedestal.http :as http]
             [io.pedestal.http.body-params :as body]
             [io.pedestal.interceptor :as interceptor]
@@ -295,7 +292,7 @@
                                     :else
                                     [version :blue])]
                (return-badge ctx status color)))
-    :error (fn [ctx err]
+    :error (fn [ctx _err]
              (let [{:keys [project]} (-> ctx :request :path-params)]
                (return-badge ctx (str "no%20release%20found%20for%20" project) :red)))}))
 
@@ -308,7 +305,7 @@
                                  artifact-id (util/clojars-id params)
                                  group-id group-id)
                    release (try (repos/latest-release-version project)
-                                (catch Exception e
+                                (catch Exception _e
                                   (log/warnf "Could not find release for %s" project)))]
                (->> (if release
                       {:status 302
@@ -326,7 +323,7 @@
   (interceptor/interceptor
    {:name ::etag
     :leave (ring-middlewares/response-fn-adapter
-            (fn [request opts]
+            (fn [request _opts]
               (etag/add-file-etag request false)))}))
 
 (def redirect-trailing-slash-interceptor

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -280,7 +280,7 @@
    {:name ::badge
     :leave (fn badge [ctx]
              (log/info "Badge req headers" (-> ctx :request :headers))
-             (let [{:keys [group-id artifact-id version]} (-> ctx :request :path-params)
+             (let [{:keys [version]} (-> ctx :request :path-params)
                    last-build (::last-build ctx)
                    [status color] (cond
                                     (and last-build (not (build-log/api-import-successful? last-build)))

--- a/src/cljdoc/server/release_monitor.clj
+++ b/src/cljdoc/server/release_monitor.clj
@@ -46,7 +46,7 @@
     build-id))
 
 (defn exclude?
-  [{:keys [group_id artifact_id version] :as  build}]
+  [{:keys [group_id artifact_id version] :as build}]
   (or (= "cljsjs" group_id)
       (.endsWith version "-SNAPSHOT")
       (and (= "org.akvo.flow" group_id)
@@ -121,5 +121,3 @@
         (map #(select-keys % [:created_ts]))))
 
   (oldest-not-built db-spec))
-
-

--- a/src/cljdoc/server/release_monitor.clj
+++ b/src/cljdoc/server/release_monitor.clj
@@ -46,7 +46,7 @@
     build-id))
 
 (defn exclude?
-  [{:keys [group_id artifact_id version] :as build}]
+  [{:keys [group_id artifact_id version] :as _build}]
   (or (= "cljsjs" group_id)
       (.endsWith version "-SNAPSHOT")
       (and (= "org.akvo.flow" group_id)

--- a/src/cljdoc/server/search/api.clj
+++ b/src/cljdoc/server/search/api.clj
@@ -41,7 +41,6 @@
     [cljdoc.server.search.search :as search]
     [cljdoc.server.search.artifact-indexer :as indexer]
     [tea-time.core :as tt]
-    [clojure.spec.alpha :as s]
     [clojure.tools.logging :as log]
     [integrant.core :as ig])
   (:import (java.util.concurrent TimeUnit)))

--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -4,7 +4,6 @@
     [clojure.edn :as edn]
     [clojure.spec.alpha :as s]
     [clojure.java.io :as io]
-    [clojure.string :refer [join]]
     [clj-http.lite.client :as http]
     [clojure.tools.logging :as log]
     [cheshire.core :as json])

--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -1,9 +1,6 @@
 (ns cljdoc.server.sitemap
-  (:require [clojure.java.io :as io]
-            [clojure.spec.alpha :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [sitemap.core :as sitemap]
-            [clojure.tools.logging :as log]
-            [cljdoc.config :as cfg]
             [cljdoc.storage.api :as storage]
             [cljdoc.server.routes :as routes]))
 

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -29,8 +29,7 @@
   (str (cfg/data-dir env-config) "index"))
 
 (defn system-config [env-config]
-  (let [ana-service (cfg/analysis-service env-config)
-        port        (cfg/get-in env-config [:cljdoc/server :port])]
+  (let [ana-service (cfg/analysis-service env-config)]
     (doseq [ns (cfg/extension-namespaces env-config)]
       (log/info "Loading extension namespace" ns)
       (require ns))
@@ -96,7 +95,7 @@
   (ragtime/migrate-all (jdbc/sql-database db-spec)
                        {}
                        (jdbc/load-resources "migrations")
-                       {:reporter (fn [store direction migration]
+                       {:reporter (fn [_store direction migration]
                                     (log/infof "Migrating %s %s" direction migration))})
   db-spec)
 
@@ -137,5 +136,3 @@
       (integrant.repl/go))
 
   (integrant.repl/reset))
-
-

--- a/src/cljdoc/user_config.clj
+++ b/src/cljdoc/user_config.clj
@@ -19,7 +19,7 @@
   [config-edn project]
   (or (get-project-specific config-edn project)
       (->> config-edn
-           (remove (fn [[k v]] (symbol? k)))
+           (remove (fn [[k _v]] (symbol? k)))
            (into {}))))
 
 (defn doc-tree [config-edn project]

--- a/src/cljdoc/util/codox.clj
+++ b/src/cljdoc/util/codox.clj
@@ -1,5 +1,4 @@
-(ns cljdoc.util.codox
-  (:require [clojure.tools.logging :as log]))
+(ns cljdoc.util.codox)
 
 (defn- index-by [k xs]
   (->> (for [[k vs] (group-by k xs)]

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -3,7 +3,6 @@
   rendered in other places, e.g. GitHub."
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [cljdoc.util :as util]
             [cljdoc.util.scm :as scm]
             [cljdoc.server.routes :as routes])
   (:import (org.jsoup Jsoup)))

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -47,7 +47,7 @@
 
 (defn fix-link
   "Return the cljdoc location for a given URL or it's page on GitHub/GitLab etc."
-  [file-path href {:keys [scm-base uri-map] :as opts}]
+  [file-path href {:keys [scm-base uri-map] :as _opts}]
   (let [root-relative (if (.startsWith href "/")
                         (subs href 1)
                         (rebase file-path href))
@@ -69,7 +69,7 @@
 ;; Below, a `nofollow` attribute is added to external links for SEO purposes.
 
 (defn fix
-  [file-path html-str {:keys [git-ls scm uri-map] :as fix-opts}]
+  [file-path html-str {:keys [git-ls scm uri-map] :as _fix-opts}]
   ;; (def fp file-path)
   ;; (def hs html-str)
   ;; (def fo fix-opts)

--- a/src/cljdoc/util/repositories.clj
+++ b/src/cljdoc/util/repositories.clj
@@ -4,7 +4,6 @@
             [clojure.string :as string]
             [clj-http.lite.client :as http]
             [cheshire.core :as json]
-            [clojure.tools.logging :as log]
             [clojure.java.io :as io])
   (:import (org.jsoup Jsoup)
            (java.time Instant Duration)))
@@ -185,5 +184,3 @@
 
   (time (get-pom-xml "org.clojure/clojure" "1.9.0"))
   (clojure.core.memoize/memo-clear! get-pom-xml '("org.clojure/clojure" "1.9.0")))
-
-

--- a/src/cljdoc/util/sqlite_cache.clj
+++ b/src/cljdoc/util/sqlite_cache.clj
@@ -9,7 +9,6 @@
   "
   (:require [clojure.core.cache :as cache]
             [clojure.core.memoize :as memo]
-            [taoensso.nippy :as nippy]
             [clojure.java.jdbc :as sql])
   (:import (java.time Instant)))
 

--- a/test/cljdoc/migration_test.clj
+++ b/test/cljdoc/migration_test.clj
@@ -20,7 +20,7 @@
                                first
                                (str/replace #"\.(up|down)\.sql$" ""))
                       expected-names (set (map #(str base "." % ".sql") ["up" "down"]))]
-                  (and (= (inc i) (try (Long/parseLong prefix) (catch Exception e)))
+                  (and (= (inc i) (try (Long/parseLong prefix) (catch Exception _e)))
                        (= (names prefix) expected-names))))
               (sort (keys names)))))))
 

--- a/test/cljdoc/util_test.clj
+++ b/test/cljdoc/util_test.clj
@@ -25,7 +25,7 @@
             :jar "https://repo.clojars.org/bidi/bidi/2.0.9-SNAPSHOT/bidi-2.0.9-20160426.224252-1.jar"})))
 
 (t/deftest latest-release-test
-  (t/is (= "0.0.4" (repositories/latest-release-version 'org/clojure/math.numeric-tower))))
+  (t/is (= "0.0.4" (repositories/latest-release-version "org/clojure/math.numeric-tower"))))
 
 (t/deftest normalize-git-url-test
   (t/is (= (util/normalize-git-url "git@github.com:clojure/clojure.git")


### PR DESCRIPTION
Overview
--------
Closes #332

- Added clj-kondo with appropriate config to lint cljdoc sources.
- For this first run, found mostly unused namespaces and bindings.
- Corrected or suppressed all errors/warnings produced by clj-kondo.
- Now failing build on circleci should any new errors/warnings crop up.

Run the new `script/lint.sh` to lint cljdoc sources.

Please continue reading.

Issues
------
The following should be reviewed before this commit is merged.

**unlogged exceptions**

We have a couple of cases of caught exceptions not being logged. They should be
reviewed and a comment added if this is intentional.

See:
- [server/api.clj](https://github.com/cljdoc/cljdoc/blob/d54cb58b20d2b4cb1e7c714b3637aa8b89956ce0/src/cljdoc/server/api.clj#L38)
- [server/pedestal.clj](https://github.com/cljdoc/cljdoc/blob/d54cb58b20d2b4cb1e7c714b3637aa8b89956ce0/src/cljdoc/server/pedestal.clj#L295)

**empty code**

An unused function with a big comment and an empty body had me puzzled. Was
I right to delete it?

See:
- [git_repo.clj](https://github.com/cljdoc/cljdoc/blob/d54cb58b20d2b4cb1e7c714b3637aa8b89956ce0/src/cljdoc/git_repo.clj#L219)

**oversights?**

The comment above an unused binding made me think there might be a
programming error - as such I left the code in and temporarily suppressed
the linter warning via an underscore prefix.

See:
- [doc_tree.clj](https://github.com/cljdoc/cljdoc/blob/d54cb58b20d2b4cb1e7c714b3637aa8b89956ce0/src/cljdoc/doc_tree.clj#L89)