### PR TITLE
Automatically select cljdoc-analyzer release

### DIFF
--- a/src/cljdoc/git_repo.clj
+++ b/src/cljdoc/git_repo.clj
@@ -5,6 +5,7 @@
             [clojure.spec.alpha :as s]
             [clj-commons.digest :as digest])
   (:import  (org.eclipse.jgit.lib RepositoryBuilder
+                                  ObjectId
                                   ObjectIdRef$PeeledNonTag
                                   ObjectIdRef$PeeledTag
                                   ObjectLoader
@@ -202,7 +203,22 @@
   (or (cljdoc.git-repo/slurp-file-at repo rev "doc/cljdoc.edn")
       (cljdoc.git-repo/slurp-file-at repo rev "docs/cljdoc.edn")))
 
+(defn ls-remote-sha
+  "Return git sha for remote tag"
+  [^String uri tag]
+  (some-> (LsRemoteCommand. nil)
+          (.setHeads false)
+          (.setTags true)
+          (.setRemote uri)
+          (.callAsMap)
+          (get (str "refs/tags/" tag) nil)
+          (.getObjectId)
+          (ObjectId/toString)))
+
 (comment
+  (ls-remote-sha "https://github.com/cljdoc/cljdoc-analyzer.git" "RELEASE")
+  (ls-remote-sha "git@github.com:cljdoc/cljdoc-analyzer.git" "RELEASE")
+
   (def r (->repo (io/file "data/git-repos/fulcrologic/fulcro/2.5.4/")))
 
   (def r (->repo (io/file "/Users/martin/code/02-oss/bidi")))

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -11,8 +11,7 @@
 (defn analyze-and-import-api!
   [{:keys [analysis-service storage build-tracker]}
    {:keys [project version jar pom languages build-id]}]
-  (let [ana-v    analysis-service/analyzer-version
-        ana-resp (analysis-service/trigger-build
+  (let [ana-resp (analysis-service/trigger-build
                   analysis-service
                   {:project project
                    :version version
@@ -21,8 +20,10 @@
                    :languages languages
                    :build-id build-id})]
 
-    ;; `build-url` and `ana-v` are only set for CircleCI
-    (build-log/analysis-kicked-off! build-tracker build-id (:build-url ana-resp) ana-v)
+    ;; `build-url` is only set for CircleCI
+    (build-log/analysis-kicked-off! build-tracker build-id
+                                    (:build-url ana-resp)
+                                    (:analyzer-version ana-resp))
 
     (try
       (let [build-result (analysis-service/wait-for-build analysis-service ana-resp)


### PR DESCRIPTION
Use the cljdoc-analyzer's new RELEASE git tag to automatically select
its current production release.

We continue to log the associated long sha as the version.

Includes minor rework to local analysis.
Build kick off now returns map with future proc instead of future map.
This allows kick off caller to inspect return of kick off for
returned analyzer version.

Closes #549