### PR TITLE
Fix bb.edn so clojure-lsp doesn't crash.

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,3 +1,3 @@
-{:paths [script]
+{:paths ["script"]
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "35ed39645038e81b42cb15ed6753b8462e60a06d"}}}


### PR DESCRIPTION
The most recently released version clojure-lsp has an issue with paths
being symbols even though babashka allows them. See link.

https://github.com/clojure-lsp/clojure-lsp/issues/507