### PR TITLE
Add support for Sourcehut as a SCM provider

### DIFF
--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -7,6 +7,7 @@
             [cljdoc.render.api :as api]
             [cljdoc.util :as util]
             [cljdoc.util.fixref :as fixref]
+            [cljdoc.util.scm :as scm]
             [cljdoc.bundle :as bundle]
             [cljdoc.spec]
             [cljdoc.server.routes :as routes]))
@@ -54,9 +55,8 @@
             {:top-bar top-bar-component
              :main-sidebar-contents sidebar-contents
              :content (articles/doc-page
-                       {:doc-scm-url (str (-> cache-bundle :version :scm :url) "/blob/"
-                                          (or (-> cache-bundle :version :scm :branch) "master")
-                                          "/" (-> doc-p :attrs :cljdoc.doc/source-file))
+                       {:doc-scm-url (scm/view-uri (bundle/scm-info cache-bundle)
+                                                   (-> doc-p :attrs :cljdoc.doc/source-file))
                         :contributors (-> doc-p :attrs :cljdoc.doc/contributors)
                         :doc-type (name doc-type)
                         :doc-html (fixref/fix (rich-text/render-text [doc-type contents])

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -70,8 +70,9 @@
          [:b.db "Can you improve this documentation?"])
        [:a.link.dib.white.bg-blue.ph2.pv1.br2.mt2
         {:href doc-scm-url}
-        (if (= :gitlab (scm/provider doc-scm-url))
-          "Edit on GitLab"
+        (case (scm/provider doc-scm-url)
+          :gitlab "Edit on GitLab"
+          :sourcehut "Edit on sourcehut"
           "Edit on GitHub")]]])])
 
 (defn doc-overview

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -152,7 +152,7 @@
       (and scm-url (scm/http-uri scm-url))
       [:a.link.dim.gray.f6.tr
        {:href (scm/http-uri scm-url)}
-       (let [icon (or (scm/provider scm-url) :git)]
+       (let [icon (get #{:github :gitlab} (scm/provider scm-url) :git)]
          [:img.v-mid.mr2-ns {:src (str "https://microicon-clone.vercel.app/" (name icon))}])
        [:span.dib-ns.dn (scm/coordinate (scm/http-uri scm-url))]]
 

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -49,7 +49,7 @@
     (when scm-url
       [:a.link.dim.gray.f6.tr
        {:href scm-url}
-       (let [icon (or (scm/provider scm-url) :code)]
+       (let [icon (get #{:github :gitlab} (scm/provider scm-url) :code)]
          [:img.v-mid.mr2 {:src (str "https://microicon-clone.vercel.app/" (name icon))}])
        [:span.dib (scm/coordinate scm-url)]])]])
 

--- a/src/cljdoc/util/datetime.clj
+++ b/src/cljdoc/util/datetime.clj
@@ -1,7 +1,8 @@
 (ns cljdoc.util.datetime
   "Helpers function to work with dates and times."
   (:import (java.time Instant ZoneId)
-           (java.time.format DateTimeFormatter)))
+           (java.time.format DateTimeFormatter)
+           (java.util Locale)))
 
 (defn day-suffix
   "Append approptiate suffix based on day of the month.
@@ -15,7 +16,7 @@
   [ts]
   (let [datetime (Instant/parse ts)
         utc      (ZoneId/of "UTC")]
-    (str (.format (.withZone (DateTimeFormatter/ofPattern "EEE, MMM dd") utc) datetime)
+    (str (.format (.withZone (DateTimeFormatter/ofPattern "EEE, MMM dd" Locale/ENGLISH) utc) datetime)
          (day-suffix (.getDayOfMonth (.atZone datetime utc))))))
 
 (comment

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -33,13 +33,13 @@
 
 (defn- scm-blob-base-url [scm]
   (let [blob-path (case (scm/provider (:url scm))
-                    :sourcelab "/tree/"
+                    :sourcehut "/tree/"
                     "/blob/")]
     (str (:url scm) blob-path (scm-rev scm) "/")))
 
 (defn- scm-raw-base-url [scm]
   (let [raw-path (case (scm/provider (:url scm))
-                   :sourcelab "/blob/"
+                   :sourcehut "/blob/"
                    "/raw/")]
     (str (:url scm) raw-path (scm-rev scm) "/")))
 

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -32,10 +32,16 @@
       (:commit scm)))
 
 (defn- scm-blob-base-url [scm]
-  (str (:url scm) "/blob/" (scm-rev scm) "/"))
+  (let [blob-path (case (scm/provider (:url scm))
+                    :sourcelab "/tree/"
+                    "/blob/")]
+    (str (:url scm) blob-path (scm-rev scm) "/")))
 
 (defn- scm-raw-base-url [scm]
-  (str (:url scm) "/raw/" (scm-rev scm) "/"))
+  (let [raw-path (case (scm/provider (:url scm))
+                   :sourcelab "/blob/"
+                   "/raw/")]
+    (str (:url scm) "/raw/" (scm-rev scm) "/")))
 
 (defn- rebase-path
   "Rebase path `s1` to directory of relative path `s2`.

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -41,7 +41,7 @@
   (let [raw-path (case (scm/provider (:url scm))
                    :sourcelab "/blob/"
                    "/raw/")]
-    (str (:url scm) "/raw/" (scm-rev scm) "/")))
+    (str (:url scm) raw-path (scm-rev scm) "/")))
 
 (defn- rebase-path
   "Rebase path `s1` to directory of relative path `s2`.

--- a/src/cljdoc/util/scm.clj
+++ b/src/cljdoc/util/scm.clj
@@ -19,7 +19,8 @@
   (when-some [host (:host (uri/uri scm-url))]
     (cond
       (.endsWith host "github.com") :github
-      (.endsWith host "gitlab.com") :gitlab)))
+      (.endsWith host "gitlab.com") :gitlab
+      (.endsWith host "sr.ht") :sourcehut)))
 
 (defn http-uri
   "Given a URI pointing to a git remote, normalize that URI to an HTTP one."
@@ -54,3 +55,10 @@
     (.startsWith scm-url "http")
     (let [{:keys [host path]} (uri/uri scm-url)]
       (str "git@" host ":" (subs path 1) ".git"))))
+
+(defn view-uri
+  [{:keys [url branch]} source-file]
+  (let [blob-path (if (= :sourcehut (provider url))
+                    "/tree/"
+                    "/blob/")]
+    (str url blob-path (or branch "master") "/" source-file)))

--- a/test/cljdoc/util/fixref_test.clj
+++ b/test/cljdoc/util/fixref_test.clj
@@ -88,7 +88,12 @@
                 (fixref/fix (str "<a href=\"/root/relative/doc.md\">root relative link</a>"
                                  "<a href=\"/root/./././relative/../a/b/c/../../d/doc.md\">root relative link</a>"
                                  "<a href=\"/root/relative/../../../../../doc.md\">root relative link</a>")
-                            fix-opts))))))
+                            fix-opts)))))
+    (t/testing "work with sourcehut"
+      (t/is (= ["<a href=\"https://git.sr.ht/~user/project/tree/#SHA#/doc/norm1.adoc\" rel=\"nofollow\">relative link</a>"]
+               (fix-result
+                (fixref/fix "<a href=\"norm1.adoc\">relative link</a>"
+                            (assoc-in fix-opts [:scm :url] "https://git.sr.ht/~user/project")))))))
 
   (t/testing "known scm relative links (imported articles)"
     (t/testing  "are adjusted to point to article slugs"
@@ -141,4 +146,13 @@
                             {:scm-file-path "doc/path/doc.adoc"
                              :scm {:commit "#SHA#"
                                    :url "https://github.com/user/project"}
+                             :uri-map {}})))))
+
+    (t/testing "work with sourcehut"
+      (t/is (= ["<img src=\"https://git.sr.ht/~user/project/blob/#SHA#/doc/path/rel.png\">"]
+               (fix-result
+                (fixref/fix "<img src=\"rel.png\">"
+                            {:scm-file-path "doc/path/doc.adoc"
+                             :scm {:commit "#SHA#"
+                                   :url "https://git.sr.ht/~user/project"}
                              :uri-map {}})))))))

--- a/test/cljdoc/util/scm_test.clj
+++ b/test/cljdoc/util/scm_test.clj
@@ -17,6 +17,7 @@
   (t/is (= :github (scm/provider "https://www.github.com/cloverage/cloverage")))
   (t/is (= :github (scm/provider "https://git@www.github.com/cloverage/cloverage")))
   (t/is (= :gitlab (scm/provider "https://gitlab.com/eval/otarta")))
+  (t/is (= :sourcehut (scm/provider "https://git.sr.ht/~miikka/clj-branca")))
   (t/is (= nil (scm/provider "https://gitea.heevyis.ninja/josha/formulare")))
   (t/is (= nil (scm/provider "https://unknown-scm.com/circleci/clj-yaml"))))
 

--- a/test/cljdoc/util/scm_test.clj
+++ b/test/cljdoc/util/scm_test.clj
@@ -30,3 +30,7 @@
   (t/is (= "http://github.com/circleci/clj-yaml" (scm/http-uri "git@github.com:circleci/clj-yaml.git")))
   (t/is (= "http://gitea.heevyis.ninja/josha/formulare" (scm/http-uri "git@gitea.heevyis.ninja:josha/formulare.git")))
   (t/is (= "http://unknown-scm.com/circleci/clj-yaml" (scm/http-uri "git@unknown-scm.com:circleci/clj-yaml"))))
+
+(t/deftest scm-view-uri-test
+  (t/is (= "https://github.com/circleci/clj-yaml/blob/master/README.md" (scm/view-uri {:url "https://github.com/circleci/clj-yaml", :branch "master"} "README.md")))
+  (t/is (= "https://git.sr.ht/~miikka/clj-branca/tree/master/README.md" (scm/view-uri {:url "https://git.sr.ht/~miikka/clj-branca", :branch "master"} "README.md"))))


### PR DESCRIPTION
Fixes #421.

* [microicon](https://microicon-clone.vercel.app/) does not have a sourcehut icon, but I suppose the generic git icon is good  enough.
* Published [org.clojars.miikka/sourcehut-and-cljdoc 0.1.0-SNAPSHOT](https://clojars.org/org.clojars.miikka/sourcehut-and-cljdoc) which has a README with an image and relative links, so it's easy to test that this patch works.

To-do:

* [x] Check that fixing image refs actually works
* [x] Check that fixing link refs actually works
* [x] Maybe update unit tests for fixref?
* [x] Add unit test for `cljdoc.util.scm/view-uri`