### PR TITLE
Update running cljdoc locally page: dependencies

### DIFF
--- a/doc/running-cljdoc-locally.md
+++ b/doc/running-cljdoc-locally.md
@@ -10,6 +10,15 @@ to instead [run cljdoc locally from docker](#run-cljdoc-locally-from-docker).
 
 ## Run cljdoc Locally from Source
 
+### Dependencies cljdoc
+
+To run cljdoc from Source, you must install these dependencies:
+ - nodejs
+ - clojure and its command line tools
+
+To install nodejs, follow [instructions here](https://nodejs.org/en/).
+To install clojure and tools, follow [instructions here](https://clojure.org/guides/getting_started).
+
 ### Setup cljdoc
 
 1. Clone cljdoc

--- a/doc/running-cljdoc-locally.md
+++ b/doc/running-cljdoc-locally.md
@@ -12,12 +12,9 @@ to instead [run cljdoc locally from docker](#run-cljdoc-locally-from-docker).
 
 ### Dependencies cljdoc
 
-To run cljdoc from Source, you must install these dependencies:
- - nodejs
- - clojure and its command line tools
-
-To install nodejs, follow [instructions here](https://nodejs.org/en/).
-To install clojure and tools, follow [instructions here](https://clojure.org/guides/getting_started).
+To run cljdoc from source, you must install these dependencies:
+ - nodejs ([installation instructions](https://nodejs.org/en/))
+ - Clojure CLI tools ([instructions here](https://clojure.org/guides/getting_started))
 
 ### Setup cljdoc
 


### PR DESCRIPTION
Add a section 'Dependencies cljdoc' in the documentation page 'running-cljdoc-locally.md'.

Fixes #381