### PR TITLE
Search score by download counts

### DIFF
--- a/resources/public/opensearch.xml
+++ b/resources/public/opensearch.xml
@@ -7,7 +7,7 @@
     <Url type="text/html" template="https://cljdoc.org/search">
         <Param name="q" value="{searchTerms}"/>
     </Url>
-    <Url type="application/x-suggestions+json" template="https://cljdoc.org/suggest">
+    <Url type="application/x-suggestions+json" template="https://cljdoc.org/api/search-suggest">
         <Param name="q" value="{searchTerms}"/>
     </Url>
     <moz:SearchForm>https://cljdoc.org/search</moz:SearchForm>

--- a/src/cljdoc/render/search.clj
+++ b/src/cljdoc/render/search.clj
@@ -25,18 +25,3 @@
        (layout/page {:title "cljdoc — documentation for Clojure/Script libraries"
                      :responsive? true})
        (str)))
-
-;; TODO: complete this function later.
-(defn suggest-api
-  "Provides suggestions for auto-completing the search terms the user is typing.
-   Note: In Firefox, the response needs to reach the browser within 500ms otherwise it will be discarded.
-
-   For more information, see:
-   - https://developer.mozilla.org/en-US/docs/Web/OpenSearch
-   - https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Supporting_search_suggestions_in_search_plugins
-   "
-  [context]
-  (assoc context
-         :response {:status 501
-                    :body "[]"
-                    :headers {"Content-Type" "application/x-suggestions+json"}}))

--- a/src/cljdoc/server/clojars_stats.clj
+++ b/src/cljdoc/server/clojars_stats.clj
@@ -73,12 +73,15 @@
         (sentry/capture {:ex e})))))
 
 (defprotocol IClojarsStats
-  (artifact-monthly [_ group-id artifact-id]))
+  (artifact-monthly [_ group-id artifact-id])
+  (downloads [_]))
 
 (defrecord ClojarsStats [db-spec]
   IClojarsStats
   (artifact-monthly [_ group-id artifact-id]
-    (sql/query db-spec ["SELECT strftime('%Y-%m', date) as month, SUM(downloads) as downloads FROM clojars_stats WHERE group_id = ? AND artifact_id = ? GROUP BY month" group-id artifact-id])))
+    (sql/query db-spec ["SELECT strftime('%Y-%m', date) as month, SUM(downloads) as downloads FROM clojars_stats WHERE group_id = ? AND artifact_id = ? GROUP BY month" group-id artifact-id]))
+  (downloads [_]
+    (sql/query db-spec ["SELECT SUM(downloads) as downloads, group_id as 'group-id', artifact_id as 'artifact-id' FROM clojars_stats GROUP BY group_id, artifact_id"])))
 
 (defmethod ig/init-key :cljdoc/clojars-stats
   [k {:keys [db-spec retention-days] :as opts}]
@@ -93,6 +96,6 @@
   (tt/cancel! (::poll-job clojars-stats))
   (tt/cancel! (::clean-job clojars-stats)))
 
-(comment
+(comment)
 
-  )
+

--- a/src/cljdoc/server/pedestal_util.clj
+++ b/src/cljdoc/server/pedestal_util.clj
@@ -12,9 +12,10 @@
 (defn transform-content
   [body content-type]
   (case content-type
-    "text/html"        (str body)
-    "application/edn"  (pr-str body)
-    "application/json" (json/generate-string body)))
+    "text/html"                      (str body)
+    "application/edn"                (pr-str body)
+    "application/json"               (json/generate-string body)
+    "application/x-suggestions+json" (json/generate-string body)))
 
 (defn coerce-to
   [response content-type]

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -19,7 +19,8 @@
 (defn api-routes []
   #{["/api/ping" :get nop :route-name :ping]
     ["/api/request-build2" :post nop :route-name :request-build]
-    ["/api/search" :get nop :route-name :api/search]})
+    ["/api/search" :get nop :route-name :api/search]
+    ["/api/search-suggest" :get nop :route-name :api/search-suggest]})
 
 (defn build-log-routes []
   #{["/builds/:id" :get nop :route-name :show-build]
@@ -41,8 +42,7 @@
     ["/versions/:group-id/:artifact-id" :get nop :route-name :artifact/index]})
 
 (defn open-search-routes []
-  #{["/search" :get nop :route-name :search]
-    ["/suggest" :get nop :route-name :suggest]})
+  #{["/search" :get nop :route-name :search]})
 
 (defn info-pages-routes []
   #{["/" :get nop :route-name :home]

--- a/src/cljdoc/server/search/api.clj
+++ b/src/cljdoc/server/search/api.clj
@@ -64,11 +64,11 @@
   (suggest [_ query]
     (search/suggest index-dir query)))
 
-(defmethod ig/init-key :cljdoc/searcher [_ {:keys [index-dir enable-indexer?] :or {enable-indexer? true}}]
+(defmethod ig/init-key :cljdoc/searcher [_ {:keys [index-dir enable-indexer? db-spec] :or {enable-indexer? true}}]
   (map->Searcher {:index-dir        index-dir
                   :artifact-indexer (when enable-indexer?
                                       (log/info "Starting ArtifactIndexer")
-                                      (tt/every! (.toSeconds TimeUnit/HOURS 1) #(indexer/download-and-index! index-dir)))}))
+                                      (tt/every! (.toSeconds TimeUnit/HOURS 1) #(indexer/download-and-index! index-dir db-spec)))}))
 
 (defmethod ig/halt-key! :cljdoc/searcher [_ searcher]
   (when-let [indexer (:artifact-indexer searcher)]

--- a/src/cljdoc/server/search/api.clj
+++ b/src/cljdoc/server/search/api.clj
@@ -47,16 +47,22 @@
   (:import (java.util.concurrent TimeUnit)))
 
 (defprotocol ISearcher
-  "Index and search artifacts"
+  ;; We use a protocol so that we can create once the datatype implementing it and
+  ;; wrap the required configuration in it, passing the type instead of the raw config
+  ;; to each of the functions that need it.
+  "Index and search artifacts."
   (index-artifact [_ artifact])
-  (search [_ query]))
+  (search [_ query])
+  (suggest [_ query]))
 
 (defrecord Searcher [index-dir]
   ISearcher
   (index-artifact [_ artifact]
     (indexer/index-artifact index-dir artifact))
   (search [_ query]
-    (search/search index-dir query)))
+    (search/search index-dir query))
+  (suggest [_ query]
+    (search/suggest index-dir query)))
 
 (defmethod ig/init-key :cljdoc/searcher [_ {:keys [index-dir enable-indexer?] :or {enable-indexer? true}}]
   (map->Searcher {:index-dir        index-dir

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -44,7 +44,8 @@
                                       :serialize-fn   nippy/freeze
                                       :deserialize-fn nippy/thaw})
       :cljdoc/searcher {:index-dir       (index-dir env-config)
-                        :enable-indexer? (cfg/enable-artifact-indexer? env-config)}
+                        :enable-indexer? (cfg/enable-artifact-indexer? env-config)
+                        :db-spec         (cfg/db env-config)}
       :cljdoc/pedestal {:port             (cfg/get-in env-config [:cljdoc/server :port])
                         :host             (get-in env-config [:cljdoc/server :host])
                         :build-tracker    (ig/ref :cljdoc/build-tracker)

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -114,6 +114,15 @@
   ;; This is the main REPL entry point into cljdoc.
   ;; Run the forms one by one up to `go` and you should
   ;; have a running server at http://localhost:8000
+  ;; OR run then all at once:
+  (do
+    (require '[cljdoc.server.system])
+    (in-ns 'cljdoc.server.system)
+    (require '[integrant.repl])
+    (integrant.repl/set-prep! #(system-config (cfg/config)))
+    (integrant.repl/go))
+
+
   (require '[integrant.repl]
            '[clojure.spec.test.alpha :as st])
 

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -234,6 +234,6 @@
 
   (store-artifact! db-spec (:group-id data) (:artifact-id data) [(:version data)])
 
-  (get-version-id db-spec (:group-id data) (:artifact-id data) (:version data))
+  (get-version-id db-spec (:group-id data) (:artifact-id data) (:version data)))
 
-  )
+

--- a/src/cljdoc/util/sqlite_cache.clj
+++ b/src/cljdoc/util/sqlite_cache.clj
@@ -184,6 +184,6 @@
                   db-artifact-uris))
 
   (time (memoized-artifact-uris 'bidi "2.0.9-SNAPSHOT"))
-  (time (memoized-artifact-uris 'com.bhauman/spell-spec "0.1.0"))
+  (time (memoized-artifact-uris 'com.bhauman/spell-spec "0.1.0")))
 
-  )
+


### PR DESCRIPTION
TODO Adjust the query structure / weights so that the effect is neither too weak nor does it push forward worse matches. Tricky! See `boost-by-downloads` at https://github.com/cljdoc/cljdoc/pull/359/files#diff-2ce74948e9ce83d10fbff231a0737ef7R121

via #308 

Note: This is how clojars incorporate download counts