### PR TITLE
Only render [[wikilinks]] when appropriate

### DIFF
--- a/doc/running-cljdoc-locally.adoc
+++ b/doc/running-cljdoc-locally.adoc
@@ -12,7 +12,7 @@
 :example-project-clone-url: https://github.com/cljdoc/cljdoc-exerciser.git
 :example-project-import-url: https://github.com/cljdoc/cljdoc-exerciser
 :example-project-coords: org.cljdoc/cljdoc-exerciser
-:example-project-version: 1.0.71
+:example-project-version: 1.0.77
 
 [[introduction]]
 == Introduction

--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -88,8 +88,9 @@
   (assert (:namespace route-params))
   (let [version-entity (:version-entity cache-bundle)
         ns-emap route-params
-        defs    (bundle/defs-for-ns-with-src-uri cache-bundle (:namespace ns-emap))
-        [[dominant-platf] :as platf-stats] (api/platform-stats defs)
+        valid-ref-pred (api/valid-ref-pred-fn cache-bundle)
+        ns-defs    (bundle/defs-for-ns-with-src-uri cache-bundle (:namespace ns-emap))
+        [[dominant-platf] :as platf-stats] (api/platform-stats ns-defs)
         ns-data (bundle/get-namespace cache-bundle (:namespace ns-emap))
         top-bar-component (layout/top-bar version-entity (bundle/scm-url cache-bundle))
         fix-opts {:scm (-> cache-bundle :version :scm)
@@ -103,12 +104,13 @@
            (layout/layout
             {:top-bar top-bar-component
              :main-sidebar-contents (sidebar/sidebar-contents route-params cache-bundle last-build)
-             :vars-sidebar-contents (when (seq defs)
+             :vars-sidebar-contents (when (seq ns-defs)
                                       [(api/platform-support-note platf-stats)
-                                       (api/definitions-list ns-emap defs {:indicate-platforms-other-than dominant-platf})])
+                                       (api/definitions-list ns-emap ns-defs {:indicate-platforms-other-than dominant-platf})])
              :content (api/namespace-page {:ns-entity ns-emap
                                            :ns-data ns-data
-                                           :defs defs
+                                           :defs ns-defs
+                                           :valid-ref-pred valid-ref-pred
                                            :fix-opts fix-opts})})
            (layout/layout
             {:top-bar top-bar-component
@@ -116,6 +118,7 @@
              :content (api/sub-namespace-overview-page {:ns-entity ns-emap
                                                         :namespaces (bundle/namespaces cache-bundle)
                                                         :defs (bundle/all-defs cache-bundle)
+                                                        :valid-ref-pred valid-ref-pred
                                                         :fix-opts fix-opts})}))
          (layout/page {:title (str (:namespace ns-emap) " — " (proj/clojars-id version-entity) " " (:version version-entity))
                        :canonical-url (some->> (bundle/more-recent-version cache-bundle)

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -43,6 +43,15 @@
    [:pre.lh-copy.bg-near-white.code.pa3.br2.f6.overflow-x-scroll.dn.raw
     doc-str]])
 
+(defn valid-ref-pred-fn [{:keys [defs] :as _cache-bundle}]
+  (fn [current-ns target-ns target-var]
+    (let [target-ns (if target-ns (ns-tree/replant-ns current-ns target-ns) current-ns)]
+      (if target-var
+        (some #(and (= target-var (:name %))
+                    (= target-ns (:namespace %)))
+              defs)
+        (some #(= target-ns (:namespace %)) defs)))))
+
 (defn render-wiki-link-fn
   "Given the `current-ns` and a function `ns-link-fn` that is assumed
   to return a link to a passed namespace, return a function that receives
@@ -236,15 +245,6 @@
         (for [adef defs]
           (def-block adef render-wiki-link fix-opts))
         [:p.i.blue "No vars found in this namespace."])]]))
-
-(defn valid-ref-pred-fn [{:keys [defs] :as _cache-bundle}]
-  (fn [current-ns target-ns target-var]
-    (let [target-ns (or target-ns current-ns)]
-      (if target-var
-        (some #(and (= target-var (:name %))
-                    (= target-ns (:namespace %)))
-              defs)
-        (some #(= target-ns (:namespace %)) defs)))))
 
 (comment
   (:platforms --d)

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -47,10 +47,11 @@
   "Given the `current-ns` and a function `ns-link-fn` that is assumed
   to return a link to a passed namespace, return a function that receives
   a `[ns var]` tuple and will return a Markdown link to the specified ns/var."
-  [current-ns ns-link-fn]
+  [current-ns valid-ref-pred ns-link-fn]
   (fn render-wiki-link-inner [[ns var]]
-    (str (ns-link-fn (if ns (ns-tree/replant-ns current-ns ns) current-ns))
-         (when var (str "#" var)))))
+    (when (valid-ref-pred current-ns ns var)
+      (str (ns-link-fn (if ns (ns-tree/replant-ns current-ns ns) current-ns))
+           (when var (str "#" var))))))
 
 (defn render-doc [mp render-wiki-link fix-opts]
   (if (platf/varies? mp :doc)
@@ -183,7 +184,7 @@
               (humanize-supported-platforms))])])]])
 
 (defn namespace-overview
-  [ns-url-fn mp-ns defs fix-opts]
+  [ns-url-fn mp-ns defs valid-ref-pred fix-opts]
   {:pre [(platf/multiplatform? mp-ns) (fn? ns-url-fn)]}
   (let [ns-name (platf/get-field mp-ns :name)]
     [:div
@@ -194,7 +195,7 @@
        ns-name
        [:img.ml2 {:src "https://microicon-clone.vercel.app/chevron/12/357edd"}]]]
      (render-doc mp-ns
-                 (render-wiki-link-fn ns-name ns-url-fn)
+                 (render-wiki-link-fn ns-name valid-ref-pred ns-url-fn)
                  fix-opts)
      (if-not (seq defs)
        [:p.i.blue "No vars found in this namespace."]
@@ -211,20 +212,21 @@
             def-name]])])]))
 
 (defn sub-namespace-overview-page
-  [{:keys [ns-entity namespaces defs fix-opts]}]
+  [{:keys [ns-entity namespaces defs valid-ref-pred fix-opts]}]
   [:div.mw7.center.pv4
    (for [mp-ns (->> namespaces
                     (filter #(.startsWith (platf/get-field % :name) (:namespace ns-entity))))
          :let [ns (platf/get-field mp-ns :name)
                ns-url-fn #(routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace %))
                defs (bundle/defs-for-ns defs ns)]]
-     (namespace-overview ns-url-fn mp-ns defs fix-opts))])
+     (namespace-overview ns-url-fn mp-ns defs valid-ref-pred fix-opts))])
 
-(defn namespace-page [{:keys [ns-entity ns-data defs fix-opts]}]
+(defn namespace-page [{:keys [ns-entity ns-data defs valid-ref-pred fix-opts]}]
   (cljdoc.spec/assert :cljdoc.spec/namespace-entity ns-entity)
   (assert (platf/multiplatform? ns-data))
   (let [render-wiki-link (render-wiki-link-fn
                           (:namespace ns-entity)
+                          valid-ref-pred
                           #(routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace %)))]
     [:div.ns-page
      [:div.w-80-ns.pv4
@@ -235,8 +237,19 @@
           (def-block adef render-wiki-link fix-opts))
         [:p.i.blue "No vars found in this namespace."])]]))
 
+(defn valid-ref-pred-fn [{:keys [defs] :as _cache-bundle}]
+  (fn [current-ns target-ns target-var]
+    (let [target-ns (or target-ns current-ns)]
+      (if target-var
+        (some #(and (= target-var (:name %))
+                    (= target-ns (:namespace %)))
+              defs)
+        (some #(= target-ns (:namespace %)) defs)))))
+
 (comment
   (:platforms --d)
+
+  (routes/url-for :artifact/namespace :path-params {:group-id "grp" :artifact-id "art" :version "ver" :namespace "foo boo loo"})
 
   (let [platforms (:platforms --d)]
     (< 1 (count (set (map :doc platforms)))))

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -121,7 +121,7 @@
          :let [defs (bundle/defs-for-ns
                       (bundle/all-defs cache-bundle)
                       (platf/get-field ns :name))]]
-     (api/namespace-overview ns-url ns defs fix-opts))])
+     (api/namespace-overview ns-url ns defs  (api/valid-ref-pred-fn cache-bundle) fix-opts))])
 
 (defn- doc-page [doc-tuple fix-opts]
   [:div
@@ -130,9 +130,9 @@
      (fixref/fix (rich-text/render-text doc-tuple)
                  fix-opts))]])
 
-(defn- ns-page [ns defs fix-opts]
+(defn- ns-page [ns defs valid-ref-pred fix-opts]
   (let [ns-name (platf/get-field ns :name)
-        render-wiki-link (api/render-wiki-link-fn ns-name #(str % ".html"))]
+        render-wiki-link (api/render-wiki-link-fn ns-name valid-ref-pred #(str % ".html"))]
     [:div.ns-offline-page
      [:h1 ns-name]
      (api/render-doc ns render-wiki-link fix-opts)
@@ -201,9 +201,10 @@
             :let [defs (bundle/defs-for-ns-with-src-uri cache-bundle (platf/get-field ns-data :name))
                   target-file (ns-url (platf/get-field ns-data :name))]]
         [target-file
-         (->> (ns-page ns-data defs (assoc fix-opts
-                                           ;; :scm-file-path - we don't currently have scm file for namespaces
-                                           :target-path (.getParent (io/file target-file))))
+         (->> (ns-page ns-data defs (api/valid-ref-pred-fn cache-bundle)
+                       (assoc fix-opts
+                              ;; :scm-file-path - we don't currently have scm file for namespaces
+                              :target-path (.getParent (io/file target-file))))
               (page' {:namespace (platf/get-field ns-data :name)}))])])))
 
 (defn zip-stream [{:keys [version-entity] :as cache-bundle} static-resources]

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -1,7 +1,7 @@
 (ns cljdoc.render.rich-text
   (:require [cljdoc.render.sanitize :as sanitize])
   (:import (org.asciidoctor Asciidoctor Asciidoctor$Factory Options)
-           (com.vladsch.flexmark.parser Parser)
+           (com.vladsch.flexmark.parser Parser LinkRefProcessorFactory LinkRefProcessor)
            (com.vladsch.flexmark.html HtmlRenderer LinkResolverFactory LinkResolver)
            (com.vladsch.flexmark.html.renderer ResolvedLink LinkType LinkStatus LinkResolverBasicContext DelegatingNodeRendererFactory NodeRenderer NodeRenderingHandler NodeRenderingHandler$CustomNodeRenderer)
            (com.vladsch.flexmark.ext.tables TablesExtension)
@@ -9,7 +9,10 @@
            (com.vladsch.flexmark.ext.anchorlink AnchorLinkExtension)
            (com.vladsch.flexmark.ext.wikilink WikiLinkExtension WikiLink)
            (com.vladsch.flexmark.ext.wikilink.internal WikiLinkNodeRenderer$Factory)
-           (com.vladsch.flexmark.util.data MutableDataSet DataHolder)))
+           (com.vladsch.flexmark.util.data MutableDataSet DataHolder)
+           #_{:clj-kondo/ignore [:unused-import]} ;; clj-kondo thinks we are not using Node
+           (com.vladsch.flexmark.util.ast Document Node)
+           (com.vladsch.flexmark.util.sequence BasedSequence)))
 
 (def ^Asciidoctor adoc-container
   (Asciidoctor$Factory/create))
@@ -25,69 +28,117 @@
 (def md-extensions
   [(TablesExtension/create)
    (AutolinkExtension/create)
-   (AnchorLinkExtension/create)
-   (WikiLinkExtension/create)])
+   (AnchorLinkExtension/create)])
 
-(def ^Parser md-container
-  (.. (Parser/builder
-       (doto (MutableDataSet.)
-         ;; Conform to GitHub tables
-         ;; https://github.com/vsch/flexmark-java/issues/370#issuecomment-590074667
-         (.set TablesExtension/COLUMN_SPANS false)
-         (.set TablesExtension/APPEND_MISSING_COLUMNS true)
-         (.set TablesExtension/DISCARD_EXTRA_COLUMNS true)
-         (.set TablesExtension/HEADER_SEPARATOR_COLUMN_MATCH true)
-         ;; and I think these are needed too:
-         ;; https://github.com/vsch/flexmark-java/issues/370#issuecomment-1033215255
-         (.set TablesExtension/WITH_CAPTION false)
-         (.set TablesExtension/MIN_HEADER_ROWS (int 1))
-         (.set TablesExtension/MAX_HEADER_ROWS (int 1))
-         (.toImmutable)))
-      (extensions md-extensions)
-      (build)))
+(def md-parser-opts (doto (MutableDataSet.)
+                      ;; Conform to GitHub tables
+                      ;; https://github.com/vsch/flexmark-java/issues/370#issuecomment-590074667
+                      (.set TablesExtension/COLUMN_SPANS false)
+                      (.set TablesExtension/APPEND_MISSING_COLUMNS true)
+                      (.set TablesExtension/DISCARD_EXTRA_COLUMNS true)
+                      (.set TablesExtension/HEADER_SEPARATOR_COLUMN_MATCH true)
+                      ;; and I think these are needed too:
+                      ;; https://github.com/vsch/flexmark-java/issues/370#issuecomment-1033215255
+                      (.set TablesExtension/WITH_CAPTION false)
+                      (.set TablesExtension/MIN_HEADER_ROWS (int 1))
+                      (.set TablesExtension/MAX_HEADER_ROWS (int 1))
+                      (.toImmutable)))
+
+(defn- md-parser
+  "Create a markdown parser
+  options:
+   :render-wiki-link - a lookup function for wikilink text inside [[]] -> href
+                       on nil return for `whatever`, `[[whatever]]` will be
+                       treated as regular markdown instead of as a wikilink."
+  ^Parser [{:keys [render-wiki-link]}]
+  (cond-> (Parser/builder md-parser-opts)
+
+    render-wiki-link
+    ;; Replicate the interesting parts of flexmark's WikiLinkLinkRefProcessor
+    ;; while customizing to our use case.
+    ;; We only want a wikilink to be considered such when it actually resolves.
+    (.linkRefProcessorFactory
+     (reify LinkRefProcessorFactory
+       (getWantExclamationPrefix [_this _opts] false)
+       (getBracketNestingLevel [_this _opts] 1)
+       (^LinkRefProcessor apply [_this ^Document _doc]
+         (reify LinkRefProcessor
+           (getWantExclamationPrefix [_this] false)
+           (getBracketNestingLevel [_this] 1)
+           (^boolean isMatch [_this ^BasedSequence node-chars]
+             (let [length (.length node-chars)]
+               (and (>= length 5)
+                    (= \[ (.charAt node-chars 0) (.charAt node-chars 1))
+                    (= \] (.endCharAt node-chars 1) (.endCharAt node-chars 2))
+                    (boolean (render-wiki-link (str (.subSequence node-chars 2 (- length 2))))))))
+           (adjustInlineText [_this _doc node]
+             (.getText node))
+           (allowDelimiters [_this _chars _doc _node] false)
+           (updateNodeElements [_this _doc _node])
+           (^Node createNode [_this ^BasedSequence chars]
+             (WikiLink. chars
+                        true  ;; link is first, as in [[link|optional text]]
+                        false ;; allow anchors
+                        false ;; can escape pipe
+                        false ;; can escape anchor
+                        ))))))
+
+    :always
+    (-> (.extensions md-extensions)
+        (.build))))
+
+(def md-render-opts (doto (MutableDataSet.)
+                      (.set AnchorLinkExtension/ANCHORLINKS_ANCHOR_CLASS "md-anchor")
+                      (.set HtmlRenderer/FENCED_CODE_NO_LANGUAGE_CLASS "language-clojure")
+                      (.toImmutable)))
 
 (defn- md-renderer
-  "Create a Markdown renderer."
-  ^HtmlRenderer [{:keys [escape-html? render-wiki-link]
-                  :as _opts}]
-  (.. (HtmlRenderer/builder
-       (doto (MutableDataSet.)
-         (.set AnchorLinkExtension/ANCHORLINKS_ANCHOR_CLASS "md-anchor")
-         (.set HtmlRenderer/FENCED_CODE_NO_LANGUAGE_CLASS "language-clojure")
-         (.toImmutable)))
-      (escapeHtml (boolean escape-html?))
-      ;; Resolve wikilinks
-      (linkResolverFactory
-       (reify LinkResolverFactory
-         (getAfterDependents [_this] nil)
-         (getBeforeDependents [_this] nil)
-         (affectsGlobalScope [_this] false)
-         (^LinkResolver apply [_this ^LinkResolverBasicContext _ctx]
-           (reify LinkResolver
-             (resolveLink [_this _node _ctx link]
-               (if (= (.getLinkType link) WikiLinkExtension/WIKI_LINK)
-                 (ResolvedLink. LinkType/LINK
-                                ((or render-wiki-link identity) (.getUrl link))
-                                nil
-                                LinkStatus/UNCHECKED)
-                 link))))))
-      ;; Wrap wikilinks content in <code>
-      (nodeRendererFactory
-       (reify DelegatingNodeRendererFactory
-         (getDelegates [_this]
-           #{WikiLinkNodeRenderer$Factory})
-         (^NodeRenderer apply [_this ^DataHolder _options]
-           (reify NodeRenderer
-             (getNodeRenderingHandlers [_this]
-               #{(NodeRenderingHandler.
-                  WikiLink
-                  (reify NodeRenderingHandler$CustomNodeRenderer
-                    (render [_this node ctx html]
-                      (let [resolved-link (.resolveLink ctx WikiLinkExtension/WIKI_LINK (.. node getLink unescape) nil)
-                            url (.getUrl resolved-link)]
-                        (.raw html (str "<a href=\"" url "\" data-source=\"wikilink\"><code>" (.. node getLink) "</code></a>"))))))})))))
-      (extensions md-extensions)
-      (build)))
+  "Create a Markdown renderer.
+  options:
+   :escape-html? - when true escape all inline html
+   :render-wiki-link - a lookup function for wikilink text inside [[]] -> href
+                       assumes wikilink has been validated by parser."
+  ^HtmlRenderer [{:keys [escape-html? render-wiki-link]}]
+  (cond-> (HtmlRenderer/builder md-render-opts)
+    :always
+    (.escapeHtml (boolean escape-html?))
+
+    render-wiki-link
+    (-> (.linkResolverFactory
+         (reify LinkResolverFactory
+           (getAfterDependents [_this] nil)
+           (getBeforeDependents [_this] nil)
+           (affectsGlobalScope [_this] false)
+           (^LinkResolver apply [_this ^LinkResolverBasicContext _ctx]
+             (reify LinkResolver
+               (resolveLink [_this _node _ctx link]
+                 ;; our parser has already validated the link will resolve,
+                 ;; otherwise we would not be here.
+                 (if (= (.getLinkType link) WikiLinkExtension/WIKI_LINK)
+                   (let [ref (.getUrl link)
+                         resolved-ref (render-wiki-link ref)]
+                     (ResolvedLink. LinkType/LINK
+                                    resolved-ref
+                                    nil ;; attributes
+                                    LinkStatus/VALID))
+                   link))))))
+        (.nodeRendererFactory
+         (reify DelegatingNodeRendererFactory
+           (getDelegates [_this]
+             #{WikiLinkNodeRenderer$Factory})
+           (^NodeRenderer apply [_this ^DataHolder _options]
+             (reify NodeRenderer
+               (getNodeRenderingHandlers [_this]
+                 #{(NodeRenderingHandler.
+                    WikiLink
+                    (reify NodeRenderingHandler$CustomNodeRenderer
+                      (render [_this node ctx html]
+                        (let [url (-> (.resolveLink ctx WikiLinkExtension/WIKI_LINK (-> node .getLink .unescape) nil)
+                                      .getUrl)]
+                          (.raw html (str "<a href=\"" url "\" data-source=\"wikilink\"><code>" (.getLink node) "</code></a>"))))))}))))))
+
+    :always (-> (.extensions md-extensions)
+                (.build))))
 
 (defn markdown-to-html
   "Parse the given string as Markdown and return HTML.
@@ -99,7 +150,7 @@
   ([^String input-str]
    (markdown-to-html input-str {}))
   ([^String input-str opts]
-   (->> (.parse md-container input-str)
+   (->> (.parse (md-parser opts) input-str)
         (.render (md-renderer opts))
         sanitize/clean)))
 
@@ -134,7 +185,20 @@
 
   (markdown-to-html "*hello world* <code>x</code>" {:escape-html? true})
 
-  (markdown-to-html "*hello world* [[link]]" {:escape-html? true
-                                              :render-wiki-link (constantly "???")})
+  (markdown-to-html "*hello world* [[some/var|alt-text]]" {:escape-html? true
+                                                           :render-wiki-link (constantly "target-url")})
+
+  (markdown-to-html "*hello world* [[some/var]]" {:escape-html? true
+                                                  :render-wiki-link (constantly "target-url")})
+
+  (markdown-to-html "*hello world* [[something unresolved]]" {:escape-html? true
+                                                              :render-wiki-link (constantly nil)})
+
+  (markdown-to-html "*hello world* [[*something unresolved*]]" {:escape-html? true
+                                                                :render-wiki-link (constantly nil)})
+
+  (markdown-to-html "*hello world* [[some text]]" {:escape-html? true})
+
+  (markdown-to-html "*hello world* [[**some text**]]" {:escape-html? true})
 
   (asciidoc-to-html "ifdef::env-cljdoc[]\nCLJDOC\nendif::[]\nifndef::env-cljdoc[]\nNOT_CLJDOC\nendif::[]"))

--- a/test/cljdoc/util/ns_tree_test.clj
+++ b/test/cljdoc/util/ns_tree_test.clj
@@ -5,4 +5,6 @@
 (t/deftest replant-ns-test
   (t/is (= "my.app.routes" (ns-tree/replant-ns "my.app.core" "routes")))
   (t/is (= "my.app.api.routes" (ns-tree/replant-ns "my.app.core" "api.routes")))
-  (t/is (= "my.app.api.handlers" (ns-tree/replant-ns "my.app.core" "my.app.api.handlers"))))
+  (t/is (= "my.app.api.handlers" (ns-tree/replant-ns "my.app.core" "my.app.api.handlers")))
+  (t/is (= "my.different.ns.here" (ns-tree/replant-ns "my.app.core" "my.different.ns.here")))
+  (t/is (= "my.app.ns2" (ns-tree/replant-ns "my.app.ns1" "ns2"))))


### PR DESCRIPTION
We now only render wikilinks as links when:
- wikilink rendering is enabled (i.e. for docstrings only)
- when the text inside the wikilink resolves to an existing namespace
  or var in the library
- wikilink syntax does not include text, ex. [[my.ns/var|text]] will
  render as self

Although we make use of elements of the flexmark wikilink extension
we no longer register it as an extension.

One could argue that we should just write our own flexmark extension
for cljdoc wikilinks, but this seems to be working for the time being.

Closes #507