### PR TITLE
Revert "Throw exception when no namespace is found"

### DIFF
--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -34,8 +34,7 @@
         (build-log/analysis-received! build-tracker build-id file-uri)
         (ingest/ingest-cljdoc-edn storage data)
         (build-log/api-imported! build-tracker build-id ns-count)
-        (build-log/completed! build-tracker build-id)
-        (when (zero? ns-count) (throw (Exception. "No namespaces found"))))
+        (build-log/completed! build-tracker build-id))
       (catch Exception e
         (log/errorf e "analysis job failed for project: %s, version: %s, build-id: %s" project version build-id)
         (build-log/failed! build-tracker build-id "analysis-job-failed")))))


### PR DESCRIPTION
Turns out this actually isn't appropriate to do since some libraries don't contain namespaces and that's fine. The red message highlighting this in the build page is sufficient to make people aware. 

Reverts cljdoc/cljdoc#389