### PR TITLE
Update more critical Clojure deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      - image: circleci/clojure:openjdk-8-tools-deps-1.10.3.822-node
-        # https://discuss.circleci.com/t/builds-getting-killed-with-vague-message-received-signal-killed/10214/9
+      - image: circleci/clojure:openjdk-11-tools-deps-1.10.3.1058-buster-node
         command: "/bin/bash"
 
     working_directory: ~/repo
@@ -105,7 +103,7 @@ jobs:
   # cat ~/.ssh/cljdoc_deploy.pub | ssh root@cljdoc.org 'cat >> .ssh/authorized_keys'
   deploy-to-nomad:
     docker:
-      - image: circleci/clojure:openjdk-8-tools-deps-1.10.3.822-node
+      - image: circleci/clojure:openjdk-11-tools-deps-1.10.3.1058-buster-node
         command: "/bin/bash"
     steps:
       - add_ssh_keys:

--- a/deps.edn
+++ b/deps.edn
@@ -1,18 +1,17 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"},
-        spootnik/unilog {:mvn/version "0.7.24"},
+        spootnik/unilog {:mvn/version "0.7.29"},
         org.clojure/tools.logging {:mvn/version "0.5.0"},
         io.pedestal/pedestal.jetty {:mvn/version "0.5.10"},
         io.pedestal/pedestal.service {:mvn/version "0.5.10"},
         tea-time/tea-time {:mvn/version "1.0.1"},
-        com.jcraft/jsch.agentproxy.jsch {:mvn/version "0.0.9"},
         integrant/repl {:mvn/version "0.3.1"},
         zprint/zprint {:mvn/version "0.4.16"},
         aero/aero {:mvn/version "1.1.3"},
-        cheshire/cheshire {:mvn/version "5.8.1"},
+        cheshire/cheshire {:mvn/version "5.10.2"},
         ragtime/ragtime {:mvn/version "0.8.0"}               ;; database migrations
         com.mjachimowicz/ragtime-clj {:mvn/version "0.1.2"}  ;; ragtime supports SQL migrations, this adds support for Clojure code migrations
-        funcool/cuerdas {:mvn/version "2.2.0"},
-        org.asciidoctor/asciidoctorj {:mvn/version "2.4.3"},
+        funcool/cuerdas {:mvn/version "2022.01.14-391"}
+        org.asciidoctor/asciidoctorj {:mvn/version "2.5.3"},
         co.deps/ring-etag-middleware {:mvn/version "0.2.0"}
         com.vladsch.flexmark/flexmark {:mvn/version "0.50.20"}
         com.vladsch.flexmark/flexmark-ext-autolink {:mvn/version "0.50.20"}
@@ -24,19 +23,18 @@
         org.clj-commons/digest {:mvn/version "1.4.100"},
         integrant/integrant {:mvn/version "0.7.0"},
         org.martinklepsch/clj-http-lite {:mvn/version "0.4.1"}
-        org.eclipse.jgit/org.eclipse.jgit {:mvn/version "4.10.0.201712302008-r"},
+        org.eclipse.jgit/org.eclipse.jgit.ssh.jsch {:mvn/version "6.0.0.202111291000-r"},
         io.sentry/sentry-logback {:mvn/version "1.7.25"},
-        com.jcraft/jsch.agentproxy.connector-factory {:mvn/version "0.0.9"},
         org.clojure/core.match {:mvn/version "0.3.0"},
         org.jsoup/jsoup {:mvn/version "1.14.3"},
         org.xerial/sqlite-jdbc {:mvn/version "3.28.0"},
         com.layerware/hugsql {:mvn/version "0.4.9"}
         com.taoensso/tufte {:mvn/version "2.0.1"}
         com.taoensso/nippy {:mvn/version "3.1.1"}
-        org.slf4j/slf4j-api {:mvn/version "1.7.26"},
+        org.slf4j/slf4j-api {:mvn/version "1.7.35"},
         expound/expound {:mvn/version "0.7.2"},
         raven-clj/raven-clj {:mvn/version "1.6.0-alpha2"},
-        me.raynes/fs {:mvn/version "1.4.6"},
+        clj-commons/fs {:mvn/version "1.6.310"}
         sitemap/sitemap {:mvn/version "0.4.0"},
         lambdaisland/uri {:mvn/version "1.2.1"}
         org.clojure/core.cache {:mvn/version "0.7.2"}
@@ -85,5 +83,5 @@
 
            :outdated
            {:replace-deps {com.github.liquidz/antq {:mvn/version "1.4.0"}
-                           org.slf4j/slf4j-simple {:mvn/version "1.7.33"}} ;; to rid ourselves of logger warnings
+                           org.slf4j/slf4j-simple {:mvn/version "1.7.35"}} ;; to rid ourselves of logger warnings
             :main-opts ["-m" "antq.core"]}}}

--- a/ops/README.adoc
+++ b/ops/README.adoc
@@ -96,6 +96,12 @@ This will package the cljdoc application in a Docker container. A tag will be de
 based on number of commits, branch and commit SHA. Images are published to Docker Hub during
 CI. See link:/.circleci/config.yml[`.circleci/config.yml`].
 
+[TIP]
+====
+Run `make clean image` when testing your image locally.
+This will ensure you are not working with stale inputs.
+====
+
 == Packaging (Uberjar)
 
 TBD.
@@ -172,3 +178,18 @@ bugs here and there. If we need to drop Traefik for some reason we could look in
 * https://github.com/Neilpang/acme.sh
 * https://github.com/Neilpang/acme.sh/wiki/How-to-issue-a-cert
 * https://github.com/Neilpang/acme.sh/wiki/Run-acme.sh-in-docker
+
+== Checking for Vulnerabilities
+
+Experts will uncover vulnerabilities in some of the technologies we use.
+It is inevitable.
+
+We use https://github.com/rm-hull/nvd-clojure[nvd-clojure] to scan cljdoc dependencies for known security issues.
+Run `nvd-check.sh` to launch a scan.
+It generates reports to `target/nvd/` off the cljdoc project root dir.
+The html report is probably the most useful.
+Be aware that the scan sometimes reports false positives.
+After some careful verification, you can quiet false positives via `nvd-suppresions.xml`.
+
+Other tools such as https://github.com/aquasecurity/trivy[trivy] can identify security holes.
+Trivy seems to be good at finding issues in docker images and configuration.

--- a/ops/nvd-check.sh
+++ b/ops/nvd-check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# This script was grabbed from: https://github.com/clojars/clojars-web/blob/main/bin/nvd-check
+# and altered.
+#
+# Checks dependencies for CVEs using the NVD database. This script is based on
+# instructions from https://github.com/rm-hull/nvd-clojure#clojure-cli-tool
+
+set -euo pipefail
+
+# Ensure that we will perform our check from cljdoc source root dir (one dir up from this script)
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+
+# Install current version of nvd-clojure
+clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd
+
+cd "$PROJECT_ROOT"
+
+# When run in production, we use the cli alias, so replicate that here.
+# Argument quoting is odd because quoting requirements for clojure cli tools is... odd.
+# Config for nvd-clojure is slightly awkward:
+# - we must specify config in a json file
+# - the json file references suppresions which are in an xml file
+clojure -J-Dclojure.main.report=stderr -Tnvd nvd.task/check \
+ :classpath '"'"$(clojure -Spath -M:cli)"'"' \
+ :config-filename '"./ops/nvd-config.json"'

--- a/ops/nvd-config.json
+++ b/ops/nvd-config.json
@@ -1,0 +1,1 @@
+{ "nvd": { "suppression-file": "./ops/nvd-suppressions.xml" } }

--- a/ops/nvd-suppressions.xml
+++ b/ops/nvd-suppressions.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <notes><![CDATA[
+    Applies to jruby versions less than v1.4.1, as of this writing, we are at v9
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/(org\.jruby/dirgra|rubygems/jruby\-readline)@.*$</packageUrl>
+    <cve>CVE-2010-1330</cve>
+  </suppress>
+  <suppress>
+   <notes><![CDATA[
+   Applies to jruby versions less than v1.6.5.1, as of this writing, we are at v9
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/(org\.jruby/dirgra|rubygems/jruby\-readline)@.*$</packageUrl>
+   <cve>CVE-2011-4838</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    JRuby's Java re-implementation of OpenSSL is falsely detected as the C implmentation of OpenSSL
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/rubygems/jruby\-openssl@.*$</packageUrl>
+    <cpe>cpe:/a:openssl:openssl</cpe>
+    <cpe>cpe:/a:jruby:jruby</cpe>
+  </suppress>
+  <suppress>
+   <notes><![CDATA[
+   file name: jsch.agentproxy.usocket-nc-0.0.9.jar
+   I don't know why this was being associated with netcat cpe, but I see no evidence on the web of
+   this lib itself having security issues.
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/com\.jcraft/jsch\.agentproxy\.usocket\-nc@.*$</packageUrl>
+   <cpe>cpe:/a:netcat:netcat</cpe>
+  </suppress>
+</suppressions>

--- a/src/cljdoc/git_repo.clj
+++ b/src/cljdoc/git_repo.clj
@@ -15,7 +15,8 @@
                                               AndTreeFilter
                                               TreeFilter)
             (org.eclipse.jgit.api Git TransportConfigCallback LsRemoteCommand)
-            (org.eclipse.jgit.transport SshTransport JschConfigSessionFactory)))
+            (org.eclipse.jgit.transport SshTransport)
+            (org.eclipse.jgit.transport.ssh.jsch JschConfigSessionFactory)))
 
 (def jsch-session-factory
   "A session-factory for use with JGit to access private


### PR DESCRIPTION
Of note:
- Jgit
  - now includes a specific jsch artifact which has appropriate and
    current jsch dependencies.
  - included a class reorg which we had to adapt to
  - now requires >= JDK11