### PR TITLE
Add keyboard shortcuts for prev/next page navigation to help (#419)

### DIFF
--- a/src/cljdoc/render/meta.clj
+++ b/src/cljdoc/render/meta.clj
@@ -1,12 +1,20 @@
 (ns cljdoc.render.meta
   (:require [cljdoc.render.layout :as layout]))
 
+(defn- shortcut [key desc]
+  [:tr
+   [:td.pv2.pr4.pr7-ns.bb.b--black-20.nowrap key]
+   [:td.pv2.pr1.bb.b--black-20 desc]])
+
 (defn shortcuts []
   (->> [:div
         (layout/top-bar-generic)
         [:div.pa4-ns.pa2
          [:h1 "Shortcuts"]
-         [:div
-          [:p.fl.w-10.pa2.dib "⌘ K"]
-          [:p.fl.w-third.pa2.dib "Jump to recently viewed docs"]]]]
+         [:div.pa2.overflow-auto
+          [:table.f6.w-100.mw6 {:cellspacing 0}
+           [:tbody.lh-copy
+            (shortcut "⌘ K" "Jump to recently viewed docs")
+            (shortcut "←" "Move to previous page")
+            (shortcut "→" "Move to next page")]]]]]
        (layout/page {:title "shortcuts"})))


### PR DESCRIPTION
Hi, this PR is supposed to resolve https://github.com/cljdoc/cljdoc/issues/419

The PR https://github.com/cljdoc/cljdoc/pull/414 already introduced two new keyboard shortcuts:
1) Arrow Left - Navigate to previous page
2) Arrow Right - Navigate to next page

Both shortcuts are now included in the "Keyboard shortcuts" help section.
I changed the view to a Tachyons table layout for this.