### PR TITLE
Distinguish analysis timeout error

### DIFF
--- a/src/cljdoc/analysis/service.clj
+++ b/src/cljdoc/analysis/service.clj
@@ -120,7 +120,8 @@
             (recur (dec n)))
 
         :else
-        (throw (ex-info "Build timeout" {:build-num build-num}))))))
+        (throw (ex-info "Build timeout" {:cljdoc/error "analysis-job-timeout"
+                                         :build-num build-num}))))))
 
 ;; Local Analysis Service -------------------------------------------------------
 

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -36,8 +36,9 @@
         (build-log/api-imported! build-tracker build-id ns-count)
         (build-log/completed! build-tracker build-id))
       (catch Exception e
-        (log/errorf e "analysis job failed for project: %s, version: %s, build-id: %s" project version build-id)
-        (build-log/failed! build-tracker build-id "analysis-job-failed")))))
+        (let [d (ex-data e)]
+          (log/errorf e "analysis job failed for project: %s, version: %s, build-id: %s" project version build-id)
+          (build-log/failed! build-tracker build-id (or (:cljdoc/error d) "analysis-job-failed")))))))
 
 (defn kick-off-build!
   "Run the Git analysis for the provided `project` and kick off an


### PR DESCRIPTION
When cljdoc gives up waiting for CircleCI job to complete API analysis,
indicate a timeout error instead of a generic failure.

Closes #446
Closes #456