### PR TITLE
Retry maven fetches with clj-http-lite.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -43,6 +43,7 @@
         org.apache.lucene/lucene-core {:mvn/version "8.1.1"}
         org.apache.lucene/lucene-analyzers-common {:mvn/version "8.1.1"}
         org.apache.lucene/lucene-queryparser {:mvn/version "8.1.1"}
+        robert/bruce {:mvn/version "0.8.0"}
 
         ;; These deps are dependencies of shared-utils and are
         ;; duplicated in the global modules/shared-utils/deps.edn,

--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -80,15 +80,10 @@
   [{:keys [artifact-id group-id], [version] :versions}]
   (let [g-path (str/replace group-id "." "/")
         url (str "https://search.maven.org/remotecontent?filepath=" g-path "/" artifact-id "/" version "/" artifact-id "-" version ".pom")]
-    (rb/try-try-again
-     {:sleep 500
-      :decay :double
-      :tries 3
-      :catch Throwable}
-     #(->> (fetch-body url)
-           line-seq
-           (some (fn [l] (re-find #"<description>(.*)</description>" l)))
-           second))))
+    (->> (fetch-body url)
+         line-seq
+         (some (fn [l] (re-find #"<description>(.*)</description>" l)))
+         second)))
 
 (defn add-description! [{a :artifact-id, g :group-id :as artifact}]
   (assoc artifact

--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -7,7 +7,8 @@
    [clojure.java.io :as io]
    [clj-http.lite.client :as http]
    [clojure.tools.logging :as log]
-   [cheshire.core :as json])
+   [cheshire.core :as json]
+   [robert.bruce :as rb])
   (:import (org.apache.lucene.analysis.standard StandardAnalyzer)
            (org.apache.lucene.index IndexWriterConfig IndexWriterConfig$OpenMode IndexWriter Term IndexOptions)
            (org.apache.lucene.document Document StringField Field$Store TextField FieldType Field)
@@ -35,13 +36,25 @@
 (comment
   (reset! maven-grp-version-counts nil))
 
-(defn fetch-json [url]
+(defn fetch-body [url]
   (try
-    (with-open [in (io/reader url)]
-      (json/parse-stream in keyword))
+    (rb/try-try-again
+     {:sleep 500
+      :decay :double
+      :tries 3
+      :catch Throwable}
+     #(-> url
+          (http/get {:as :stream :throw-exceptions true})
+          :body
+          io/input-stream
+          io/reader))
     (catch Exception e
       (log/info e "Failed to download artifacts from url")
       nil)))
+
+(defn fetch-json [url]
+  (when-let [body (fetch-body url)]
+    (json/parse-stream body keyword)))
 
 (defn fetch-maven-docs
   "Fetch documents matching the query from Maven Central; supports pagination."
@@ -67,9 +80,14 @@
   [{:keys [artifact-id group-id], [version] :versions}]
   (let [g-path (str/replace group-id "." "/")
         url (str "https://search.maven.org/remotecontent?filepath=" g-path "/" artifact-id "/" version "/" artifact-id "-" version ".pom")]
-    (with-open [in (io/reader url)]
-      (->> (line-seq in)
-           (some #(re-find #"<description>(.*)</description>" %))
+    (rb/try-try-again
+     {:sleep 500
+      :decay :double
+      :tries 3
+      :catch Throwable}
+     #(->> (fetch-body url)
+           line-seq
+           (some (fn [l] (re-find #"<description>(.*)</description>" l)))
            second))))
 
 (defn add-description! [{a :artifact-id, g :group-id :as artifact}]
@@ -262,9 +280,11 @@
   ([^String index-dir] (download-and-index! index-dir false))
   ([^String index-dir force?]
    (log/info "Download & index starting...")
-   (index! index-dir (into
-                      (load-clojars-artifacts force?)
-                      (load-maven-central-artifacts force?)))))
+   (let [result (index! index-dir (into
+                                   (load-clojars-artifacts force?)
+                                   (load-maven-central-artifacts force?)))]
+     (log/info "Finished downloading & indexing.")
+     result)))
 
 (defn index-artifact [^String index-dir artifact]
   (index! index-dir [artifact]))


### PR DESCRIPTION
The artifact indexer was failing for me every time it ran. The maven
servers kept giving us back 429 responses which mean we should back
off on our request rate a little.

So for the implementation I went to add retries with backoff and
discovered that we're using with-open with io/reader on a url to pull
docs from maven. This is less than ideal and we have clj-http-lite
already in the project so it makes sense to switch to that.

This change moves to clj-http-lite and adds robert-bruce for retrying
with backoff on exceptions when requests fail. Now download and
indexing doesn't fall over!