### PR TITLE
Prevent default behavior for Ctrl-K

### DIFF
--- a/js/switcher.js
+++ b/js/switcher.js
@@ -105,6 +105,7 @@ class Switcher extends Component {
 
     if (e.which === 75) {
       if ((isMac && e.metaKey) || (!isMac && e.ctrlKey)) {
+        e.preventDefault();
         switcherShortcut = true;
       }
     }


### PR DESCRIPTION
On Firefox and Chrome (the ones I tested), when you press `Ctrl+K`
the browser's navigation bar gets focused and adds a question mark
for searching, which prevents the user from using this as an actual
feature. Calling `preventDefault` on the event, makes the cljdoc
search box to get focused instead.

**Reference**:

  * Chrome: https://support.google.com/chrome/answer/157179
  * Firefox: https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly#w_search

**Note**: I don't know if this could be the better option, if you're trying not to obstruct the user's usual interaction with the browser. But, at least, letting it here as a note.