### PR TITLE
add keyboad navigation

### DIFF
--- a/js/cljdoc.js
+++ b/js/cljdoc.js
@@ -104,11 +104,27 @@ function toggleMetaDialog() {
   }
 }
 
+function addpPrevNextPageKeyHandlers() {
+  const prevLink = document.getElementById("prev-article-page-link");
+  const nextLink = document.getElementById("next-article-page-link");
+  if (prevLink || nextLink) {
+    document.addEventListener("keydown", function(e) {
+      if (e.code === "ArrowLeft" && prevLink) {
+        document.location.href = prevLink.href;
+      }
+      if (e.code === "ArrowRight" && nextLink) {
+        document.location.href = nextLink.href;
+      }
+    });
+  }
+}
+
 export {
   initSrollIndicator,
   initToggleRaw,
   restoreSidebarScrollPos,
   toggleMetaDialog,
   isNSPage,
-  isProjectDocumentationPage
+  isProjectDocumentationPage,
+  addpPrevNextPageKeyHandlers
 };

--- a/js/cljdoc.js
+++ b/js/cljdoc.js
@@ -104,7 +104,7 @@ function toggleMetaDialog() {
   }
 }
 
-function addpPrevNextPageKeyHandlers() {
+function addPrevNextPageKeyHandlers() {
   const prevLink = document.getElementById("prev-article-page-link");
   const nextLink = document.getElementById("next-article-page-link");
   if (prevLink || nextLink) {
@@ -126,5 +126,5 @@ export {
   toggleMetaDialog,
   isNSPage,
   isProjectDocumentationPage,
-  addpPrevNextPageKeyHandlers
+  addPrevNextPageKeyHandlers
 };

--- a/js/index.js
+++ b/js/index.js
@@ -10,7 +10,7 @@ import {
   initToggleRaw,
   restoreSidebarScrollPos,
   toggleMetaDialog,
-  addpPrevNextPageKeyHandlers
+  addPrevNextPageKeyHandlers
 } from "./cljdoc";
 
 trackProjectOpened();
@@ -36,7 +36,7 @@ if (isNSPage()) {
 if (isProjectDocumentationPage()) {
   render(h(MobileNav), document.querySelector("#js--mobile-nav"));
   toggleMetaDialog();
-  addpPrevNextPageKeyHandlers();
+  addPrevNextPageKeyHandlers();
 }
 
 window.onbeforeunload = function() {

--- a/js/index.js
+++ b/js/index.js
@@ -36,6 +36,7 @@ if (isNSPage()) {
 if (isProjectDocumentationPage()) {
   render(h(MobileNav), document.querySelector("#js--mobile-nav"));
   toggleMetaDialog();
+  addpPrevNextPageKeyHandlers();
 }
 
 window.onbeforeunload = function() {
@@ -51,5 +52,3 @@ window.onbeforeunload = function() {
     localStorage.setItem("sidebarScrollPos", JSON.stringify(data));
   }
 };
-
-addpPrevNextPageKeyHandlers();

--- a/js/index.js
+++ b/js/index.js
@@ -9,7 +9,8 @@ import {
   initSrollIndicator,
   initToggleRaw,
   restoreSidebarScrollPos,
-  toggleMetaDialog
+  toggleMetaDialog,
+  addpPrevNextPageKeyHandlers
 } from "./cljdoc";
 
 trackProjectOpened();
@@ -50,3 +51,5 @@ window.onbeforeunload = function() {
     localStorage.setItem("sidebarScrollPos", JSON.stringify(data));
   }
 };
+
+addpPrevNextPageKeyHandlers();

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -15,12 +15,14 @@
   [:div.flex.justify-between.mt4
    (if prev-page
      [:a.link.blue
-      {:href (doc-link version-entity (-> prev-page :attrs :slug-path))}
+      {:href (doc-link version-entity (-> prev-page :attrs :slug-path))
+       :id "prev-article-page-link"}
       [:span [:span.mr1 "❮"] (-> prev-page :title)]]
      [:div])
    (when next-page
      [:a.link.blue
-      {:href (doc-link version-entity (-> next-page :attrs :slug-path))}
+      {:href (doc-link version-entity (-> next-page :attrs :slug-path))
+       :id "next-article-page-link"}
       [:span (-> next-page :title) [:span.ml1 "❯"]]])])
 
 (defn doc-tree-view


### PR DESCRIPTION
Hello, this is a super naive implementation to fix #28 

### Changelog
- add `id` attribute to links for next and prev page
- add a function that listens to keyboard events and navigate to the page from that link