### PR TITLE
Update dev deps and digest lib

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -5,4 +5,5 @@
            clojure.java.jdbc/with-db-transaction clojure.core/let
            clojure.test.check.clojure-test/defspec clojure.core/def
            clojure.test.check.properties/for-all clojure.core/let}
- :linters {:unused-binding {:exclude-destructured-keys-in-fn-args true}}}
+ :linters {:unused-binding {:exclude-destructured-keys-in-fn-args true}
+           :unresolved-var {:exclude [clj-commons.digest/sha-256]}}}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ resources-compiled
 pom.xml
 test-data/
 /.parcel-cache
+/.lsp

--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,7 @@
         com.vladsch.flexmark/flexmark-ext-wikilink {:mvn/version "0.50.20"}
         org.clojure/java.jdbc {:mvn/version "0.7.9"},
         hiccup/hiccup {:mvn/version "2.0.0-alpha1"},
-        digest/digest {:mvn/version "1.4.9"},
+        org.clj-commons/digest {:mvn/version "1.4.100"},
         integrant/integrant {:mvn/version "0.7.0"},
         org.martinklepsch/clj-http-lite {:mvn/version "0.4.1"}
         org.eclipse.jgit/org.eclipse.jgit {:mvn/version "4.10.0.201712302008-r"},
@@ -59,12 +59,12 @@
          "modules/shared-utils/resources"]
  :aliases {:test
            {:extra-paths ["test"]
-            :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}
-                         org.clojure/test.check {:mvn/version "1.1.0"}}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.60.977"}
+                         org.clojure/test.check {:mvn/version "1.1.1"}}
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2020.09.09"}}
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.01.15"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :cli
@@ -73,7 +73,7 @@
             :main-opts ["-m"  "cljdoc.cli"]}
 
            :code-format
-           {:extra-deps {cljfmt/cljfmt {:mvn/version "0.7.0"}}
+           {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
             :main-opts [ "-m" "cljfmt.main"  "--indents" "./.cljfmt/indentation.edn"]}
 
            :jar-deploy

--- a/modules/deploy/src/cljdoc/deploy.clj
+++ b/modules/deploy/src/cljdoc/deploy.clj
@@ -92,7 +92,7 @@
     (assert (= placed-allocs desired-total) "Not enough allocs placed")
     (assert (not= "failed" status) "Deployment failed")
     (log/infof "%d healthy / %d desired - status: '%s'" healthy-allocs desired-total status)
-    (and (= desired-total healthy-allocs))))
+    (= desired-total healthy-allocs)))
 
 (defn tag-exists?
   "Check if a given tag exists in the DockerHub cljdoc/cljdoc repository."

--- a/modules/shared-utils/src/cljdoc/spec.cljc
+++ b/modules/shared-utils/src/cljdoc/spec.cljc
@@ -67,12 +67,10 @@
         :artifact   ::artifact-entity
         :group      ::group-entity))
 
-
 ;; Cache specific ----------------------------------------------------
 
 ;; Docs-cache: this is intended for a specific
 ;; versioned artifact, e.g. [re-frame 0.10.5]
-
 
 (s/def ::defs (s/coll-of ::def-full :gen-max 2))
 (s/def ::namespaces (s/coll-of map? :gen-max 2))
@@ -101,10 +99,8 @@
   ;; help them to understand the API faster
   (s/keys :req-un [::cache-id ::cache-contents]))
 
-
 ;; codox -------------------------------------------------------------
 ;; A spec for Codox namespace analysis data
-
 
 (s/def :cljdoc.codox.public/name symbol? #_(s/or :a string? :b symbol?))
 (s/def :cljdoc.codox.public/file string?)
@@ -133,9 +129,7 @@
                    :cljdoc.codox.namespace/publics]
           :opt-un [:cljdoc.codox.namespace/doc]))
 
-
 ;; cljdoc.edn ---------------------------------------------------------
-
 
 (s/def :cljdoc.cljdoc-edn/codox
   (s/map-of ::platform (s/coll-of :cljdoc.codox/namespace)))
@@ -146,9 +140,7 @@
   (s/keys :req-un [:cljdoc.cljdoc-edn/codox
                    :cljdoc.cljdoc-edn/pom-str]))
 
-
 ;; grimoire -----------------------------------------------------------
-
 
 (s/def :cljdoc.grimoire/def
   ;; like codox output but without name

--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -41,9 +41,7 @@
   {:deps {'cljdoc/cljdoc-analyzer {:git/url "https://github.com/cljdoc/cljdoc-analyzer.git"
                                    :sha analyzer-version}}})
 
-
 ;; CircleCI AnalysisService -----------------------------------------------------
-
 
 (declare get-circle-ci-build-artifacts get-circle-ci-build poll-circle-ci-build)
 

--- a/src/cljdoc/git_repo.clj
+++ b/src/cljdoc/git_repo.clj
@@ -3,7 +3,7 @@
             [clojure.tools.logging :as log]
             [clojure.string :as string]
             [clojure.spec.alpha :as s]
-            [digest :as digest])
+            [clj-commons.digest :as digest])
   (:import  (org.eclipse.jgit.lib RepositoryBuilder
                                   ObjectIdRef$PeeledNonTag
                                   ObjectIdRef$PeeledTag

--- a/src/cljdoc/platforms.clj
+++ b/src/cljdoc/platforms.clj
@@ -39,16 +39,16 @@
 
         :else
         (first uniq-vals))))
-  (get-field [this k platf]
+  (get-field [_this k platf]
     (assert (contains? #{"clj" "cljs"} platf) (format "unknown platform: %s" platf))
     (-> (filter #(= platf (:platform %)) platforms)
         (first)
         (get k)))
-  (varies? [this k]
+  (varies? [_this k]
     (< 1 (count (set (map k platforms)))))
-  (platforms [this]
+  (platforms [_this]
     (set (map :platform platforms)))
-  (all-vals [this k]
+  (all-vals [_this k]
     (keep k platforms)))
 
 (defn multiplatform? [x]

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -53,13 +53,13 @@
     (sql/update! db-spec "builds" (cond-> {:error error}
                                     e (assoc :error_info_map (nippy/freeze (Throwable->map e))))
                  ["id = ?" build-id]))
-  (api-imported! [this build-id namespaces-count]
+  (api-imported! [_this build-id namespaces-count]
     (sql/update! db-spec
                  "builds"
                  {:api_imported_ts (now)
                   :namespaces_count namespaces-count}
                  ["id = ?" build-id]))
-  (git-completed! [this build-id {:keys [scm-url error commit] :as git-result}]
+  (git-completed! [_this build-id {:keys [scm-url error commit] :as git-result}]
     (sql/update! db-spec
                  "builds"
                  {:scm_url scm-url
@@ -67,7 +67,7 @@
                   :git_imported_ts (when (and git-result (nil? error)) (now))
                   :git_problem (if git-result error "repo-not-provided")}
                  ["id = ?" build-id]))
-  (completed! [this build-id]
+  (completed! [_this build-id]
     (sql/update! db-spec "builds" {:import_completed_ts (now)} ["id = ?" build-id]))
   (get-build [_ build-id]
     (first (sql/query db-spec ["SELECT * FROM builds WHERE id = ?" build-id])))
@@ -149,6 +149,5 @@
   (analysis-requested! bt "bidi" "bidi" "2.1.3")
 
   (track-analysis-kick-off! db 2 "xxx"))
-
 
 ;; insert into builds (group_id, artifact_id, version, analysis_triggered_ts) values ('xxx', 'aaa', '1.0.0', datetime('now'));

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -178,10 +178,8 @@
 
     (.. doc body html toString)))
 
-
 ;; Some utilities to find which file in a git repository corresponds
 ;; to a file where a `def` is coming from --------------------------
-
 
 (defn- find-full-filepath
   "Take a list of filepaths, one subpath and find the best matching full path.

--- a/src/cljdoc/util/sqlite_cache.clj
+++ b/src/cljdoc/util/sqlite_cache.clj
@@ -96,14 +96,14 @@
   cache/CacheProtocol
   (lookup [_ k]
     (delay (fetch-item! k (:cache-spec state))))
-  (lookup [this k not-found]
+  (lookup [_this k not-found]
     (delay (or (fetch-item! k (:cache-spec state))
                (if (derefable? not-found) (deref not-found) not-found))))
   (has? [_ k]
     (let [item (fetch! k (:cache-spec state))]
       (and (not (nil? item))
            (not (stale? item)))))
-  (hit [this k]
+  (hit [this _k]
     this)
   (miss [this k v]
     (let [item (fetch! k (:cache-spec state))]


### PR DESCRIPTION
As part of a maintenance sweep have updated
libs we use for linting and testing.

Clj-kondo found a few small things, and had issue
with the singly-namespaced digest library.
The digest library is now hosted under clj-commons,
so updated it to current.

Cljfmt has some slightly new behavior around
whitespace around comments, so adjusted code
formatting to appease it.

Also: now git ignoring /.lsp for those who are using
and loving clojure-lsp.