### PR TITLE
Add links to prev and next article on doc page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ project.clj
 .clj-kondo/.cache
 node_modules
 .envrc
+.calva
 resources-compiled
 pom.xml
 test-data/

--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -74,7 +74,7 @@
                         :version-entity version-entity
                         :prev-page (when (<= 0 (dec article-idx) (count flatten-article-tree))
                                      (nth flatten-article-tree (dec article-idx)))
-                        :next-page (when (<= 0 (inc article-idx) (count flatten-article-tree))
+                        :next-page (when (< 0 (inc article-idx) (count flatten-article-tree))
                                      (nth flatten-article-tree (inc article-idx)))})})
            (layout/layout
             {:top-bar top-bar-component

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -31,13 +31,23 @@
           (into [:ul.list.ma0 {:class (if (pos? level) "f6-ns pl2" "pl0")}])))))
 
 (defn doc-page
-  [{:keys [doc-scm-url doc-html doc-type contributors]}]
+  [{:keys [doc-scm-url doc-html doc-type contributors next-page prev-page version-entity]}]
   (assert doc-type)
   [:div.mw7.center
    (if doc-html
      [:div#doc-html.cljdoc-article.lh-copy.pv4
       {:class (name doc-type)}
-      (hiccup/raw doc-html)]
+      (hiccup/raw doc-html)
+      [:div.flex.justify-between
+       (if prev-page
+         [:a.link.blue
+          {:href (doc-link version-entity (-> prev-page :attrs :slug-path))}
+          [:span [:span.mr1 "<"] (-> prev-page :title)]]
+         [:div])
+       (when next-page
+         [:a.link.blue
+          {:href (doc-link version-entity (-> next-page :attrs :slug-path))}
+          [:span (-> next-page :title) [:span.ml1 ">"]]])]]
      [:div.lh-copy.pv6.tc
       [:span.f4.serif.gray.i "Space intentionally left blank."]])
    ;; outside of div with markdown specific styling so markdown


### PR DESCRIPTION
This is my attempt to fix #207 

For some reason Icons does not work so I added just regular characters `<` and `>` instead arrows. Will be glad to hear any proposition on how it should look like

![image](https://user-images.githubusercontent.com/14214811/89862830-6ba6a880-dbb1-11ea-8b2d-ec3c05b77960.png)
