### PR TITLE
Add retries to maven fetches.

### DIFF
--- a/src/cljdoc/util/with_retries.clj
+++ b/src/cljdoc/util/with_retries.clj
@@ -1,0 +1,34 @@
+(ns cljdoc.util.with-retries)
+
+(def ^:dynamic *default-delay* 250)
+
+(defn do-retryable
+  [{:keys [attempt attempts retry-on delay on-failure on-retry]
+    :or {attempt 1}
+    :as opts} retryable-fn]
+  (try
+    {::value (retryable-fn)}
+    (catch Exception e
+      (if (and (some #(instance? % e) retry-on)
+               (< attempt attempts))
+        (do
+          (Thread/sleep (* attempt delay))
+          (on-retry e)
+          #(do-retryable (assoc opts :attempt (inc attempt)) retryable-fn))
+        (do
+          (on-failure e)
+          nil)))))
+
+(defmacro with-retries
+  [{:keys [attempts retry-on delay on-failure on-retry]
+    :or {attempts 3
+         retry-on [Exception]
+         on-retry (fn [_])
+         delay *default-delay*
+         on-failure #(throw %)}}
+   & retryable-body]
+  `(::value (trampoline do-retryable ~{:attempts attempts
+                                       :retry-on retry-on
+                                       :on-retry on-retry
+                                       :delay delay
+                                       :on-failure on-failure} #(do ~@retryable-body))))

--- a/test/cljdoc/util/with_retries_test.clj
+++ b/test/cljdoc/util/with_retries_test.clj
@@ -1,0 +1,51 @@
+(ns cljdoc.util.with-retries-test
+  (:require [cljdoc.util.with-retries :as wr]
+            [clojure.test :as t]))
+
+(defn ->call-counting-fn
+  [return-value]
+  (let [call-count (atom 0)]
+    (fn [& args]
+      (if (= (first args) :call-count)
+        @call-count
+        (do
+          (swap! call-count inc)
+          return-value)))))
+
+(t/deftest with-retries-test
+  (binding [wr/*default-delay* 1]
+    (t/testing "does not retry bodies that succeed"
+      (let [f (->call-counting-fn :value)]
+        (wr/with-retries {} (f))
+        (t/is (= 1 (f :call-count)))))
+    (t/testing "returns the body's return value"
+      (let [f (->call-counting-fn :value)]
+        (t/is (= :value (wr/with-retries {} (f))))))
+    (t/testing "retries bodies that fail, re-raising the exception by default"
+      (let [f (->call-counting-fn :value)]
+        (t/is (thrown? Exception (wr/with-retries {}
+                                   (f)
+                                   (throw (Exception. "oops")))))
+        (t/is (= 3 (f :call-count)))))
+    (t/testing "calls a function on retry"
+      (let [on-retry (->call-counting-fn :retry)]
+        (t/is (thrown? Exception (wr/with-retries {:on-retry on-retry}
+                                   (throw (Exception. "oops")))))
+        (t/is (= 2 (on-retry :call-count)))))
+    (t/testing "calls a function on failure and returns nil"
+      (let [on-failure (->call-counting-fn :retry)]
+        (t/is (nil? (wr/with-retries {:on-failure on-failure}
+                      (throw (Exception. "oops")))))
+        (t/is (= 1 (on-failure :call-count)))))
+    (t/testing "can retry on a specific list of exception types"
+      (let [retry-on [ArithmeticException]
+            f1 (->call-counting-fn :f1)
+            f2 (->call-counting-fn :f2)]
+        (t/is (thrown? Exception (wr/with-retries {:retry-on retry-on}
+                                   (f1)
+                                   (throw (Exception. "oops")))))
+        (t/is (= 1 (f1 :call-count)))
+        (t/is (thrown? ArithmeticException (wr/with-retries {:retry-on retry-on}
+                                             (f2)
+                                             (/ 1 0))))
+        (t/is (= 3 (f2 :call-count)))))))


### PR DESCRIPTION
The artifact indexer was failing for me every time it ran. The maven
servers kept giving us back 429 responses which mean we should back
off on our request rate a little.

So for the implementation I went to add retries with backoff and
discovered that we're using io/reader with a url to fetch from maven.
Since there's no way to get a response map and handle this another way
we need to catch the exception and retry the operation.

There are libraries we could pull in to catch exceptions and retry
operations but they're all a little overcomplicated in their own way.
Given how simple of a need we have it seemed a good idea to write it
ourselves. If our needs grow then it's probably a good idea to pull
in a library instead.