### PR TITLE
Refactor how HTML body is created in coerce-body helpers

### DIFF
--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -259,9 +259,7 @@
     :enter (fn build-show-render [ctx]
              (if-let [build-info (->> ctx :request :path-params :id
                                       (build-log/get-build build-tracker))]
-               (if (= "text/html" (pu/accepted-type ctx))
-                 (pu/ok ctx (cljdoc.render.build-log/build-page build-info))
-                 (pu/ok ctx build-info))
+               (pu/ok ctx build-info)
                ;; Not setting :response implies 404 response
                ctx))}))
 
@@ -411,7 +409,9 @@
          :search     [(interceptor/interceptor {:name ::search :enter #(pu/ok-html % (render-search/search-page %))})]
          :shortcuts  [(interceptor/interceptor {:name ::shortcuts :enter #(pu/ok-html % (render-meta/shortcuts))})]
          :sitemap    [(sitemap-interceptor storage)]
-         :show-build [pu/coerce-body
+         :show-build [(pu/coerce-body-conf
+                        (fn html-render [ctx]
+                          (cljdoc.render.build-log/build-page (-> ctx :response :body))))
                       (pu/negotiate-content #{"text/html" "application/edn" "application/json"})
                       (show-build build-tracker)]
          :all-builds [(all-builds build-tracker)]

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -90,13 +90,13 @@
   `route-name` can be either `:artifact/index`,  `:group/index` or `:cljdoc/index`."
   [store route-name]
   [(pu/coerce-body-conf
-     (fn html [{:keys [path-params]} content-type body]
-       (if (= content-type "text/html")
+     (fn html-render-fn [ctx]
+       (let [artifact-ent (-> ctx :request :path-params)
+             body (-> ctx :response :body)]
          (case route-name
-               :artifact/index (index-pages/artifact-index path-params body)
-               :group/index (index-pages/group-index path-params body)
-               :cljdoc/index (index-pages/full-index body))
-         body)))
+           :artifact/index (index-pages/artifact-index artifact-ent body)
+           :group/index (index-pages/group-index artifact-ent body)
+           :cljdoc/index (index-pages/full-index body)))))
    (pu/negotiate-content #{"text/html" "application/edn" "application/json"})
    (interceptor/interceptor
     {:name ::releases-loader

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -92,11 +92,11 @@
   [(pu/coerce-body-conf
      (fn html-render-fn [ctx]
        (let [artifact-ent (-> ctx :request :path-params)
-             body (-> ctx :response :body)]
+             versions-data (-> ctx :response :body)]
          (case route-name
-           :artifact/index (index-pages/artifact-index artifact-ent body)
-           :group/index (index-pages/group-index artifact-ent body)
-           :cljdoc/index (index-pages/full-index body)))))
+           :artifact/index (index-pages/artifact-index artifact-ent versions-data)
+           :group/index (index-pages/group-index artifact-ent versions-data)
+           :cljdoc/index (index-pages/full-index versions-data)))))
    (pu/negotiate-content #{"text/html" "application/edn" "application/json"})
    (interceptor/interceptor
     {:name ::releases-loader


### PR DESCRIPTION
Looking at that code to understand the search issue I had a bit of a hard time understanding what the `transformer` is actually doing. It is passed down very far and in many places augmented/changed slightly making overall program flow a little hard to understand (to me). 

I'm pretty sure there are still issues with this PR, particularly the `show-build` interceptor may need some touching up, but I wanted to open this just to get your thoughts on the general refactoring @holyjak. 