### PR TITLE
Add previously visited doc links on homepage

### DIFF
--- a/js/index.tsx
+++ b/js/index.tsx
@@ -13,6 +13,7 @@ import {
   toggleMetaDialog,
   addPrevNextPageKeyHandlers
 } from "./cljdoc";
+import { initRecentDocLinks } from "./recent-doc-links";
 
 export type SidebarScrollPos = { page: string; scrollTop: number };
 
@@ -54,6 +55,10 @@ if (isProjectDocumentationPage()) {
   addPrevNextPageKeyHandlers();
 }
 
+const docLinks = document.querySelector("#doc-links");
+if (docLinks) {
+  initRecentDocLinks(docLinks);
+}
 window.onbeforeunload = function () {
   var sidebar = Array.from(document.querySelectorAll(".js--main-sidebar"))[0];
   if (sidebar) {

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -1,0 +1,32 @@
+import { h, render } from "preact";
+import { CljdocProject } from "./switcher";
+
+export const initRecentDocLinks = (docLinks: Element) => {
+  const previouslyOpened: Array<CljdocProject> = JSON.parse(
+    localStorage.getItem("previouslyOpened") || "[]"
+  );
+
+  const originalLinks: Array<String> = [];
+
+  for (const child of Array.from(docLinks.children)) {
+    originalLinks.push(child.innerHTML);
+  }
+
+  previouslyOpened
+    .reverse()
+    .slice(0, 3)
+    .forEach(
+      ({ group_id, artifact_id, version }, i) =>
+        !originalLinks.includes(artifact_id) &&
+        render(
+          <a
+            className="link blue nowrap"
+            href={`/d/${group_id}/${artifact_id}/${version}`}
+          >
+            {artifact_id}
+          </a>,
+          docLinks,
+          docLinks.children[i]
+        )
+    );
+};

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -6,13 +6,14 @@ const dayInMs = 86400000;
 
 const lastViewedMessage = (last_viewed: string | undefined) => {
   if (last_viewed) {
-    const lastViewedDate = new Date(Date.parse(last_viewed)).getTime();
-    const viewedToday = new Date().getTime() - lastViewedDate < dayInMs;
+    const lastViewedDate = new Date(Date.parse(last_viewed));
+    const viewedToday =
+      new Date().getTime() - lastViewedDate.getTime() < dayInMs;
     return (
       " last viewed " +
       (viewedToday
         ? "today"
-        : formatDistanceToNowStrict(new Date(Date.parse(last_viewed)), {
+        : formatDistanceToNowStrict(lastViewedDate, {
             addSuffix: true,
             unit: "day"
           }))

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -28,6 +28,10 @@ export const initRecentDocLinks = (docLinks: Element) => {
     localStorage.getItem("previouslyOpened") || "[]"
   );
   if (previouslyOpened.length > 0) {
+    if (previouslyOpened.length >= 3) {
+      const examples = document.querySelector("#examples");
+      if (examples) examples.remove();
+    }
     render(
       <p className="mt4 mb0">
         <div className="fw5">Pick up where you left off:</div>

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -43,10 +43,10 @@ export const initRecentDocLinks = (docLinks: Element) => {
                     href={`/d/${group_id}/${artifact_id}/${version}`}
                   >
                     {artifact_id}
+                    <span className="gray f6">
+                      {lastViewedMessage(last_viewed)}
+                    </span>
                   </a>
-                  <span className="gray f6">
-                    {lastViewedMessage(last_viewed)}
-                  </span>
                 </li>
               );
             })}

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -1,32 +1,57 @@
 import { h, render } from "preact";
 import { CljdocProject } from "./switcher";
+import { formatDistanceToNowStrict } from "date-fns";
+
+const dayInMs = 86400000;
+
+const lastViewedMessage = (last_viewed: string | undefined) => {
+  if (last_viewed) {
+    const lastViewedDate = new Date(Date.parse(last_viewed)).getTime();
+    const viewedToday = new Date().getTime() - lastViewedDate < dayInMs;
+    return (
+      " last viewed " +
+      (viewedToday
+        ? "today"
+        : formatDistanceToNowStrict(new Date(Date.parse(last_viewed)), {
+            addSuffix: true,
+            unit: "day"
+          }))
+    );
+  } else {
+    return "";
+  }
+};
 
 export const initRecentDocLinks = (docLinks: Element) => {
   const previouslyOpened: Array<CljdocProject> = JSON.parse(
     localStorage.getItem("previouslyOpened") || "[]"
   );
-
-  const originalLinks: Array<String> = [];
-
-  for (const child of Array.from(docLinks.children)) {
-    originalLinks.push(child.innerHTML);
-  }
-
-  previouslyOpened
-    .reverse()
-    .slice(0, 3)
-    .forEach(
-      ({ group_id, artifact_id, version }, i) =>
-        !originalLinks.includes(artifact_id) &&
-        render(
-          <a
-            className="link blue nowrap"
-            href={`/d/${group_id}/${artifact_id}/${version}`}
-          >
-            {artifact_id}
-          </a>,
-          docLinks,
-          docLinks.children[i]
-        )
+  if (previouslyOpened.length > 0) {
+    render(
+      <p className="mt4 mb0">
+        <div className="fw5">Pick up where you left off:</div>
+        <ul className="mv0 pl0 list">
+          {previouslyOpened
+            .reverse()
+            .slice(0, 3)
+            .map(({ group_id, artifact_id, version, last_viewed }) => {
+              return (
+                <li className="mr1 pt2">
+                  <a
+                    className="link blue nowrap"
+                    href={`/d/${group_id}/${artifact_id}/${version}`}
+                  >
+                    {artifact_id}
+                  </a>
+                  <span className="gray f6">
+                    {lastViewedMessage(last_viewed)}
+                  </span>
+                </li>
+              );
+            })}
+        </ul>
+      </p>,
+      docLinks
     );
+  }
 };

--- a/js/search.tsx
+++ b/js/search.tsx
@@ -128,7 +128,7 @@ class SearchInput extends Component<SearchInputProps> {
     return (
       <input
         autofocus={true}
-        placeholder="NEW! Jump to docs..."
+        placeholder="Jump to docs..."
         className="pa2 w-100 br1 border-box b--blue ba input-reset"
         onFocus={(_e: Event) => props.focus()}
         onBlur={(_e: Event) => setTimeout(_ => props.unfocus(), 200)}

--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -7,6 +7,7 @@ export type CljdocProject = {
   artifact_id: string;
   version: string;
   project_id?: string;
+  last_viewed?: string;
 };
 
 function isSameProject(p1: CljdocProject, p2: CljdocProject): boolean {
@@ -34,6 +35,7 @@ function trackProjectOpened() {
     );
     // remove identical values
     previouslyOpened = previouslyOpened.filter(p => !isSameProject(p, project));
+    project.last_viewed = new Date().toUTCString();
     previouslyOpened.push(project);
     // truncate from the front to not have localstorage grow too large
     if (previouslyOpened.length > maxTrackedCount) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2351,6 +2351,11 @@
         "whatwg-url": "^7.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+      "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "npx tsc --watch"
   },
   "dependencies": {
+    "date-fns": "^2.24.0",
     "fuzzysort": "^1.1.4",
     "preact": "^10.5.14"
   },

--- a/src/cljdoc/render/home.clj
+++ b/src/cljdoc/render/home.clj
@@ -28,7 +28,7 @@
           [:img {:src "/cljdoc-logo.svg" :alt "cljdoc logo" :width "150px"}]]
          [:p.f2-ns.f3.mv3.w-90-l.lh-copy tagline]
          (search/search-form (-> context :request :query-params :q))
-         [:p.lh-copy "Read " [:a.link.blue {:href (util/github-url :rationale)} "the rationale"]
+         [:p#examples.lh-copy "Read " [:a.link.blue {:href (util/github-url :rationale)} "the rationale"]
           " or check out some examples: "
           [:a.link.blue.nowrap {:href "/d/rum/rum/CURRENT"} "rum"] ", "
           [:a.link.blue.nowrap {:href "/d/lambdaisland/kaocha/CURRENT"} "kaocha"] ", "

--- a/src/cljdoc/render/home.clj
+++ b/src/cljdoc/render/home.clj
@@ -30,9 +30,10 @@
          (search/search-form (-> context :request :query-params :q))
          [:p.lh-copy "Read " [:a.link.blue {:href (util/github-url :rationale)} "the rationale"]
           " or check out some examples: "
-          [:a.link.blue.nowrap {:href "/d/rum/rum/CURRENT"} "rum"] ", "
-          [:a.link.blue.nowrap {:href "/d/lambdaisland/kaocha/CURRENT"} "kaocha"] ", "
-          [:a.link.blue.nowrap {:href "/d/metosin/reitit/CURRENT"} "reitit"] "."]]
+          [:span#doc-links
+           [:a.link.blue.nowrap {:href "/d/rum/rum/CURRENT"} "rum"] ", "
+           [:a.link.blue.nowrap {:href "/d/lambdaisland/kaocha/CURRENT"} "kaocha"] ", "
+           [:a.link.blue.nowrap {:href "/d/metosin/reitit/CURRENT"} "reitit"]] "."]]
 
         [:div.mt5-ns.bg-white
          (into [:div.dt-l.dt--fixed.bb.bt.b--light-gray.lh-copy]

--- a/src/cljdoc/render/home.clj
+++ b/src/cljdoc/render/home.clj
@@ -30,10 +30,10 @@
          (search/search-form (-> context :request :query-params :q))
          [:p.lh-copy "Read " [:a.link.blue {:href (util/github-url :rationale)} "the rationale"]
           " or check out some examples: "
-          [:span#doc-links
-           [:a.link.blue.nowrap {:href "/d/rum/rum/CURRENT"} "rum"] ", "
-           [:a.link.blue.nowrap {:href "/d/lambdaisland/kaocha/CURRENT"} "kaocha"] ", "
-           [:a.link.blue.nowrap {:href "/d/metosin/reitit/CURRENT"} "reitit"]] "."]]
+          [:a.link.blue.nowrap {:href "/d/rum/rum/CURRENT"} "rum"] ", "
+          [:a.link.blue.nowrap {:href "/d/lambdaisland/kaocha/CURRENT"} "kaocha"] ", "
+          [:a.link.blue.nowrap {:href "/d/metosin/reitit/CURRENT"} "reitit"] "."]
+         [:p#doc-links.mv0]]
 
         [:div.mt5-ns.bg-white
          (into [:div.dt-l.dt--fixed.bb.bt.b--light-gray.lh-copy]

--- a/src/cljdoc/render/search.clj
+++ b/src/cljdoc/render/search.clj
@@ -5,11 +5,7 @@
   ([] (search-form ""))
   ([search-terms]
    [:div.w-90.mb4
-    [:div#cljdoc-search {:data-initial-value search-terms}]
-    [:p.bg-washed-yellow.ba.b--yellow.ph3.pv2.br2.f6.lh-copy
-     "New search - please report problems and bad results in the "
-     [:a.link {:href "https://github.com/cljdoc/cljdoc/issues/308"} "search improvements issue"]
-     " to help us make it better!"]]))
+    [:div#cljdoc-search {:data-initial-value search-terms}]]))
 
 (defn search-page [context]
   (->> [:div


### PR DESCRIPTION
There's already an abandoned PR for this issue #399 so I thought I'd give it another try. I kept only the first commit of the old PR since merging the complete old PR  would be more effort.

After the page is loaded existing example links are replaced with the most recently visited doc links. If one of the initial example links is used it get's ignored.

Fixes #282