### PR TITLE
Add com.turtlequeue to group IDs searched on Maven Central

### DIFF
--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -6,7 +6,8 @@
     [clojure.java.io :as io]
     [clj-http.lite.client :as http]
     [clojure.tools.logging :as log]
-    [cheshire.core :as json])
+    [cheshire.core :as json]
+    [clojure.string :as string])
   (:import (org.apache.lucene.analysis.standard StandardAnalyzer)
            (org.apache.lucene.index IndexWriterConfig IndexWriterConfig$OpenMode IndexWriter Term IndexOptions)
            (org.apache.lucene.document Document StringField Field$Store TextField FieldType Field)

--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -36,10 +36,17 @@
                :description (str "Clojure Contrib library " g "/" a)
                :origin :maven-central}))))
 
+(def ^:private maven-artefacts ["org.clojure"
+                                "com.turtlequeue"])
+(defn maven-search-url []
+  (let [q (->> (map #(str "g:" %) maven-artefacts)
+               (string/join "+OR+"))]
+    (str "http://search.maven.org/solrsearch/select?q=" q "&rows=200")))
+
 (defn load-maven-central-artifacts []
   ;; GET http://search.maven.org/solrsearch/select?q=g:org.clojure -> JSON .response.docs[] = {g: group, a: artifact-id, latestVersion, versionCount
   (try
-    (with-open [in (io/reader "http://search.maven.org/solrsearch/select?q=g:org.clojure&rows=200")]
+    (with-open [in (io/reader (maven-search-url))]
       (format-maven-central-resp
         (json/parse-stream in keyword)))
     (catch Exception e

--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -34,13 +34,13 @@
                :versions [latestVersion]
                ;; We do not have description so fake one with g and a so
                ;; that it will match of this field too and score higher
-               :description (str "Clojure Contrib library " g "/" a)
+               :description (str "Maven Central Clojure library " g "/" a)
                :origin :maven-central}))))
 
-(def ^:private maven-artefacts ["org.clojure"
-                                "com.turtlequeue"])
+(def ^:private maven-groups ["org.clojure"
+                             "com.turtlequeue"])
 (defn maven-search-url []
-  (let [q (->> (map #(str "g:" %) maven-artefacts)
+  (let [q (->> (map #(str "g:" %) maven-groups)
                (string/join "+OR+"))]
     (str "http://search.maven.org/solrsearch/select?q=" q "&rows=200")))
 


### PR DESCRIPTION
Following discussion on this issue: https://github.com/cljdoc/cljdoc/issues/308#issuecomment-530584697

Notes:
 - I did not include the quotes in the search as they do not seem useful
```
http://search.maven.org/solrsearch/select?q=g:%22org.clojure%22+OR+g:%22com.turtlequeue%22&rows=200
```
returns the same as
```
http://search.maven.org/solrsearch/select?q=g:org.clojure+OR+g:com.turtlequeue&rows=200
```
- the `description` will be wrong https://github.com/cljdoc/cljdoc/blob/1eaaac904b275ebe581f1775a3c4b5bb44e43bdd/src/cljdoc/server/search/artifact_indexer.clj#L36