### PR TITLE
Allow importing of svg files

### DIFF
--- a/js/svg.d.ts
+++ b/js/svg.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
Allow importing of svg files in tsx files such that they can be passed to the img tsx tag as a src like so:

```
import cactus from "../resources/public/cactus.svg";
<img src={cactus} />
```

This will make the rendered image tag have a src of something like `/cactus.df3ff92b.svg?1649565213993=`. The hash in the filename (`df3ff92b`) is derived from the file contents. This ensures that if the file content changes the url will change as well, avoiding image caching bugs. The query string includes the file modification time in milliseconds since epoch (`1649565213993`). I suspect that this helps avoid image caching bugs due to hash collisions.
