### PR TITLE
Give adoc table of contents title some oomph

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -317,6 +317,24 @@ table.frame-sides > colgroup + * > :first-child > * {
   font-size: 1em;
 }
 
+/* Asciidoc table of contents title is rendered as:
+
+   <div id="toctitle">Table of Contents</div>
+
+   Well give it the same ooomph as a level 1 heading (which is rendered as h2)
+ */
+
+.asciidoc #toctitle {
+  /* mimic h2 defaults */
+  font-size: 1.5em;
+  font-weight: bolder;
+  /* copied from tachyons css */
+  box-sizing: border-box;
+  line-height: 1.5;
+  font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir,
+    helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif;
+}
+
 /* Asciidoc admonition tip/note blocks
 
    When adoc icons attribute is set to fonts, example rendering:


### PR DESCRIPTION
The original, now ancient, issue showed some renderings that also
changed the formatting of the table of contents list. I decided against
this for the following reasons:
1. feature creep of the raised issue
2. would be inconsistent with a CommonMark manually hand-coded TOC

Closes #322

Before:
![image](https://user-images.githubusercontent.com/967328/164550933-92113d36-86ee-41eb-b87d-761c977f4cbb.png)

After:
![image](https://user-images.githubusercontent.com/967328/164550976-a3fe2eff-3656-4c4a-a2f3-1c728bbbb14e.png)
