### PR TITLE
ops: have jvm dump heap out of memory errors

### DIFF
--- a/ops/docker/Dockerfile
+++ b/ops/docker/Dockerfile
@@ -23,4 +23,4 @@ COPY . /app
 
 EXPOSE 8000
 
-ENTRYPOINT ["clojure", "-J-Dcljdoc.host=0.0.0.0", "-M", "-m", "cljdoc.server.system"]
+ENTRYPOINT ["script/docker-entrypoint.sh"]

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# cljdoc web server launch script called from docker container
+
+set -eou pipefail
+
+echo "Preparing heap dump dir"
+DATA_DIR="$(clojure -M script/get_cljdoc_data_dir.clj)"
+HEAP_DUMP_DIR="${DATA_DIR}/heapdumps"
+mkdir -p "${HEAP_DUMP_DIR}"
+
+echo "Launching cljdoc server"
+exec clojure \
+  -J-Dcljdoc.host=0.0.0.0 \
+  -J-XX:+HeapDumpOnOutOfMemoryError \
+  -J-XX:HeapDumpPath="${HEAP_DUMP_DIR}" \
+  -M -m cljdoc.server.system

--- a/script/get_cljdoc_data_dir.clj
+++ b/script/get_cljdoc_data_dir.clj
@@ -1,0 +1,9 @@
+;; a wee special purpose script to grab our configured cljdoc data directory
+(require '[clojure.java.io :as io]
+         '[cljdoc.config :as config])
+
+(println (-> (config/config)
+             (config/data-dir)
+             io/file
+             .getCanonicalPath
+             str))


### PR DESCRIPTION
Ask the JVM to dump the heap when it encounters an out
of memory error.

Apparently there is no penalty for this action.

Should be useful in diagnosing our next out of memory error.

Can analyze dump file with tools like:
- jvisualvm
- Eclipse Memory Analyzer

Closes #524