### PR TITLE
Builds using maven central are failing because http vs https.

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,7 +2,7 @@
  ;; or from resources/secrets if CLJDOC secrets isn't set
  :secrets #include #or [#env CLJDOC_SECRETS "secrets.edn"]
  :maven-repositories [{:id "clojars" :url "https://repo.clojars.org/"}
-                      {:id "central" :url "http://central.maven.org/maven2/"}]
+                      {:id "central" :url "https://repo.maven.apache.org/maven2/"}]
  :cljdoc/version #profile {:prod #slurp "CLJDOC_VERSION"
                            :default "dev"}
  :cljdoc/server {:port 8000

--- a/test/cljdoc/util_test.clj
+++ b/test/cljdoc/util_test.clj
@@ -7,7 +7,7 @@
            (java.io StringReader)))
 
 (t/deftest find-artifact-repository-test
-  (let [central "http://central.maven.org/maven2/"
+  (let [central "https://repo.maven.apache.org/maven2/"
         clojars "https://repo.clojars.org/"]
     (t/is (= (repositories/find-artifact-repository "org.clojure/clojure" "1.9.0")
              central))


### PR DESCRIPTION
More info: https://support.sonatype.com/hc/en-us/articles/360041287334

See https://github.com/cljdoc/cljdoc/issues/376