### PR TITLE
maint: upgrade lucene to current

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -21,9 +21,9 @@
         com.taoensso/nippy {:mvn/version "3.1.1"}            ;; fast compact serializer that we use for blobs
 
         ;; full text search database
-        org.apache.lucene/lucene-core {:mvn/version "8.1.1"} ;; search engine
-        org.apache.lucene/lucene-analyzers-common {:mvn/version "8.1.1"}
-        org.apache.lucene/lucene-queryparser {:mvn/version "8.1.1"}
+        org.apache.lucene/lucene-core {:mvn/version "9.0.0"} ;; search engine
+        org.apache.lucene/lucene-analysis-common {:mvn/version "9.0.0"}
+        org.apache.lucene/lucene-queryparser {:mvn/version "9.0.0"}
 
         ;; markdown
         org.asciidoctor/asciidoctorj {:mvn/version "2.5.3"}  ;; render adoc to html

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -27,7 +27,7 @@
                [{:appender :sentry}])})
 
 (defn index-dir [env-config]
-  (str (cfg/data-dir env-config) "index"))
+  (str (cfg/data-dir env-config) "index-lucene9"))
 
 (defn system-config [env-config]
   (let [ana-service (cfg/analysis-service env-config)]


### PR DESCRIPTION
This brings us to lucene v9.

Adapted to v9 artifact name changes.

The lucene v9 index is incompatible with lucene v8, so I've updated our
storage for indexes from index to index-lucene9 under the data dir.

This also helps to identify what is stored under this dir.

The old "index" dir can be deleted at some later time.