### PR TITLE
maint: bump highlight.js

### DIFF
--- a/resources/asset-deps.edn
+++ b/resources/asset-deps.edn
@@ -78,7 +78,7 @@
                  "jax/output/PreviewHTML/jax.js"]}}
  :highlightjs
  {:npm-name "highlight.js"
-  :version "9.12.0"
+  :version "11.4.0"
   :js {:root "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@{{:version}}/build/"
        :assets ["highlight.min.js"
                 "languages/clojure.min.js"

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -14,7 +14,7 @@
   [:script
    (hiccup/raw
     "hljs.registerLanguage('cljs', function (hljs) { return hljs.getLanguage('clj') });
-      hljs.initHighlightingOnLoad();")])
+      hljs.highlightAll();")])
 
 (defn highlight-js []
   [:div


### PR DESCRIPTION
Addressed usage of deprecated call.

This bump includes some refinements to Clojure syntax highlighting

Verified change is active and working in offline bundles.

**Before Upgrade**
![image](https://user-images.githubusercontent.com/967328/156666881-a20f6a75-5d07-43a1-bbe6-b780416813f9.png)

**After Upgrade**
![image](https://user-images.githubusercontent.com/967328/156666752-1352d0bf-ef1e-416f-ac19-dd89b2cea771.png)


