### PR TITLE
Support also JSON, EDN for /versions/*

### DIFF
--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -103,11 +103,10 @@
      :enter (fn releases-loader-inner [ctx]
               (case route-name
                 (:artifact/index :group/index)
-                (assoc ctx ::releases (storage/list-versions store (-> ctx :request :path-params :group-id)))
+                (pu/ok ctx (storage/list-versions store (-> ctx :request :path-params :group-id)))
 
                 :cljdoc/index
-                (assoc ctx ::releases (storage/all-distinct-docs store))))})
-   (pu/body (fn body [ctx] (-> ctx ::releases index-pages/versions-tree)))])
+                (pu/ok ctx (storage/all-distinct-docs store))))})])
 
 (defn artifact-data-loader
   "Return an interceptor that loads all data from `store` that is

--- a/src/cljdoc/server/pedestal_util.clj
+++ b/src/cljdoc/server/pedestal_util.clj
@@ -74,12 +74,3 @@
    {:name ::html
     :enter (fn html-render-inner [context]
              (ok-html context (render-fn context)))}))
-
-(defn body
-  "Return an interceptor that will pass the context to the provided
-  function `body-fn` and return it's result as the body of an OK response."
-  [body-fn]
-  (interceptor/interceptor
-    {:name ::body
-     :enter (fn body-render-inner [context]
-              (ok context (body-fn context)))}))

--- a/src/cljdoc/server/pedestal_util.clj
+++ b/src/cljdoc/server/pedestal_util.clj
@@ -11,26 +11,39 @@
   (get-in context [:request :accept :field] "text/html"))
 
 (defn transform-content
-  [body content-type]
-  (case content-type
-    "text/html"                      (str body)
-    "application/edn"                (pr-str body)
-    "application/json"               (json/generate-string body)
-    "application/x-suggestions+json" (json/generate-string body)))
+  ([body content-type] transform-content body content-type nil)
+  ([body content-type transformer]
+   (let [body' ((or transformer identity) body)]
+     (case content-type
+       "text/html"                      (str body')
+       "application/edn"                (pr-str body')
+       "application/json"               (json/generate-string body')
+       "application/x-suggestions+json" (json/generate-string body')))))
 
 (defn coerce-to
-  [response content-type]
-  (-> response
-      (update :body transform-content content-type)
-      (assoc-in [:headers "Content-Type"] content-type)))
+  ([response content-type] (coerce-to response content-type nil))
+  ([response content-type transformer]
+   (-> response
+       (update :body transform-content content-type transformer)
+       (assoc-in [:headers "Content-Type"] content-type))))
+
+(defn coerce-body-conf
+  "Coerce the `:response :body` to the `accepted-type`, optionally passing it
+  through the `transformer`, a `(fn [request content-type body] (modify body))`
+  See [[transform-content]]."
+  [transformer]
+  (interceptor/interceptor
+    {:name  ::coerce-body
+     :leave (fn [context]
+              (let [content-type (accepted-type context)
+                    transformer' (when transformer
+                                   (partial transformer (:request context) content-type))]
+                (cond-> context
+                        (nil? (get-in context [:response :headers "Content-Type"]))
+                        (update-in [:response] coerce-to content-type transformer'))))}))
 
 (def coerce-body
-  (interceptor/interceptor
-   {:name ::coerce-body
-    :leave (fn [context]
-             (cond-> context
-               (nil? (get-in context [:response :body :headers "Content-Type"]))
-               (update-in [:response] coerce-to (accepted-type context))))}))
+  (coerce-body-conf nil))
 
 (defn ok
   "Return the context `ctx` with response `body` and status 200"
@@ -61,3 +74,12 @@
    {:name ::html
     :enter (fn html-render-inner [context]
              (ok-html context (render-fn context)))}))
+
+(defn body
+  "Return an interceptor that will pass the context to the provided
+  function `body-fn` and return it's result as the body of an OK response."
+  [body-fn]
+  (interceptor/interceptor
+    {:name ::body
+     :enter (fn body-render-inner [context]
+              (ok context (body-fn context)))}))

--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -194,4 +194,4 @@
   (index! index-dir [artifact]))
 
 (s/fdef index-artifact
-        :args (s/cat :artifact ::cljdoc-spec/artifact))
+        :args (s/cat :index-dir string? :artifact ::cljdoc-spec/artifact))

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -135,4 +135,14 @@
       (st/instrument)
       (integrant.repl/go))
 
-  (integrant.repl/reset))
+  (integrant.repl/reset)
+
+  ;; To invoke a URL in a started system
+  integrant.repl.state/system
+  (do
+    (require '[io.pedestal.test :as pdt])
+    (pdt/response-for
+      (get-in integrant.repl.state/system [:cljdoc/pedestal :io.pedestal.http/service-fn])
+      :get "/versions" #_:body :headers {"Content-Type" "text/html"}))
+
+  nil)

--- a/test/cljdoc/integration_test.clj
+++ b/test/cljdoc/integration_test.clj
@@ -95,6 +95,6 @@
 
   (t/run-tests)
 
-  (ig/halt! @sys)
+  (ig/halt! @sys))
 
-  )
+


### PR DESCRIPTION
so that Dash can use it to fetch the available versions of a document.

(Impl.: Transform versions seq into the versions-tree of
group->artifacts->versions, all sorted, use it everywhere.)

Fixes #350