### PR TITLE
remove uneccessary CURRENT and old /jump docs

### DIFF
--- a/doc/userguide/faq.md
+++ b/doc/userguide/faq.md
@@ -36,12 +36,14 @@ Sure thing! cljdoc provides badges that will show the latest release
 version as well as an endpoint that redirects to it.
 
 - Badge URL: https://cljdoc.org/badge/re-frame
-- Redirect URL: https://cljdoc.org/jump/release/re-frame
+- Redirect URL: https://cljdoc.org/d/re-frame
+
+In this case `re-frame` is sufficient because the group and artifact ID are the same. If your group and artifact ID differ, provide both, e.g. `/d/metosin/malli`
 
 Using it in a Markdown file may look like this:
 
 ```markdown
-[![](https://cljdoc.org/badge/re-frame)](https://cljdoc.org/jump/release/re-frame)
+[![](https://cljdoc.org/badge/re-frame)](https://cljdoc.org/d/re-frame)
 ```
 
 # How to update documentation?

--- a/doc/userguide/for-library-authors.adoc
+++ b/doc/userguide/for-library-authors.adoc
@@ -16,7 +16,7 @@ For basic docs to be available you don't have to do anything at all. cljdoc will
 [source,sh]
 ----
 # This will redirect to the latest released version
-https://cljdoc.org/d/$group-id/$artifact-id/CURRENT
+https://cljdoc.org/d/$group-id/$artifact-id
 ----
 
 [source,sh]
@@ -29,17 +29,17 @@ In full it may look like this for markdown:
 
 [source,markdown]
 ----
-[![cljdoc badge](https://cljdoc.org/badge/manifold/manifold)](https://cljdoc.org/d/manifold/manifold/CURRENT)
+[![cljdoc badge](https://cljdoc.org/badge/manifold/manifold)](https://cljdoc.org/d/manifold/manifold)
 ----
 
 or this for asciidoctor:
 
 [source,asciidoctor]
 ----
-image::https://cljdoc.org/badge/manifold/manifold[cljdoc badge, link=https://cljdoc.org/d/manifold/manifold/CURRENT]
+image::https://cljdoc.org/badge/manifold/manifold[cljdoc badge, link=https://cljdoc.org/d/manifold/manifold]
 ----
 
-link:https://cljdoc.org/d/manifold/manifold/CURRENT[image:https://cljdoc.org/badge/manifold/manifold[cljdoc badge]]
+link:https://cljdoc.org/d/manifold/manifold[image:https://cljdoc.org/badge/manifold/manifold[cljdoc badge]]
 
 IMPORTANT: In the cljdoc URLs above `$group-id` and `$artifact-id` always refer to the Clojars/Maven group/artifact ID, not e.g. GitHub's owner/repo names.
 


### PR DESCRIPTION
This came up [in Slack](https://clojurians.slack.com/archives/C8V0BQ0M6/p1630341077012500) as potentially confusing. `CURRENT` isn't actually needed unless you want to link to a specific document/namespace and so we can just remove it. Same goes for the old `/jump` routes which I think don't solve any real purpose over the redirects we do with just `/d/project-id` or `/d/group-id/artifact-id`.
