### PR TITLE
Quiet pedestal broken pipe errors

### DIFF
--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -33,6 +33,7 @@
             [cljdoc.util.repositories :as repos]
             [cljdoc.util.sentry :as sentry]
             [clojure.tools.logging :as log]
+            [clojure.stacktrace :as stacktrace]
             [clojure.string :as string]
             [clj-http.lite.client :as http-client]
             [co.deps.ring-etag-middleware :as etag]
@@ -40,10 +41,13 @@
             [io.pedestal.http :as http]
             [io.pedestal.http.body-params :as body]
             [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.log :as plog]
             [io.pedestal.http.ring-middlewares :as ring-middlewares]
+            [io.pedestal.http.impl.servlet-interceptor :as servlet-interceptor]
             [ring.util.codec :as ring-codec]
             [lambdaisland.uri.normalize :as normalize]
-            [net.cgrand.enlive-html :as en]))
+            [net.cgrand.enlive-html :as en])
+  (:import (java.io IOException)))
 
 (def render-interceptor
   "This interceptor will render the documentation page for the current route
@@ -530,28 +534,53 @@
                               (last-build-loader build-tracker)])
        (assoc route :interceptors)))
 
+;; Hack for filtering out verbose broken pipe error logging.
+;; This is just someone clicking x and then y before x is fully deliverd.
+;; Credits to tonksy: https://tonsky.me/blog/pedestal/#running-the-app
+;; Replace with something more proper when the following is addressed:
+;; https://github.com/pedestal/pedestal/issues/623
+(defn quieter-error-stylobate [{:keys [servlet-response] :as context} exception]
+  (let [cause (stacktrace/root-cause exception)]
+    (if (and (instance? IOException cause)
+             (= "Broken pipe" (.getMessage cause)))
+      (log/info "broken pipe")
+      (plog/error
+       :msg "error-stylobate triggered"
+       :exception exception
+       :context context))
+    (@#'servlet-interceptor/leave-stylobate context)))
+
+; io.pedestal.http.impl.servlet-interceptor/stylobate
+(def quieter-stylobate
+  (io.pedestal.interceptor/interceptor
+   {:name ::stylobate
+    :enter @#'io.pedestal.http.impl.servlet-interceptor/enter-stylobate
+    :leave @#'io.pedestal.http.impl.servlet-interceptor/leave-stylobate
+    :error quieter-error-stylobate}))
+
 (defmethod ig/init-key :cljdoc/pedestal [_ opts]
   (log/infof "Starting pedestal on %s:%s" (:host opts) (:port opts))
-  (-> {::http/routes (routes/routes (partial route-resolver opts) {})
-       ::http/type   :jetty
-       ::http/join?  false
-       ::http/port   (:port opts)
-       ::http/host   (:host opts)
-       ;; TODO look into this some more:
-       ;; - https://groups.google.com/forum/#!topic/pedestal-users/caRnQyUOHWA
-       ::http/secure-headers {:content-security-policy-settings {:object-src "'none'"}}
-       ::http/resource-path "public/out"
-       ::http/not-found-interceptor not-found-interceptor}
-      http/default-interceptors
-      (update ::http/interceptors #(into [sentry/interceptor
-                                          static-resource-interceptor
-                                          redirect-trailing-slash-interceptor
-                                          (ring-middlewares/not-modified)
-                                          etag-interceptor
-                                          cache-control-interceptor]
-                                         %))
-      (http/create-server)
-      (http/start)))
+  (with-redefs [servlet-interceptor/stylobate quieter-stylobate]
+    (-> {::http/routes (routes/routes (partial route-resolver opts) {})
+         ::http/type   :jetty
+         ::http/join?  false
+         ::http/port   (:port opts)
+         ::http/host   (:host opts)
+         ;; TODO look into this some more:
+         ;; - https://groups.google.com/forum/#!topic/pedestal-users/caRnQyUOHWA
+         ::http/secure-headers {:content-security-policy-settings {:object-src "'none'"}}
+         ::http/resource-path "public/out"
+         ::http/not-found-interceptor not-found-interceptor}
+        http/default-interceptors
+        (update ::http/interceptors #(into [sentry/interceptor
+                                            static-resource-interceptor
+                                            redirect-trailing-slash-interceptor
+                                            (ring-middlewares/not-modified)
+                                            etag-interceptor
+                                            cache-control-interceptor]
+                                           %))
+        (http/create-server)
+        (http/start))))
 
 (defmethod ig/halt-key! :cljdoc/pedestal [_ server]
   (http/stop server))


### PR DESCRIPTION
If a user clicks on x and then y before x is fully delivered,
pedestal logs an extremely verbose broken pipe error.

We work around this with a strategy tonsky blogged about here:
https://tonsky.me/blog/pedestal/#running-the-app

We now simple log an info level "broken pipe" message when
this normal event occurs.

We can do something more proper after this pedestal issue is
addressed: https://github.com/pedestal/pedestal/issues/623

Closes #367