### PR TITLE
Upgrade to jsoup v1.14.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,7 @@
         io.sentry/sentry-logback {:mvn/version "1.7.25"},
         com.jcraft/jsch.agentproxy.connector-factory {:mvn/version "0.0.9"},
         org.clojure/core.match {:mvn/version "0.3.0"},
-        org.jsoup/jsoup {:mvn/version "1.12.1"},
+        org.jsoup/jsoup {:mvn/version "1.14.3"},
         org.xerial/sqlite-jdbc {:mvn/version "3.28.0"},
         com.layerware/hugsql {:mvn/version "0.4.9"}
         com.taoensso/tufte {:mvn/version "2.0.1"}

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -115,6 +115,12 @@
                     (routes/url-for :artifact/doc :path-params))]))
        (into {})))
 
+(defn- parse-html [html-str]
+  (let [doc (Jsoup/parse html-str)
+        props (.outputSettings doc)]
+    (.prettyPrint props false)
+    doc))
+
 (defn fix
   "Rewrite references in HTML produced from rendering markdown.
 
@@ -141,7 +147,7 @@
     * `:uri-map` - map of relative scm paths to cljdoc doc slugs (or for offline bundles html files)
     * `:scm` - scm-info from bundle used to link to correct SCM file revision"
   [html-str {:keys [scm-file-path target-path scm uri-map] :as _fix-opts}]
-  (let [doc (Jsoup/parse html-str)]
+  (let [doc (parse-html html-str)]
     (doseq [scm-relative-link (->> (.select doc "a")
                                    (map #(.attributes %))
                                    (remove #(= "wikilink" (.get % "data-source")))

--- a/test/cljdoc/util/fixref_test.clj
+++ b/test/cljdoc/util/fixref_test.clj
@@ -18,7 +18,7 @@
   (t/testing "favors git tag representing version, when present, over commit"
     (t/is (= ["<a href=\"https://scm/user/project/blob/v1.2.3/doc/doc.md\" rel=\"nofollow\">my doc</a>"
               "<img src=\"https://scm/user/project/raw/v1.2.3/doc/images/one.png\">"]
-             (fix-result (fixref/fix (str "<a href=\"doc.md\">my doc</a>"
+             (fix-result (fixref/fix (str "<a href=\"doc.md\">my doc</a>\n"
                                           "<img src=\"images/one.png\">")
                                      (assoc-in fix-opts [:scm :tag :name] "v1.2.3"))))))
 
@@ -46,7 +46,7 @@
       (t/is (= ["<a href=\"#!cljdoc-error!ref-must-be-root-relative!\">link text</a>"
                 "<img src=\"#!cljdoc-error!ref-must-be-root-relative!\">"]
                (fix-result
-                (fixref/fix (str "<a href=\"rel/ref/here.md\">link text</a>"
+                (fixref/fix (str "<a href=\"rel/ref/here.md\">link text</a>\n"
                                  "<img src=\"rel/ref/here.png\">")
                             (dissoc fix-opts :scm-file-path)))))))
 
@@ -55,7 +55,7 @@
       (t/is (= ["<a href=\"https://clojure.org\" rel=\"nofollow\">absolute link elsewhere</a>"
                 "<a href=\"http://unsecure.com\" rel=\"nofollow\">absolutely insecure</a>"]
                (fix-result
-                (fixref/fix (str "<a href=\"https://clojure.org\">absolute link elsewhere</a>"
+                (fixref/fix (str "<a href=\"https://clojure.org\">absolute link elsewhere</a>\n"
                                  "<a href=\"http://unsecure.com\">absolutely insecure</a>")
                             fix-opts))))))
 
@@ -64,7 +64,7 @@
       (t/is (= ["<a href=\"/some/path/here\">absolute link to cljdoc</a>"
                 "<a href=\"/another/path\">absolute link to cljdoc.xyz</a>"]
                (fix-result
-                (fixref/fix (str "<a href=\"https://cljdoc.org/some/path/here\">absolute link to cljdoc</a>"
+                (fixref/fix (str "<a href=\"https://cljdoc.org/some/path/here\">absolute link to cljdoc</a>\n"
                                  "<a href=\"https://cljdoc.xyz/another/path\">absolute link to cljdoc.xyz</a>")
                             fix-opts))))))
 
@@ -75,9 +75,9 @@
                 "<a href=\"https://scm/user/project/blob/#SHA#/norm2.adoc\" rel=\"nofollow\">norm2</a>"
                 "<a href=\"https://scm/user/project/blob/#SHA#/../../../norm2.adoc\" rel=\"nofollow\">norm2</a>"]
                (fix-result
-                (fixref/fix (str "<a href=\"down/deeper/to/doc.adoc\">relative link</a>"
-                                 "<a href=\"../upone/norm1.adoc\">norm1</a>"
-                                 "<a href=\"../../norm2.adoc\">norm2</a>"
+                (fixref/fix (str "<a href=\"down/deeper/to/doc.adoc\">relative link</a>\n"
+                                 "<a href=\"../upone/norm1.adoc\">norm1</a>\n"
+                                 "<a href=\"../../norm2.adoc\">norm2</a>\n"
                                  "<a href=\"../../../../../norm2.adoc\">norm2</a>")
                             (assoc fix-opts :scm-file-path "doc/path/doc.adoc"))))))
     (t/testing "when root relative, will point to normalized scm project root"
@@ -85,8 +85,8 @@
                 "<a href=\"https://scm/user/project/blob/#SHA#/root/a/d/doc.md\" rel=\"nofollow\">root relative link</a>"
                 "<a href=\"https://scm/user/project/blob/#SHA#/doc.md\" rel=\"nofollow\">root relative link</a>"]
                (fix-result
-                (fixref/fix (str "<a href=\"/root/relative/doc.md\">root relative link</a>"
-                                 "<a href=\"/root/./././relative/../a/b/c/../../d/doc.md\">root relative link</a>"
+                (fixref/fix (str "<a href=\"/root/relative/doc.md\">root relative link</a>\n"
+                                 "<a href=\"/root/./././relative/../a/b/c/../../d/doc.md\">root relative link</a>\n"
                                  "<a href=\"/root/relative/../../../../../doc.md\">root relative link</a>")
                             fix-opts)))))
     (t/testing "work with sourcehut"
@@ -122,16 +122,16 @@
                 "<img src=\"https://scm/user/project/raw/#SHA#/homages/rel3.png\">"
                 "<img src=\"https://scm/user/project/raw/#SHA#/../../../../../../../../rel4.png\">"]
                (fix-result
-                (fixref/fix (str "<img src=\"rel1.png\">"
-                                 "<img src=\"../../images/rel2.png\">"
-                                 "<img src=\"../../images/../homages/./././rel3.png\">"
+                (fixref/fix (str "<img src=\"rel1.png\">\n"
+                                 "<img src=\"../../images/rel2.png\">\n"
+                                 "<img src=\"../../images/../homages/./././rel3.png\">\n"
                                  "<img src=\"../../../../../../../../../../rel4.png\">")
                             (assoc fix-opts :scm-file-path "doc/path/doc.adoc"))))))
     (t/testing "when root relative, will point point to scm raw ref"
       (t/is (= ["<img src=\"https://scm/user/project/raw/#SHA#/root/relative/image.png\">"
                 "<img src=\"https://scm/user/project/raw/#SHA#/root/relative/.././image.png\">"]
                (fix-result
-                (fixref/fix (str "<img src=\"/root/relative/image.png\">"
+                (fixref/fix (str "<img src=\"/root/relative/image.png\">\n"
                                  "<img src=\"/root/relative/.././image.png\">")
                             (assoc fix-opts :scm-file-path "doc/path/doc.adoc"))))))
     (t/testing "can be svg"


### PR DESCRIPTION
JSoup HTML pretty printing behavior has changed which caused our url
fixup tests to fail.

We don't need JSoup to pretty-print HTML.
So we've turn this feature off.
This makes current tests clearer as input now matches output
wrt to whitespace/newlines.