### PR TITLE
Analysis is now saved to cljdoc-analysis.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,7 @@
 
         ;; cljoc and cljdoc-analyzer should reference same version of cljdoc-shared
         cljdoc/cljdoc-shared {:git/url "https://github.com/cljdoc/cljdoc-shared.git"
-                              :git/sha "834006d527ac00b58194ff752eb0b5db3653e4b0"}}
+                              :git/sha "30bcba1bf6ad0ff9f3496a46949dd590f87dcd7e"}}
 
  :paths ["src" "resources" "resources-compiled"]
  :aliases {:test

--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -35,7 +35,7 @@
    :repos   repos})
 
 (def analyzer-version
-  "5caf14018c09212a558a2aa5e88bfa78dcfa64a4")
+  "50d5e657172d99ec5fb046142747347036fb9859")
 
 (def analyzer-dependency
   {:deps {'cljdoc/cljdoc-analyzer {:git/url "https://github.com/cljdoc/cljdoc-analyzer.git"
@@ -69,12 +69,12 @@
     (assert (integer? build-num))
     (let [done-build (poll-circle-ci-build this build-num)
           success?   (contains? #{"success" "fixed"} (get done-build "status"))
-          cljdoc-edn (analysis/result-file project version)
+          cljdoc-analysis-edn (analysis/result-file project version)
           artifacts (-> (get-circle-ci-build-artifacts this build-num)
                         :body json/parse-string)]
       (if-let [artifact (and success?
                              (= 1 (count artifacts))
-                             (= cljdoc-edn (get (first artifacts) "path"))
+                             (= cljdoc-analysis-edn (get (first artifacts) "path"))
                              (first artifacts))]
         {:analysis-result (get artifact "url")}
         (throw (ex-info "Analysis on CircleCI failed"
@@ -138,8 +138,8 @@
       (let [proc            (sh/sh "clojure" "-Sdeps" (pr-str analyzer-dependency)
                                    "-M" "-m" "cljdoc-analyzer.cljdoc-main" (pr-str (ng-analysis-args arg repos))
                                    :dir (doto (io/file "/tmp/cljdoc-analysis-runner-dir/") (.mkdir)))
-            cljdoc-edn-file (analysis/result-path project version)]
-        {:analysis-result cljdoc-edn-file
+            cljdoc-analysis-edn-file (analysis/result-path project version)]
+        {:analysis-result cljdoc-analysis-edn-file
          :proc proc})))
   (wait-for-build
     [_ build-future]

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -32,7 +32,7 @@
             ns-count     (let [{:strs [clj cljs]} (:analysis data)]
                            (count (set (into (map :name cljs) (map :name clj)))))]
         (build-log/analysis-received! build-tracker build-id file-uri)
-        (ingest/ingest-cljdoc-edn storage data)
+        (ingest/ingest-cljdoc-analysis-edn storage data)
         (build-log/api-imported! build-tracker build-id ns-count)
         (build-log/completed! build-tracker build-id))
       (catch Exception e

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -12,7 +12,7 @@
     ;; "Track a request for analysis and return the build's ID."
     [_ group-id artifact-id version])
   (analysis-kicked-off! [_ build-id analysis-job-uri analyzer-version])
-  (analysis-received! [_ build-id cljdoc-edn-uri])
+  (analysis-received! [_ build-id cljdoc-analysis-edn-uri])
   (failed! [_ build-id error] [_ build-id error e])
   (api-imported! [_ build-id namespaces-count])
   (git-completed! [_ build-id git-result])
@@ -40,10 +40,10 @@
                   :analysis_triggered_ts (now)
                   :analyzer_version analyzer-version}
                  ["id = ?" build-id]))
-  (analysis-received! [_ build-id cljdoc-edn-uri]
+  (analysis-received! [_ build-id cljdoc-analysis-edn-uri]
     (sql/update! db-spec
                  "builds"
-                 {:analysis_result_uri cljdoc-edn-uri
+                 {:analysis_result_uri cljdoc-analysis-edn-uri
                   :analysis_received_ts (now)}
                  ["id = ?" build-id]))
   (failed! [this build-id error]

--- a/src/cljdoc/server/ingest.clj
+++ b/src/cljdoc/server/ingest.clj
@@ -10,13 +10,13 @@
             [cljdoc.storage.api :as storage]
             [cljdoc-shared.spec.analyzer :as analyzer-spec]))
 
-(defn ingest-cljdoc-edn
-  "Store all the API-related information in the passed `cljdoc-edn` data"
-  [storage {:keys [analysis group-id artifact-id version] :as cljdoc-edn}]
-  (let [project (proj/clojars-id cljdoc-edn)
+(defn ingest-cljdoc-analysis-edn
+  "Store all the API-related information in the passed `cljdoc-analysis-edn` data"
+  [storage {:keys [analysis group-id artifact-id version] :as cljdoc-analysis-edn}]
+  (let [project (proj/clojars-id cljdoc-analysis-edn)
         artifact (storage/version-entity project version)]
-    (log/info "Verifying cljdoc-edn contents against spec")
-    (analyzer-spec/assert-result-full cljdoc-edn)
+    (log/info "Verifying cljdoc analysis edn contents against spec")
+    (analyzer-spec/assert-result-full cljdoc-analysis-edn)
     (log/infof "Importing API into database %s %s" project version)
     (storage/import-api storage artifact (codox/sanitize-macros analysis))))
 

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -288,6 +288,7 @@
     (update-version-meta! db-spec version-id {:jar jar :scm scm, :doc doc-tree, :config config})))
 
 (comment
+  ;; Note to reader: if this link still worked, it would reference new naming convention: .../cljdoc-analysis-edn/.../cljdoc-analysis.edn
   (def data (clojure.edn/read-string (slurp "https://2941-119377591-gh.circle-artifacts.com/0/cljdoc-edn/stavka/stavka/0.4.1/cljdoc.edn")))
 
   (def db-spec


### PR DESCRIPTION
The goal is to avoid future confusion, includes updating of bindings and
variable names, etc.

Closes #540