### PR TITLE
Fix broken image links in SNAPSHOT releases (#426)

### DIFF
--- a/src/cljdoc/analysis/git.clj
+++ b/src/cljdoc/analysis/git.clj
@@ -59,7 +59,7 @@
       ;; Stuff that depends on a SCM url being present
       (let [repo        (git/->repo git-dir)
             version-tag (git/version-tag repo version)
-            default-branch (.getFullBranch (.getRepository repo))
+            default-branch (.getBranch (.getRepository repo))
             revision    (or pom-revision
                             (:name version-tag)
                             (when (.endsWith version "-SNAPSHOT")


### PR DESCRIPTION
This PR attempts to fix a bug in the git analysis step that causes broken image links in SNAPSHOT releases.

I added a detailed bug description as comment on the ticket: https://github.com/cljdoc/cljdoc/issues/426#issuecomment-933734109