### PR TITLE
Find neighbour article tests now use test.check

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -2,5 +2,7 @@
  :skip-comments true ;; there's a fair bit of old test code in comment blocks that does not lint, skip it for now
  :lint-as {taoensso.tufte/defnp clojure.core/defn
            clojure.core.cache/defcache clojure.core/defrecord
-           clojure.java.jdbc/with-db-transaction clojure.core/let}
+           clojure.java.jdbc/with-db-transaction clojure.core/let
+           clojure.test.check.clojure-test/defspec clojure.core/def
+           clojure.test.check.properties/for-all clojure.core/let}
  :linters {:unused-binding {:exclude-destructured-keys-in-fn-args true}}}

--- a/.cljfmt/indentation.edn
+++ b/.cljfmt/indentation.edn
@@ -1,2 +1,4 @@
 ;; for defaults see: https://github.com/weavejester/cljfmt/blob/master/cljfmt/resources/cljfmt/indents/clojure.clj
-{defcache  [[:block 2] [:inner 1]]}
+{defcache  [[:block 2] [:inner 1]]
+ for-all   [[:block 1]]
+ defspec   [[:inner 0]]}

--- a/deps.edn
+++ b/deps.edn
@@ -35,7 +35,6 @@
         org.slf4j/slf4j-api {:mvn/version "1.7.26"},
         expound/expound {:mvn/version "0.7.2"},
         raven-clj/raven-clj {:mvn/version "1.6.0-alpha2"},
-        org.clojure/test.check {:mvn/version "0.9.0"},
         me.raynes/fs {:mvn/version "1.4.6"},
         sitemap/sitemap {:mvn/version "0.4.0"},
         lambdaisland/uri {:mvn/version "1.2.1"}
@@ -57,7 +56,8 @@
          "modules/shared-utils/resources"]
  :aliases {:test
            {:extra-paths ["test"]
-            :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-529"}}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}
+                         org.clojure/test.check {:mvn/version "1.1.0"}}
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo

--- a/test/cljdoc/doc_tree_test.clj
+++ b/test/cljdoc/doc_tree_test.clj
@@ -65,28 +65,27 @@
 (tc/defspec inside-elements-in-tree-have-both-next-and-prev
   1
   (prop/for-all [entries (gen-entries)]
-                (let [example-tree (doctree/add-slug-path entries)
-                      slug-paths (get-slug-paths example-tree)]
-                  (every? (fn [[prev-elem elem next-elem]]
-                            (and prev-elem elem next-elem))
-                        (->> slug-paths
-                             rest
-                             butlast
-                             (take 20) ;; generated tree can be large, don't need to test it all
-                             (map #(doctree/get-neighbour-entries example-tree %)))))))
+    (let [example-tree (doctree/add-slug-path entries)
+          slug-paths (get-slug-paths example-tree)]
+      (every? (fn [[prev-elem elem next-elem]]
+                (and prev-elem elem next-elem))
+              (->> slug-paths
+                   rest
+                   butlast
+                   (take 20) ;; generated tree can be large, don't need to test it all
+                   (map #(doctree/get-neighbour-entries example-tree %)))))))
 
 (tc/defspec last-element-in-tree-has-no-next-entry
   1
   (prop/for-all [entries (gen-entries)]
-                (let [example-tree (doctree/add-slug-path entries)
-                      slug-paths (get-slug-paths example-tree)
-                      [prev-elem elem next-elem] (->> (last slug-paths)
-                                                      (doctree/get-neighbour-entries example-tree))]
-                  (and prev-elem elem (nil? next-elem)))))
+    (let [example-tree (doctree/add-slug-path entries)
+          slug-paths (get-slug-paths example-tree)
+          [prev-elem elem next-elem] (->> (last slug-paths)
+                                          (doctree/get-neighbour-entries example-tree))]
+      (and prev-elem elem (nil? next-elem)))))
 
 (comment
 
   (def example-tree (doctree/add-slug-path (gen/sample (spec/gen ::entry) 3)))
 
-  (count (gen/sample (spec/gen ::entry) 3))
-  )
+  (count (gen/sample (spec/gen ::entry) 3)))

--- a/test/cljdoc/doc_tree_test.clj
+++ b/test/cljdoc/doc_tree_test.clj
@@ -1,9 +1,11 @@
 (ns cljdoc.doc-tree-test
   (:require [cljdoc.doc-tree :as doctree]
             [clojure.test :as t]
+            [clojure.test.check.clojure-test :as tc]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
             [clojure.spec.test.alpha :as st]
-            [clojure.spec.alpha :as spec]
-            [clojure.spec.gen.alpha :as gen]))
+            [clojure.spec.alpha :as spec]))
 
 (t/use-fixtures :once (fn [f] (st/instrument) (f)))
 
@@ -27,71 +29,64 @@
           [["Readme" {:file "README.md"}
             ["Nested" {:file "nested.adoc"}]]]))))
 
-;; we redefine spec for entry because for test we want every entry have attrs with slug
+;; we redefine spec for entry because for test we want every entry have attrs with slug so that slug-path will be
+;; generated (neighbours are found based on the slug-path)
 (spec/def ::entry
   (spec/keys :req-un [:cljdoc.doc-tree/attrs :cljdoc.doc-tree/title]
              :opt-un [::children]))
 
-(spec/def ::children
-  (spec/coll-of ::entry))
+;; encourage generation of unique slugs across siblings.
+;; this matches reality and avoids duplicate slug-paths
+(defn- slug-is-unique? [entries]
+  (if (empty? entries)
+    true
+    (apply distinct? (map #(get-in % [:attrs :slug]) entries))))
 
-(t/deftest find-neighbour-articles
-  (t/testing "find neighbour entries in doc-tree by slug-path"
-    (let [example-tree (doctree/add-slug-path (gen/sample (spec/gen ::entry) 3))]
-      (t/testing "First element in tree will have no previous entry"
-        (t/is (->> example-tree
-                   first
-                   :attrs
-                   :slug-path
-                   (doctree/get-neighbour-entries example-tree)
-                   first
-                   nil?)))
-      (t/testing "Any not first and not last entry in tree have two neighbours"
-        (t/is (->> example-tree
-                   second
-                   :attrs
-                   :slug-path
-                   (doctree/get-neighbour-entries example-tree)
-                   (every? (complement nil?)))))
-      (t/testing "Last element in tree have no next neighbour"
-        (t/is (->> example-tree
-                   doctree/flatten*
-                   reverse
-                   first
-                   :attrs
-                   :slug-path
-                   (doctree/get-neighbour-entries example-tree)
-                   last
-                   nil?))))))
+(spec/def ::children
+  (spec/and (spec/coll-of ::entry) slug-is-unique?))
+
+(defn- gen-entries []
+  (gen/such-that slug-is-unique? (gen/vector (spec/gen ::entry) 3)))
+
+(defn- get-slug-paths [doc-tree]
+  (->> doc-tree
+       (mapcat #(tree-seq :attrs :children %))
+       (map #(get-in % [:attrs :slug-path]))))
+
+(tc/defspec first-element-in-tree-has-no-previous-entry
+  1
+  (prop/for-all [entries (gen-entries)]
+    (let [example-tree (doctree/add-slug-path entries)
+          slug-paths (get-slug-paths example-tree)
+          [prev-elem elem next-elem] (->> (first slug-paths)
+                                          (doctree/get-neighbour-entries example-tree))]
+      (and (nil? prev-elem) elem next-elem))))
+
+(tc/defspec inside-elements-in-tree-have-both-next-and-prev
+  1
+  (prop/for-all [entries (gen-entries)]
+                (let [example-tree (doctree/add-slug-path entries)
+                      slug-paths (get-slug-paths example-tree)]
+                  (every? (fn [[prev-elem elem next-elem]]
+                            (and prev-elem elem next-elem))
+                        (->> slug-paths
+                             rest
+                             butlast
+                             (take 20) ;; generated tree can be large, don't need to test it all
+                             (map #(doctree/get-neighbour-entries example-tree %)))))))
+
+(tc/defspec last-element-in-tree-has-no-next-entry
+  1
+  (prop/for-all [entries (gen-entries)]
+                (let [example-tree (doctree/add-slug-path entries)
+                      slug-paths (get-slug-paths example-tree)
+                      [prev-elem elem next-elem] (->> (last slug-paths)
+                                                      (doctree/get-neighbour-entries example-tree))]
+                  (and prev-elem elem (nil? next-elem)))))
 
 (comment
+
   (def example-tree (doctree/add-slug-path (gen/sample (spec/gen ::entry) 3)))
 
-  (def test-slug-path (->> example-tree
-                           doctree/flatten*
-                           reverse
-                           first
-                           :attrs
-                           :slug-path))
-  test-slug-path
-  (count (filter #(-> %
-                      :attrs
-                      :slug-path
-                      (= test-slug-path)) (doctree/flatten* example-tree)))
-
-  (->> example-tree
-       second
-       :attrs
-       :slug-path
-       (doctree/get-neighbour-entries example-tree)
-       (every? (complement nil?)))
-
-  (->> example-tree
-       doctree/flatten*
-       reverse
-       first
-       :attrs
-       :slug-path
-       (doctree/get-neighbour-entries example-tree)
-       last
-       nil?))
+  (count (gen/sample (spec/gen ::entry) 3))
+  )


### PR DESCRIPTION
This should help to rid us of a sporadic test failure - and if a failure recurs we'll now be able to reproduce it.