### PR TITLE
add version 0.6.1 to muuntaja URL in running-cljsdoc-locally.md

### DIFF
--- a/doc/running-cljdoc-locally.md
+++ b/doc/running-cljdoc-locally.md
@@ -117,7 +117,7 @@ test before mapping this knowledge onto your own project.
     > commit them locally so there is a revision that the repo can be analysed
     > at. This can be done in a branch, if you don't want to pollute your master.
 
-1. Open the docs for muuntaja on the local cljdoc server: http://localhost:8000/d/metosin/muuntaja
+1. Open the docs for muuntaja on the local cljdoc server: http://localhost:8000/d/metosin/muuntaja/0.6.1
 
 ## Run cljdoc Locally from docker
 


### PR DESCRIPTION
This is necessary because the URL without 0.6.1 defaults (upon pressing enter)
to 0.6.6 which is just not the version installed locally when following
the instructions.