### PR TITLE
maint: upgrade clj-kondo

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -5,5 +5,6 @@
            clojure.java.jdbc/with-db-transaction clojure.core/let
            clojure.test.check.clojure-test/defspec clojure.core/def
            clojure.test.check.properties/for-all clojure.core/let}
- :linters {:unused-binding {:exclude-destructured-keys-in-fn-args true}
+ :linters {:redundant-fn-wrapper {:level :warning} ;; experimental linter, let's give it a go
+           :unused-binding {:exclude-destructured-keys-in-fn-args true}
            :unresolved-var {:exclude [clj-commons.digest/sha-256]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -86,7 +86,7 @@
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.01.15"}}
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.02.09"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :cli

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -501,9 +501,7 @@
          :search     [(interceptor/interceptor {:name ::search :enter #(pu/ok-html % (render-search/search-page %))})]
          :shortcuts  [(interceptor/interceptor {:name ::shortcuts :enter #(pu/ok-html % (render-meta/shortcuts %))})]
          :sitemap    [(sitemap-interceptor storage)]
-         :show-build [(pu/coerce-body-conf
-                       (fn html-render [ctx]
-                         (cljdoc.render.build-log/build-page ctx)))
+         :show-build [(pu/coerce-body-conf cljdoc.render.build-log/build-page)
                       (pu/negotiate-content #{"text/html" "application/edn" "application/json"})
                       (show-build build-tracker)]
          :all-builds [(all-builds build-tracker)]


### PR DESCRIPTION
Enabled new redundant-fn-wrapper linter.

Much to my surprise, given the number of folks who have worked on
cljdoc, it only found one instance of unnecessary wrapping!