### PR TITLE
Improve shortcut table styles

### DIFF
--- a/src/cljdoc/render/meta.clj
+++ b/src/cljdoc/render/meta.clj
@@ -2,19 +2,20 @@
   (:require [cljdoc.render.layout :as layout]))
 
 (defn- shortcut [key desc]
-  [:tr
-   [:td.pv2.pr4.pr7-ns.bb.b--black-20.nowrap key]
-   [:td.pv2.pr1.bb.b--black-20 desc]])
+  [:tr.striped--near-white
+   [:td.pv2.pr3.pl3.bb.b--black-20.nowrap key]
+   [:td.pv2.pr3.pl3.bb.b--black-20 desc]])
 
 (defn shortcuts []
   (->> [:div
         (layout/top-bar-generic)
-        [:div.pa4-ns.pa2
-         [:h1 "Shortcuts"]
-         [:div.pa2.overflow-auto
-          [:table.f6.w-100.mw6 {:cellspacing 0}
-           [:tbody.lh-copy
-            (shortcut "⌘ K" "Jump to recently viewed docs")
-            (shortcut "←" "Move to previous page")
-            (shortcut "→" "Move to next page")]]]]]
+        [:div.pa4-ns.pa2.w-auto.flex.justify-center
+         [:div
+          [:h1 "Shortcuts"]
+          [:div.overflow-auto
+           [:table.f6.w-auto.mw6.ba.br2.b--black-10 {:cellspacing 0}
+            [:tbody.lh-copy
+             (shortcut "⌘ K" "Jump to recently viewed docs")
+             (shortcut "←" "Move to previous page")
+             (shortcut "→" "Move to next page")]]]]]]
        (layout/page {:title "shortcuts"})))

--- a/src/cljdoc/render/meta.clj
+++ b/src/cljdoc/render/meta.clj
@@ -3,8 +3,8 @@
 
 (defn- shortcut [key desc]
   [:tr.striped--near-white
-   [:td.pv2.pr3.pl3.bb.b--black-20.nowrap key]
-   [:td.pv2.pr3.pl3.bb.b--black-20 desc]])
+   [:td.pv2.pr2.pl3.bb.b--black-20.nowrap.tr key]
+   [:td.pv2.pr3.pl2.bb.b--black-20 desc]])
 
 (defn shortcuts []
   (->> [:div


### PR DESCRIPTION
Tables were a great addition but we can tighten up the styles a bunch.

Before:

![20210928103711-rj8xb-shortcuts](https://user-images.githubusercontent.com/130/135119422-ffbca1d5-8899-456d-a520-d556ebaf27a1.png)

After:

![20210928103402-c2ycp-shortcuts](https://user-images.githubusercontent.com/130/135119281-6b10ad8c-a346-4eff-8651-b2873970e19f.png)
