### PR TITLE
Bump retries of maven requests up to 10.

### DIFF
--- a/src/cljdoc/server/search/artifact_indexer.clj
+++ b/src/cljdoc/server/search/artifact_indexer.clj
@@ -41,7 +41,7 @@
     (rb/try-try-again
      {:sleep 500
       :decay :double
-      :tries 3
+      :tries 10
       :catch Throwable}
      #(-> url
           (http/get {:as :stream :throw-exceptions true})


### PR DESCRIPTION
When I use `./script/cljdoc run` the initial indexing run fails.
Bumping the retries up to 5 makes it work but really we don't want
this to fail in other odd situations and so I'm bumping it way up to 10
tries.