### PR TITLE
Fix badge routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ node_modules
 .envrc
 resources-compiled
 pom.xml
+test-data/

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -52,17 +52,14 @@
     ["/shortcuts" :get nop :route-name :shortcuts]
     ["/sitemap.xml" :get nop :route-name :sitemap]})
 
-(def project-path
-  "Ensure at most one slash.
-  See https://github.com/cljdoc/cljdoc/issues/348"
-  #"^[^/]+(/[^/]+)?$")
-
 (defn utility-routes []
   #{["/jump/release/*project" :get nop :route-name :jump-to-project]
     ["/badge/*project"
      :get nop
      :route-name :badge-for-project
-     :constraints {:project project-path}]})
+     ;; Ensure at most one slash.
+     ;; See https://github.com/cljdoc/cljdoc/issues/348
+     :constraints {:project #"^[^/]+(/[^/]+)?$"}]})
 
 (defn routes
   "Return the expanded routes given the `opts` as passed to

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -52,9 +52,17 @@
     ["/shortcuts" :get nop :route-name :shortcuts]
     ["/sitemap.xml" :get nop :route-name :sitemap]})
 
+(def project-path
+  "Ensure at most one slash.
+  See https://github.com/cljdoc/cljdoc/issues/348"
+  #"^[^/]+(/[^/]+)?$")
+
 (defn utility-routes []
   #{["/jump/release/*project" :get nop :route-name :jump-to-project]
-    ["/badge/*project" :get nop :route-name :badge-for-project]})
+    ["/badge/*project"
+     :get nop
+     :route-name :badge-for-project
+     :constraints {:project project-path}]})
 
 (defn routes
   "Return the expanded routes given the `opts` as passed to

--- a/test/cljdoc/server/routes_test.clj
+++ b/test/cljdoc/server/routes_test.clj
@@ -1,0 +1,13 @@
+(ns cljdoc.server.routes-test
+  (:require [io.pedestal.http.route :refer [expand-routes try-routing-for]]
+            [cljdoc.server.routes :as routes]
+            [clojure.test :as t]))
+
+(t/deftest badge-for-project-test
+  (let [table (-> (routes/utility-routes)
+                  expand-routes)
+        dispatch (fn [path]
+                   (try-routing-for table :map-tree path :get))]
+    (t/is (some? (dispatch "/badge/foo")))
+    (t/is (some? (dispatch "/badge/foo/bar")))
+    (t/is (nil?  (dispatch "/badge/foo/bar/baz")))))


### PR DESCRIPTION
This shall fix #348 .

In https://github.com/cljdoc/cljdoc/issues/348#issuecomment-531135828 it's suggested to fix it by use two separate routes:

```clojure
["/badge/project-id" :get nop :route-name :badge-for-project]
["/badge/group-id/artifact-id" :get nop :route-name :badge-for-project]
```

However I think using constraints are slightly better because pedestal requires each route to have a unique name, which means we need to duplicate the `:badge-for-project` entry in the `route-resolver` function:

https://github.com/cljdoc/cljdoc/blob/f08a21696d887c0c357a3f75338167c1d5b18d6b/src/cljdoc/server/pedestal.clj#L431-L433

(It's a pity that pedestal doesn't support capturing path params with regular expressions, btw)