### PR TITLE
Fix raw docstring toggle in offline bundles #412

### DIFF
--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -2,6 +2,10 @@ function isNSPage(): boolean {
   return !!document.querySelector(".ns-page");
 }
 
+function isNSOfflinePage(): boolean {
+  return !!document.querySelector("ns-offline-page");
+}
+
 function isProjectDocumentationPage(): boolean {
   let pathSegs = window.location.pathname.split("/");
   return pathSegs.length >= 5 && pathSegs[1] == "d";
@@ -143,6 +147,7 @@ export {
   restoreSidebarScrollPos,
   toggleMetaDialog,
   isNSPage,
+  isNSOfflinePage,
   isProjectDocumentationPage,
   addPrevNextPageKeyHandlers
 };

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -5,6 +5,7 @@ import { MobileNav } from "./mobile";
 import { Navigator } from "./navigator";
 import {
   isNSPage,
+  isNSOfflinePage,
   isProjectDocumentationPage,
   initSrollIndicator,
   initToggleRaw,
@@ -39,6 +40,10 @@ navigatorNode && render(<Navigator />, navigatorNode);
 
 if (isNSPage()) {
   initSrollIndicator();
+  initToggleRaw();
+}
+
+if (isNSOfflinePage()) {
   initToggleRaw();
 }
 

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -86,7 +86,8 @@
                     {:style {:top "52px"}}
                     [:div.mw7.center.pa2.pb4
                      contents]]]
-                  (->> (assets/offline-js :highlightjs)
+                  (->> (concat ["assets/js/index.js"]
+                               (assets/offline-js :highlightjs))
                        (adjust-refs sub-page?)
                        (apply hiccup.page/include-js))
                   (layout/highlight-js-customization)
@@ -132,7 +133,7 @@
 (defn- ns-page [ns defs fix-opts]
   (let [ns-name (platf/get-field ns :name)
         render-wiki-link (api/render-wiki-link-fn ns-name #(str % ".html"))]
-    [:div
+    [:div.ns-offline-page
      [:h1 ns-name]
      (api/render-doc ns render-wiki-link fix-opts)
      (for [def defs]
@@ -171,6 +172,8 @@
     (reduce
      into
      [[["assets/cljdoc.css" (io/file (io/resource "public/cljdoc.css"))]]
+      [["assets/js/index.js" (io/file "resources-compiled/public/js/index.js")]]
+      [["assets/js/index.js.map" (io/file "resources-compiled/public/js/index.js.map")]]
       (assets/offline-assets :tachyons)
       (assets/offline-assets :highlightjs)
       [["index.html" (->> (index-page cache-bundle fix-opts)


### PR DESCRIPTION
There were 2 causes why it was not working:
- cljdocs's `assets/js/index.js` was not included in offline bundles
- raw toggles are not initialized since the `.ns-page` css class was missing in offline bundles

Solution:
- `assets/js/index.js` is included in the offline bundle (using the same as approach as `assets/cljdoc.css` which is already included)
- Adding `.ns-page` did not work. If it is set the Scroll Indicators are initialized as well which are not available in the offline bundle. Therefore a new class `.ns-offline-page` was added which initializes the raw toggle but not the scroll indicators.