### PR TITLE
home: mention dash, zeal right here

### DIFF
--- a/src/cljdoc/render/home.clj
+++ b/src/cljdoc/render/home.clj
@@ -47,7 +47,7 @@
                       :link-text "→ Articles"
                       :link (util/github-url :userguide/articles)}
                      {:title "Offline Docs"
-                      :text "Download documentation for any project in a zip file for easy offline use while travelling or swinging in your hammock."
+                      :text "Download documentation for any project in a zip file for easy offline use while travelling or swinging in your hammock. Supports Dash and Zeal."
                       :link-text "→ Offline Docs"
                       :link (util/github-url :userguide/offline-docs)}
                      {:title "Specs, Examples, ..."


### PR DESCRIPTION
I believe most people have little use for downloading .zip of docs but there is a fair number of users of Dash and Zeal so it is valuable to mention them right on the home page as they might not guess that offline docs are about more than just the zip download.