### PR TITLE
Return JSON for search-suggest API call

### DIFF
--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -292,7 +292,6 @@
     :enter (fn search-suggest-handler [ctx]
              (if-let [q (-> ctx :request :params :q)]
                (assoc ctx :response {:status  200
-                                     :headers {"Content-Type" "application/x-suggestions+json"}
                                      :body    (search-api/suggest searcher q)})
                (assoc ctx :response {:status 400 :headers {} :body "ERROR: Missing q query param"})))}))
 


### PR DESCRIPTION
We were explicitly setting the Content-Type response header.
Which seems like a good thing to do.

But this signals body coercion interceptors that we've already converted
the content type and that they need not coerce to JSON.
Which was not the case.

Closes #581