### PR TITLE
Sanitize HTML converted from library markdown

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,6 +38,8 @@
         org.jsoup/jsoup {:mvn/version "1.14.3"}              ;; xml/html parser/rewriter
         enlive/enlive {:mvn/version "1.1.6"}                 ;; html templating
         sitemap/sitemap {:mvn/version "0.4.0"}               ;; web sitemap generation
+        com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer
+        {:mvn/version "20211018.2"}                          ;; sanitize html converted from user markdown
 
         ;; logging
         spootnik/unilog {:mvn/version "0.7.29"}              ;; easy log setup

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -1,4 +1,5 @@
 (ns cljdoc.render.rich-text
+  (:require [cljdoc.render.sanitize :as sanitize])
   (:import (org.asciidoctor Asciidoctor$Factory Options)
            (com.vladsch.flexmark.parser Parser)
            (com.vladsch.flexmark.html HtmlRenderer LinkResolverFactory LinkResolver CustomNodeRenderer)
@@ -18,7 +19,8 @@
                (.setAttributes (java.util.HashMap. {"env-cljdoc" true
                                                     "outfilesuffix" ".adoc"
                                                     "showtitle" true})))]
-    (.convert adoc-container file-content opts)))
+    (-> (.convert adoc-container file-content opts)
+        sanitize/clean)))
 
 (def md-extensions
   [(TablesExtension/create)
@@ -85,7 +87,8 @@
    (markdown-to-html input-str {}))
   ([input-str opts]
    (->> (.parse md-container input-str)
-        (.render (md-renderer opts)))))
+        (.render (md-renderer opts))
+        sanitize/clean)))
 
 (defmulti render-text
   "An extension point for the rendering of different article types.

--- a/src/cljdoc/render/sanitize.clj
+++ b/src/cljdoc/render/sanitize.clj
@@ -1,0 +1,571 @@
+(ns cljdoc.render.sanitize
+  "Sanitize HTML
+
+  Goals
+  - disallow the blatantly dangerous, for example: `<script>` `onclick`, etc.
+  - allow valid html generated from markdown styling
+    - adoc generator includes `class` and very limited `style` attributes
+    - md generator includes minimal `class`
+
+  Of Interest
+  - Authors writing markdown can include arbitrary HTML in their docs.
+    It is just the nature of the adoc and md beasts.
+    - We don't expect authors will typically want to, but if they wish, they
+      can include `class` and `style` attributes in their arbitrary HTML that
+      match what our markdown to HTML generators produce.
+      Or more precisely, what our sanitizer allows through.
+    - Not that they'd necessarly want to, but we don't want authors using cljdoc site
+      stylings (currently tachyons) in their arbitrary HTML in their docs.
+
+  Strategies
+  - Start with a GitHub-like sanitizer config then tweak.
+  - Adoc. I've taken an oldish adoc user manual (the one I included in cljdoc-exerciser)
+    and analyzed the html produced by cljdoc.
+    This should give us an idea of what we should allow through.
+    This is pretty simple for most things, a little more complex for classes.
+  - Md. Much simpler, barely includes any class and no style.
+  - If a class attribute specifies an un-allowed css class, we'll
+    just strip that un-allowed css class.
+  - Log changes made by sanitizer to tags, attributes and attribute values.
+    This will be server side only for now, but will help us with any support and to tweak
+    our sanitizer config if necessary.
+
+  Technical choice:
+  - Chose java-html-sanitizer
+  - Also considered JSoup clean, because we are already using JSoup.
+    It did not have all the features of java-html-sanitizer, and right or wrong, I like
+    that the OWASP folks have a single focus library, it makes me think they spent lots
+    of time thinking about how to sanitize."
+  (:require [clojure.string :as string]
+            [clojure.tools.logging :as log])
+  (:import (org.owasp.html AttributePolicy
+                           ElementPolicy
+                           FilterUrlByProtocolAttributePolicy
+                           Handler
+                           HtmlSanitizer
+                           HtmlSanitizer$Policy
+                           HtmlStreamEventProcessor$Processors
+                           HtmlStreamEventReceiver
+                           HtmlStreamRenderer
+                           HtmlPolicyBuilder))
+  (:require [clojure.string :as string]))
+
+;; helpers for awkward interop
+(defn- allow-tags [policy & tags]
+  (.allowElements policy (into-array String tags)))
+
+(defn- allow-attributes [policy & attrs]
+  (.allowAttributes policy (into-array String attrs)))
+
+(defn- with-protocols
+  [attribute-policy & protocols]
+  (.matching attribute-policy (FilterUrlByProtocolAttributePolicy. protocols)))
+
+(defn- on-tags [attribute-policy & tags]
+  (.onElements attribute-policy (into-array String tags)))
+
+(defn- matching-vals [attribute-policy & expected-values]
+  (-> attribute-policy
+      (.matching (proxy [AttributePolicy] []
+                   (apply [tag-name attribute-name value]
+                     (when (some (fn [test-value]
+                                   (if (string? test-value)
+                                     (= test-value value)
+                                     (re-matches test-value value)))
+                                 expected-values)
+                       value))))))
+
+(defn- class-matches? [t v]
+  (if (string? t)
+    (= t v)
+    (re-matches t v)))
+
+(defn- sanitize-classes
+  "sanitize class-combos where a class-combo is:
+  [marker-class optional-class...]
+  where marker-class and optional-class can be a string or regular expression.
+
+  We match a class-combo on marker-class and then check that any other classes match optional-classes.
+  This seems to work well for our current use case.
+  Adjust as necessary if/when that stops being the case."
+  [policy & class-combos]
+  ;; adoc roles can, I think, appear in any class attribute.
+  ;; note that there are deprecated adoc roles such as colors (ex. `red` `background-green` etc) and
+  ;; `big` and `small`, we can add support for these if it makes sense to cljdoc and its users.
+  (let [global-classes ["underline" "overline" "line-through" "nobreak" "nowrap" "pre-wrap"]]
+    (-> policy
+        (allow-attributes "class")
+        (.matching (proxy [AttributePolicy] []
+                     (apply [tag-name attribute-name value]
+                       (let [cur-classes (string/split value #" +")
+                             matching-combo (reduce (fn [_acc class-combo]
+                                                      (let [marker-class (first class-combo)]
+                                                        (when (some #(class-matches? marker-class %) cur-classes)
+                                                          (reduced class-combo))))
+                                                    nil
+                                                    class-combos)
+                             valid-classes (concat matching-combo global-classes)
+                             [valid invalid] (reduce (fn [[valid invalid] cur-class]
+                                                       (if (some #(class-matches? % cur-class) valid-classes)
+                                                         [(conj valid cur-class) invalid]
+                                                         [valid (conj invalid cur-class)]))
+                                                     [[] []]
+                                                     cur-classes)]
+                         (if (seq invalid)
+                           (when (seq valid)
+                             (string/join " " valid))
+                           value))))))))
+
+(defn- allow-tag-with-attribute-value
+  "If tag does not include required-attribute with required-value, it will be dropped.
+  We deal with this at the tag level (rather than the attribute level) to allow dropping
+  a tag based on its attributes (rather than just dropping the attribute only)."
+  [policy tag required-attribute required-value]
+  (-> policy
+      (.allowElements (proxy [ElementPolicy] []
+                        (apply [tag-name av-pairs]
+                          (let [avs (->> av-pairs (partition 2) (map vec) (into {}))
+                                actual-value (get avs required-attribute nil)]
+                            (when (= required-value actual-value)
+                              tag-name))))
+                      (into-array String [tag]))))
+
+(def ^:private policy
+  (-> (HtmlPolicyBuilder.)
+
+      ;; github pipeline sanitization ref:
+      ;; https://github.com/gjtorikian/html-pipeline/blob/0e3d84eb13845e0d2521ef0dc13c9c51b88e5087/lib/html/pipeline/sanitization_filter.rb#L44-L106
+
+      (allow-tags
+       ;; from github pipeline
+       "a" "abbr" "b" "bdo" "blockquote" "br" "caption" "cite" "code"
+       "dd" "del" "details" "dfn" "div" "dl" "dt" "em" "figcaption"
+       "figure" "h1" "h2" "h3" "h4" "h5" "h6" "h7" "h8" "hr"
+       "i" "img" "ins" "kbd" "li" "mark" "ol" "p" "pre" "q" "rp" "rt" "ruby"
+       "s" "samp" "small" "span" "strike" "strong" "sub" "summary" "sup"
+       "table" "tbody" "td" "tfoot" "th" "thead" "time" "tr" "tt" "ul" "var" "wbr"
+       ;; adoc extras
+       "col" "colgroup" "input" "u")
+      (allow-attributes
+       ;; from (former?) github pipeline, seems a bit permissive, but if gh was happy, probably fine
+       "abbr" "accept" "accept-charset"
+       "accesskey" "action" "align" "alt"
+       "aria-describedby" "aria-hidden" "aria-label" "aria-labelledby"
+       "axis" "border" "cellpadding" "cellspacing" "char"
+       "charoff" "charset" "charset" "checked" "clear"
+       "color" "cols" "colspan"
+       "compact" "coords" "datetime" "describedby"
+       "dir" "disabled" "enctype" "for"
+       "frame" "headers" "height" "hidden"
+       "hreflang" "hspace" "ismap"
+       "itemprop" "label" "label" "labelledby"
+       "lang" "maxlength" "media"
+       "method" "multiple" "name" "nohref"
+       "noshade" "nowrap" "open" "progress" "prompt" "readonly" "rel"
+       "rev" "role" "rows" "rowspan" "rules"
+       "scope" "selected" "shape" "size"
+       "span" "start" "summary" "tabindex"
+       "target" "title" "type" "usemap" "valign"
+       "value" "vspace" "width")
+      (.globally)
+
+      ;; id attribute
+      ;; assuming  HTML5 ids are safe which is basically no spaces and more than 1 char.
+      (allow-attributes "id")
+      (matching-vals #"\S+")
+      (.globally)
+
+      ;;
+      ;; protocols, config inspired by github pipeline
+      ;;
+
+      ;; superset of all allowed protocols
+      (.allowUrlProtocols (into-array String ["http" "https" "mailto" "xmpp" "irc" "ircs" "viewsource"]))
+
+      (allow-attributes "href")
+      (with-protocols "http" "https" "mailto" "xmpp" "irc" "ircs" "viewsource")
+      (on-tags "a")
+
+      (allow-attributes "src" "longdesc")
+      (with-protocols "http" "https")
+      (on-tags "img")
+
+      (allow-attributes "cite")
+      (with-protocols "http" "https")
+      (on-tags "blockquote" "del" "ins" "q")
+
+      ;;
+      ;; specific attribute config
+      ;;
+
+      ;; for md wikilink support
+      (allow-attributes "data-source")
+      (matching-vals "wikilink")
+      (on-tags "a")
+
+      ;; mimic from github pipeline
+      (allow-attributes "itemscope" "itemtype")
+      (on-tags "div")
+
+      ;; style restrictions for adoc
+      (allow-attributes "style")
+      (matching-vals #"width: \d+(\.\d+)?%;?")
+      (on-tags "col" "table")
+
+      ;; adoc can show checkboxes, but that's the only input type that we should allow
+      (allow-tag-with-attribute-value "input" "type" "checkbox")
+
+      (allow-attributes "data-item-complete"
+                        "checked")
+      (on-tags "input")
+
+      ;; adoc allows reverse order lists
+      (allow-attributes "reversed")
+      (on-tags "ol")
+
+      ;; allow data-lang on code blocks for formatting support
+      (allow-attributes "data-lang")
+      (on-tags "code")
+
+      ;;
+      ;; class - we'd like markdown styles to get through but not for
+      ;;         our users to do their own styling.
+      ;;       - assume adoc unless commented with md
+      ;;       - letting classes through allows us the freedom to style elements - but only if we want to.
+      ;;       - if some combo of classes aren't gettting through that is required for some sort of desired
+      ;;         styling, probably something I just missed, adjust as necessary
+      ;;
+      ;; Ref: https://github.com/asciidoctor/asciidoctor/blob/main/src/stylesheets/asciidoctor.css
+      ;;
+      ;; currently not allowing (have not looked into)
+      ;; - audioblock
+      ;; - clearfix
+      ;; - fa-* ;; font awesome classses, we don't currently use these
+      ;; - float-group
+      ;; - icon-caution
+      ;; - icon-important
+      ;; - icon-note
+      ;; - icon-tip
+      ;; - icon-warning
+      ;; - toc-right
+      ;; - videoblock
+      ;; and I think these relate to highlighting featues which we do not use
+      ;; - highlight
+      ;; - linenos
+      ;; - linenotable
+      ;; - linenums
+      ;; - prettyprint
+      ;; I think these are maybe obsolete? or obscure?
+      ;; - output
+      ;; - subheader
+      ;; - toc2
+      ;; - tr.even
+      (sanitize-classes
+       ["md-anchor"] ;; md
+       ["anchor"]
+       ["bare"]
+       ["footnote"]
+       ["image"]
+       ["link"])
+      (on-tags "a")
+
+      (sanitize-classes
+       ["button"]
+       ["caret"]
+       ["conum"]
+       ["menu"]
+       ["menuref"]
+       ["menuitem"]
+       ["submenu"])
+      (on-tags "b")
+
+      (sanitize-classes ["title"])
+      (on-tags "caption")
+
+      (sanitize-classes
+       [#"language-[-+_.a-zA-Z0-9]+"] ;; md & adoc
+       ["code"])
+      (on-tags "code")
+
+      (sanitize-classes
+       ["admonitionblock" #"(caution|important|note|tip|warning)"]
+       ["attribution"]
+       ["colist" "arabic"] ;; -- arabic only ??
+       ["content"]
+       ["details"]
+       ["dlist" "gloassary"]
+       ["exampleblock"]
+       ["footnote"]
+       ["hdlist"]
+       ["imageblock" "left" "right" "thumb" "text-center" "text-right" "text-left"]
+       ["listingblock"]
+       ["literal"]
+       ["literalblock"]
+       ["olist" #"(arabic|decimal|lower(alpha|greek|roman)|upper(alpha|roman))"]
+       ["openblock" "partintro"]
+       ["paragraph" "lead"]
+       ["qlist" "qanda"]
+       ["quoteblock" "abstract"]
+       [#"sect[0-6]"]
+       ["sectionbody"]
+       ["sidebarblock"]
+       ["stemblock"]
+       ["title"]
+       ["toc"]
+       ["ulist" #"(bibliography|checklist|square)"]
+       ["verseblock"])
+      (on-tags "div")
+
+      (sanitize-classes
+       ["hdlist1"])
+      (on-tags "dt")
+
+      (sanitize-classes
+       ["path"]
+       ["term"])
+      (on-tags "em")
+
+      (sanitize-classes
+       ["float"]
+       ["sect0"])
+      (on-tags "h1")
+
+      (sanitize-classes
+       ["float"])
+      (on-tags "h2" "h3" "h4" "h5" "h6")
+
+      (sanitize-classes
+       ["arabic"]
+       ["decimal"]
+       ["loweralpha"]
+       ["upperalpha"]
+       ["lowergreek"]
+       ["lowerroman"]
+       ["upperroman"]
+       ["no-bullet"]
+       ["unnumbered"]
+       ["unstyled"])
+      (on-tags "ol")
+
+      (sanitize-classes
+       ["tableblock"]
+       ["quoteblock"])
+      (on-tags "p")
+
+      (sanitize-classes
+       ["content"]
+       ["highlight"])
+      (on-tags "pre")
+
+      (sanitize-classes
+       ["alt"]
+       ["icon"]
+       ["image" "left" "right"]
+       ["keyseq"]
+       ["menuseq"])
+      (on-tags "span")
+
+      (sanitize-classes
+       ["footnote"]
+       ["footnoteref"])
+      (on-tags "sup")
+
+      (sanitize-classes
+       ["tableblock"
+        #"frame-(all|sides|ends|none)"
+        #"grid-(all|cols|rows|none)"
+        #"stripes-(even|odd|all|hover)"
+        "fit-content" "stretch" "unstyled"])
+      (on-tags "table")
+
+      (sanitize-classes
+       ["content"]
+       ["hdlist1"]
+       ["hdlist2"]
+       ["icon"]
+       ["tableblock" #"halign-(left|center|right)" #"valign-(top|middle|bottom)"])
+      (on-tags "td" "th")
+
+      (sanitize-classes
+       ["bibliography"]
+       ["checklist"]
+       ["circle"]
+       ["disc"]
+       ["inline"]
+       ["none"]
+       ["no-bullet"]
+       [#"sectlevel[0-6]"]
+       ["square"]
+       ["unstyled"])
+      (on-tags "ul")
+
+      (.toFactory)))
+
+(defn clean*
+  "The java-html-sanitizer HtmlChangeReporter only supports reporting on discarded tags and attributes, and
+  not attribute values.
+  We essentially mimic its strategy here but support reporting on attribute values.
+
+  The strategy is:
+  - what the policy removed will not be rendered
+  - so, compare tag, by tag what is passed to policy vs what is actually rendered
+  This little lower-level complexity removes multiple higher-level work-arounds.
+
+  Careful in here, Java lists are mutable, so make copies."
+  [html]
+  (if (not html)
+    {:cleaned ""
+     :changes []}
+    (let [changes (atom [])
+          change-tracker (atom {})
+          out (StringBuilder. (count html))
+          renderer (HtmlStreamRenderer/create out Handler/DO_NOTHING)
+          wrapped-renderer (proxy [HtmlStreamEventReceiver] []
+                             (openDocument [] (.openDocument renderer))
+                             (closeDocument [] (.closeDocument renderer))
+                             (openTag [tag av-pairs]
+                               (reset! change-tracker {:rendered-tag tag
+                                                       :rendered-av-pairs (into [] av-pairs)})
+                               (.openTag renderer tag av-pairs))
+                             (closeTag [tag-name] (.closeTag renderer tag-name))
+                             (text [text] (.text renderer text)))
+          wrapped-policy (.apply policy wrapped-renderer)
+          wrapped-policy (proxy [HtmlSanitizer$Policy] []
+                           (openDocument [] (.openDocument wrapped-policy))
+                           (closeDocument [] (.closeDocument wrapped-policy))
+                           (openTag [tag av-pairs]
+                             (let [orig-av-pairs (into [] av-pairs)]
+                               (reset! change-tracker {})
+                               (.openTag wrapped-policy tag av-pairs)
+                               (let [{:keys [rendered-tag rendered-av-pairs]} @change-tracker]
+                                 (reset! change-tracker {})
+                                 (if (not= rendered-tag tag)
+                                   (swap! changes conj {:type :removed
+                                                        :tag tag
+                                                        :attributes (partition 2 orig-av-pairs)})
+                                   (when (not= orig-av-pairs rendered-av-pairs)
+                                     (swap! changes conj {:type :modified
+                                                          :tag tag
+                                                          :old-attributes (partition 2 orig-av-pairs)
+                                                          :new-attributes (partition 2 rendered-av-pairs)}))))))
+                           (closeTag [tag-name] (.closeTag wrapped-policy tag-name))
+                           (text [text] (.text wrapped-policy text)))]
+      (HtmlSanitizer/sanitize
+       html
+       wrapped-policy
+       HtmlStreamEventProcessor$Processors/IDENTITY)
+      {:cleaned (.toString out)
+       :changes @changes})))
+
+(defn- triage-changes
+  "Attach a log level to changes."
+  [changes]
+  (for [c changes]
+    (if (= :removed (:type c))
+      (assoc c :level :info)
+      (let [new-attributes (->> c
+                                :new-attributes
+                                (map vec)
+                                (into {}))
+            ;; drive from old attributes, we don't care much if:
+            ;; - the sanitizer has added attributes
+            ;; - the sanitizer has changed attribute values by encoding only
+            ;; - the new and old attribute values are the same
+            interesting-changes (->> (:old-attributes c)
+                                     (remove (fn [[old-attr old-value]]
+                                               (let [new-value (get new-attributes old-attr nil)]
+                                                 (or (= old-value new-value)
+                                                     ;; assume that href/src, if present in both old and new is an encoding change
+                                                     (and new-value (some #{old-attr} ["href" "src" "longdesc" "cite"])))))))]
+        (if (seq interesting-changes)
+          (assoc c :level :info)
+          (assoc c :level :debug))))))
+
+(defn- log-changes [changes]
+  (doseq [{:keys [level] :as c} changes]
+    (log/log level (pr-str (dissoc c :level)))))
+
+(defn clean
+  "Returns cleaned html string for given `html`.
+  Changes are logged:
+  - I don't see a need to format to text, just log the edn for now
+  - Some changes are uninteresting, like attribute addditions or simple escaping of urls,
+    these are currently logged anyway but at debug, rather than info level."
+  [html]
+  (let [{:keys [cleaned changes]} (clean* html)]
+    (-> changes
+        distinct ;; duplicates findings do not add value
+        triage-changes
+        log-changes)
+    cleaned))
+
+(comment
+
+  (clean* "<div style=\"width: 10.3%;\">hiya</div>")
+
+  (clean* "<h1 bad='foo' id='ok' class='float boat'>")
+
+  (clean* "<hippo bad='foo' apple>")
+
+  (clean* "<img src='booya.png'>")
+  (clean* "<img src='mailto:bing@bang.com'>")
+
+  (clean* "<a href='view-source:asciidoctor.org' target='_blank' rel='noopener'>Asciidoctor homepage</a>")
+
+  (clean* "<a href='mailto:foo@bar.com'>hey</a>")
+
+  ;; only using single quotes because they are easier on the eyes, sanitizer converts
+  (clean "<h1 id='3'>hi</h1> <script>alert('hey');</script>")
+  (clean "<q cite='https://boo.com'>hey</cite>")
+
+  (clean* "<h1 id='***'>boo</h1>")
+
+  (clean "<input>")
+
+  (clean "<input type='text' checked chucked>")
+  (clean "<input type='checkbox' checked chucked>")
+
+  (clean* "<a href='view-source:asciidoctor.org' target='_blank' rel='noopener'>Asciidoctor homepage</a>")
+
+  (clean* "<a href='mailto:foo@bar.com'>hey</a>")
+
+  (clean "<a href='https://foo.you'>hey</a>");; => "hey"
+  (clean "<a href=' '>hey</a>");; => "hey"
+
+  (clean "<a class='amd-anchor foo' href='#' nope='dope'>hmm</a>")
+
+  (clean "<a class='md-anchor foo underline' href='#'>hmm</a>")
+  (clean "<a class='underline md-anchor foo' href='#'>hmm</a>")
+
+  (clean "<caption class='title'>Yup</caption>")
+  (clean "<caption class='underline'>Yup</caption>")
+  (clean "<caption>Yup</caption>")
+
+  (clean "<code class='code'>boo</code>")
+
+  (clean "<code class='language-foo.ffoo'>boo</code>")
+
+  (clean "<img src='https://boo.com/ha().png'>")
+  (clean "<img src='https://boo.com/ha().png' uhno>")
+
+  (distinct [8 1 22 1 3 8])
+
+  (clean "<img src='mailto:lee@dlread.com'>")
+
+  (clean "<table style='width: 13.5%;'></table>")
+  (clean "<table style='width: 10px;'></table>")
+
+  (clean "<table style='not: allowed;'>");; => "<table></table>"
+
+  (clean "<div class=\"ok foo nice\">hey ho</div>")
+
+  (clean "<table class='tableblock frame-ends grid-all unstyled2'>")
+
+  (clean "<a class=\"md-anchor\" href=\"#\">iii</a>")
+  (clean "<a class=\"language-foopack.roo\" href=\"#\">iii</a>")
+
+  (clean* "<a href=\"https://opencollective.com/boot-clj/sponsor/4/website\" target=\"_blank\">boo</a>")
+
+  (clean* "<a href=\"https://opencollective.com/boot-clj/sponsor/0/website\" target=\"_blank\"><img src=\"https://opencollective.com/boot-clj/sponsor/0/avatar.svg\"></a>")
+
+  (spit "leetest-cleaned.html" (clean (slurp "leetest.html"))))

--- a/test/cljdoc/render/rich_text_test.clj
+++ b/test/cljdoc/render/rich_text_test.clj
@@ -3,9 +3,9 @@
             [clojure.test :as t]))
 
 (t/deftest renders-wikilinks-from-markdown
-  (t/is (= "<p><a href=\"updated:my.namespace.here/fn1\" data-source=\"wikilink\"><code>my.namespace.here/fn1</code></a></p>\n"
+  (t/is (= "<p><a href=\"/updated:my.namespace.here/fn1\" data-source=\"wikilink\"><code>my.namespace.here/fn1</code></a></p>\n"
            (rich-text/markdown-to-html "[[my.namespace.here/fn1]]"
-                                       {:render-wiki-link (fn [ref] (str "updated:" ref))}))))
+                                       {:render-wiki-link (fn [ref] (str "/updated:" ref))}))))
 
 (t/deftest determines-doc-features
   (t/is (nil? (rich-text/determine-features [:cljdoc/markdown "== CommonMark has not optional features"])))

--- a/test/cljdoc/render/sanitize_test.clj
+++ b/test/cljdoc/render/sanitize_test.clj
@@ -1,0 +1,153 @@
+(ns cljdoc.render.sanitize-test
+  "Some spot checks for our html sanitizer"
+  (:require [cljdoc.render.sanitize :as sanitize]
+            [clojure.test :as t]))
+
+(t/deftest discards-harmful-attributes
+  (t/is (= {:changes [{:type :modified
+                       :tag "div"
+                       :old-attributes [["onclick" "alert('boo');"]]
+                       :new-attributes []}]
+            :cleaned "<div>some content</div>"}
+           (sanitize/clean* "<div onclick=\"alert('boo');\">some content</div>"))))
+
+(t/deftest discards-harmful-tags
+  (t/is (= {:changes [{:type :removed
+                       :tag "script"
+                       :attributes []}]
+            :cleaned "<div>some content</div>"}
+           (sanitize/clean* "<div>some content<script>alert('boo');</script></div>"))))
+
+(t/deftest restricts-protocols
+  (t/is (= {:changes [{:type :removed
+                       :tag "a"
+                       :attributes [["href" "nogoproto://something"]]}]
+            :cleaned "lookey here"}
+           (sanitize/clean* "<a href=\"nogoproto://something\">lookey here</a>")))
+  (t/is (= {:changes [{:type :removed
+                       :tag "img"
+                       :attributes [["src" "mailto:john.smith@example.com"]]}]
+            :cleaned ""}
+           (sanitize/clean* "<img src=\"mailto:john.smith@example.com\"")))
+  (t/is (= {:changes []
+            :cleaned "<q cite=\"https://boo.com\">hey</q>"}
+           (sanitize/clean* "<q cite='https://boo.com'>hey</q>"))))
+
+(t/deftest handles-style
+  ;; we allow specific width styling for adoc on table and col only
+  (t/is (= {:changes []
+            :cleaned "<table style=\"width: 10.3%;\"></table>"}
+           (sanitize/clean* "<table style=\"width: 10.3%;\"></table>")))
+  ;; notice that the sanitizer also completes any incomplete elements
+  (t/is (= {:changes []
+            :cleaned "<table><colgroup><col style=\"width: 5%;\" /></colgroup></table>"}
+           (sanitize/clean* "<col style=\"width: 5%;\"></col>")))
+  ;; we only allow % widths
+  (t/is (= {:changes [{:type :modified
+                       :tag "table"
+                       :old-attributes [["style" "width: 10px;"]]
+                       :new-attributes []}]
+            :cleaned "<table></table>"}
+           (sanitize/clean* "<table style=\"width: 10px;\"></table>")))
+  ;; and disallow styles on other tags
+  (t/is (= {:changes [{:type :modified
+                       :tag "div"
+                       :old-attributes [["style" "width: 10.3%;"]]
+                       :new-attributes []}]
+            :cleaned "<div>hiya</div>"}
+           (sanitize/clean* "<div style=\"width: 10.3%;\">hiya</div>"))))
+
+(t/deftest handles-classes
+  ;; we make a reasonable attempt to only allow class values through that occur
+  ;; from markdown->html rendering
+  (t/is (= {:changes []
+            :cleaned "<code class=\"language-some-language-here\">code here</code>"}
+           (sanitize/clean* "<code class=\"language-some-language-here\">code here</code>")))
+  ;; we discard what we don't recognize
+  (t/is (= {:changes [{:type :modified
+                       :tag "div"
+                       :old-attributes [["class" "admonitionblock mt5-ns mw7 center pa4 pa0-l caution"]]
+                       :new-attributes [["class" "admonitionblock caution"]]}]
+            :cleaned "<div class=\"admonitionblock caution\">caution text</div>"}
+           (sanitize/clean* "<div class=\"admonitionblock mt5-ns mw7 center pa4 pa0-l caution\">caution text</div>")))
+  ;; generic adoc roles such as nowrap, nobreak etc should be allowed on their own...
+  (t/is (= {:changes []
+            :cleaned "<p class=\"nowrap\">paragraph text</p>"}
+           (sanitize/clean* "<p class=\"nowrap\">paragraph text</p>")))
+  ;; ...and when combined with other valid (and invalid) classes
+  (t/is (= {:changes [{:type :modified
+                       :tag "table"
+                       :old-attributes [["class" "tableblock frame-ends nobreak whazzup grid-rows fit-content"]]
+                       :new-attributes [["class" "tableblock frame-ends nobreak grid-rows fit-content"]]}]
+            :cleaned "<table class=\"tableblock frame-ends nobreak grid-rows fit-content\"></table>"}
+           (sanitize/clean* "<table class=\"tableblock frame-ends nobreak whazzup grid-rows fit-content\"></table>"))))
+
+(t/deftest handles-input
+  ;; adoc will render input checkboxes, if we see any other type of input tag, it will be dropped.
+  ;; a valid checkbox with an invalid attribute
+  (t/is (= {:changes [{:type :modified
+                       :tag "input"
+                       :old-attributes [["type" "checkbox"] ["checked" "checked"] ["chucked" "chucked"]]
+                       :new-attributes [["type" "checkbox"] ["checked" "checked"]]}]
+            :cleaned "<input type=\"checkbox\" checked=\"checked\" />"}
+           (sanitize/clean* "<input type='checkbox' checked chucked>")))
+  ;; an invalid input
+  (t/is (= {:changes [{:type :removed
+                       :tag "input"
+                       :attributes [["type" "text"] ["checked" "checked"] ["chucked" "chucked"]]}]
+            :cleaned ""}
+           (sanitize/clean* "<input type='text' checked chucked>"))))
+
+(t/deftest validates-id-attribute
+  (t/is (= {:changes []
+            :cleaned "<h1 id=\"μ\">hiya</h1>"}
+           (sanitize/clean* "<h1 id=\"μ\">hiya</h1>")))
+  (t/is (= {:changes [{:type :modified
+                       :tag "h1"
+                       :old-attributes [["id" ""]]
+                       :new-attributes []}]
+            :cleaned "<h1>hiya</h1>"}
+           (sanitize/clean* "<h1 id=\"\">hiya</h1>")))
+  (t/is (= {:changes [{:type :modified
+                       :tag "h1"
+                       :old-attributes [["id" "a "]]
+                       :new-attributes []}]
+            :cleaned "<h1>hiya</h1>"}
+           (sanitize/clean* "<h1 id=\"a \">hiya</h1>"))))
+
+(t/deftest deals-with-wikilinks
+  (t/is (= {:changes []
+            :cleaned "<a href=\"/d/some/link\" data-source=\"wikilink\">sometext</a>"}
+           (sanitize/clean* "<a href=\"/d/some/link\" data-source=\"wikilink\">sometext</a>"))))
+
+(t/deftest nesting-does-not-confuse
+  (t/is (= {:changes [{:type :modified
+                       :tag "a"
+                       :old-attributes [["href" "https://example.com"] ["target" "_blank"]]
+                       :new-attributes [["href" "https://example.com"] ["target" "_blank"]
+                                        ;; notice in this case, the sanitizer added some attributes
+                                        ["rel" "noopener noreferrer"]]}]
+            :cleaned "<a href=\"https://example.com\" target=\"_blank\" rel=\"noopener noreferrer\"><img src=\"https://example.com/avatar.svg\" /></a>"}
+           (sanitize/clean* "<a href=\"https://example.com\" target=\"_blank\"><img src=\"https://example.com/avatar.svg\"></a>")))
+  ;; repeat but this time both parent and nested have changes
+  (t/is (= {:changes [{:type :modified
+                       :tag "a"
+                       :old-attributes [["href" "https://example.com"] ["target" "_blank"]]
+                       :new-attributes [["href" "https://example.com"] ["target" "_blank"]
+                                        ["rel" "noopener noreferrer"]]}
+                      {:type :modified
+                       :tag "img"
+                       :old-attributes [["src" "https://example.com/avatar.svg"] ["uhno" "uhno"]]
+                       :new-attributes [["src" "https://example.com/avatar.svg"]]}]
+            :cleaned "<a href=\"https://example.com\" target=\"_blank\" rel=\"noopener noreferrer\"><img src=\"https://example.com/avatar.svg\" /></a>"}
+           (sanitize/clean* "<a href=\"https://example.com\" target=\"_blank\"><img src=\"https://example.com/avatar.svg\" uhno></a>")))
+  ;; when parent is removed, valid children are preserved
+  (t/is (= {:changes [{:type :removed
+                       :tag "notatag"
+                       :attributes [["what" "dis"]]}
+                      {:type :modified
+                       :tag "div"
+                       :old-attributes [["id" "ok"] ["uhno" "uhno"]]
+                       :new-attributes [["id" "ok"]]}]
+            :cleaned "<div id=\"ok\">something</div>"}
+           (sanitize/clean* "<notatag what=\"dis\"><div id=\"ok\" uhno>something</div></notatag>"))))


### PR DESCRIPTION
Documentation of libraries that cljdoc imports include markdown in the
form of:
- AsciiDoc and CommonMark articles
- CommonMark in docstrings

We now sanitize this markdown after it is converted to HTML to:
1. primarily protect cljdoc users from potentially malicious HTML
2. secondarily ensure separation of user markdown styling from cljdoc
   styling

Testing has been done, but if we learn that we are over-sanitizing,
this is easy enough to correct.

See cljdoc.render.sanitize namespace for more verbiage.