### PR TITLE
Make docker Makefile a bit less dev-friendly

### DIFF
--- a/ops/docker/Makefile
+++ b/ops/docker/Makefile
@@ -17,7 +17,7 @@ clean:
 cljdoc-build: ../../target/cljdoc.zip
 	unzip ../../target/cljdoc.zip -d cljdoc-build/
 
-image: clean cljdoc-build
+image: cljdoc-build
 	cp Dockerfile cljdoc-build/
 	docker build --no-cache -t $(DOCKER_IMAGE):$(CLJDOC_VERSION) cljdoc-build/ && \
           docker tag $(DOCKER_IMAGE):$(CLJDOC_VERSION) $(DOCKER_IMAGE):latest


### PR DESCRIPTION
My change to always rebuild does not jive with
our CircleCI workflow.

The build job packages up cljdoc for the
publish-docker job.

My change to force a full clean does not work
for this strategy. The publish-docker job
does not expect to package up cljdoc.