### PR TITLE
Update to current clj-kondo

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,5 @@
-{ ;; there's a fair bit of old test code in comment blocks that does not lint, skip it for now
- :skip-comments true
+{:config-paths ^:replace [] ;; don't include user configs
+ :skip-comments true ;; there's a fair bit of old test code in comment blocks that does not lint, skip it for now
  :lint-as {taoensso.tufte/defnp clojure.core/defn
            clojure.core.cache/defcache clojure.core/defrecord
            clojure.java.jdbc/with-db-transaction clojure.core/let}

--- a/deps.edn
+++ b/deps.edn
@@ -61,7 +61,7 @@
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo {:mvn/version "2020.05.09"}}
+           {:extra-deps {clj-kondo {:mvn/version "2020.09.09"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :cli


### PR DESCRIPTION
Clj-kondo now includes a user config by default.
This is now disabled for cljdoc.