### PR TITLE
Fix adoc xrefs

### DIFF
--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -15,7 +15,8 @@
 
 (defn asciidoc-to-html [file-content]
   (let [opts (doto (Options.)
-               (.setAttributes (java.util.HashMap. {"env-cljdoc" true})))]
+               (.setAttributes (java.util.HashMap. {"env-cljdoc" true
+                                                    "outfilesuffix" ".adoc"})))]
     (.convert adoc-container file-content opts)))
 
 (def md-extensions


### PR DESCRIPTION
When cljdoc encounters a relative path, it will look for it in the list
of _source files_.  This is because it's operating similarly to GitHub
where the link ends in `.md`, rather than `.html` as the output format.
Cross references use outfilesuffix to automatically add a suffix as is
appropriate for their platform, by default when generating html output
that suffix is `.html`.  To allow cljdoc's URL fixer to run, we instead
make this output `.adoc`, which allows the path to be found in the list
of source files again.