### PR TITLE
Improve Git analysis error reporting

### DIFF
--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -73,9 +73,9 @@
                                                       :pom-revision scm-rev})]
                      (when error
                        (log/warnf "Error while processing %s %s: %s" project version error))
-                     (build-log/git-completed! build-tracker build-id (update git-result :error :type))
-                     (analyze-and-import-api! deps ana-args))
-                   (analyze-and-import-api! deps ana-args))
+                     (build-log/git-completed! build-tracker build-id (update git-result :error :type)))
+                   (build-log/git-completed! build-tracker build-id {:error "Error while trying to processe Git repository: no SCM URL found"}))
+                 (analyze-and-import-api! deps ana-args)
 
                  (catch Throwable e
                    (log/error e (format "Exception while processing %s %s (build %s)" project version build-id))

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -74,7 +74,7 @@
                      (when error
                        (log/warnf "Error while processing %s %s: %s" project version error))
                      (build-log/git-completed! build-tracker build-id (update git-result :error :type)))
-                   (build-log/git-completed! build-tracker build-id {:error "Error while trying to processe Git repository: no SCM URL found"}))
+                   (build-log/git-completed! build-tracker build-id {:error "Error while trying to process Git repository: no SCM URL found"}))
                  (analyze-and-import-api! deps ana-args)
 
                  (catch Throwable e


### PR DESCRIPTION
Fixes #363, ready to merge into master.

During the build process as implemented pre-this-PR:
When the SCM-URL does for some reason not make it into the function "kick-off-build" (i.e. is nil), the message "in progress" is displayed and never changes. The already implemented print of a nice explanation message is never triggered.

With this PR, the nice message is now actually shown on screen, with the new additional message "Error while trying to process Git repository: no SCM URL found" included.