### PR TITLE
Style kbd (md and adoc), menu & button (adoc)

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -715,6 +715,95 @@ table.frame-sides > colgroup + * > :first-child > * {
 }
 
 /*
+ * Keyboard
+ *
+ * Can be as simple as: <kbd>q</kbd>
+ */
+
+/* styling for any markup kdb element */
+.cljdoc-markup kbd {
+  display: inline-block;
+  color: #555;
+  font-size: 0.875rem;
+  background: #f7f7f7;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  margin: 0 0.15em;
+  padding: 0.2em 0.5em;
+  vertical-align: middle;
+  position: relative;
+  top: -0.1em;
+  white-space: nowrap;
+}
+
+/*
+  For AsciiDoc can be wrapped in a keyseq:
+  <span class="keyseq"><kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>space</kbd></span>
+*/
+
+.asciidoc .keyseq {
+  color: #777;
+}
+
+.asciidoc .keyseq kbd:first-child {
+  margin-left: 0;
+}
+
+.asciidoc .keyseq kbd:last-child {
+  margin-right: 0;
+}
+
+/* AsciiDoc ui menuseq
+<span class="menuseq">
+ <b class="menu">View</b>&nbsp;<i class="caret"></i>
+ <b class="submenu">Zoom</b>&nbsp;<i class="caret"></i>
+ <b class="menuitem">Reset</b>
+</span>
+*/
+.asciidoc .menuseq,
+.asciidoc .menuref {
+  color: #000;
+  font-weight: bold;
+}
+
+.asciidoc .menuseq b:not(.caret) {
+  font-weight: inherit;
+}
+
+.asciidoc .menuseq {
+  word-spacing: -0.02em;
+}
+
+.asciidoc .menuseq i.caret::before {
+  font-weight: bold;
+  text-align: center;
+  width: 0.45em;
+  font-style: normal;
+  content: ">";
+}
+
+/* AsciiDoc ui button
+   <b class="button">OK</b>
+*/
+
+.asciidoc b.button::before,
+.asciidoc b.button::after {
+  position: relative;
+  top: -1px;
+  font-weight: 400;
+}
+
+.asciidoc b.button::before {
+  content: "[";
+  padding: 0 3px 0 2px;
+}
+
+.asciidoc b.button::after {
+  content: "]";
+  padding: 0 2px 0 3px;
+}
+
+/*
  * Scroll Indicator
  */
 

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -20,15 +20,15 @@
 (defn asciidoc-to-html [^String file-content]
   (let [opts (doto (Options.)
                (.setAttributes
-                 (java.util.HashMap.
-                   {"env-cljdoc" true
-                    "sectlinks" true
-                    "experimental" true ;; don't let the "experimental" worry you,
-                                        ;; it now only means enable the stable
-                                        ;; kbd, menu and button macros
-                    "icons" "font"
-                    "outfilesuffix" ".adoc"
-                    "showtitle" true})))]
+                (java.util.HashMap.
+                 {"env-cljdoc" true
+                  "sectlinks" true
+                  "experimental" true ;; don't let the "experimental" worry you,
+                                      ;; it now only means enable the stable
+                                      ;; kbd, menu and button macros
+                  "icons" "font"
+                  "outfilesuffix" ".adoc"
+                  "showtitle" true})))]
     (-> (.convert adoc-container file-content opts)
         sanitize/clean)))
 

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -19,11 +19,16 @@
 
 (defn asciidoc-to-html [^String file-content]
   (let [opts (doto (Options.)
-               (.setAttributes (java.util.HashMap. {"env-cljdoc" true
-                                                    "sectlinks" true
-                                                    "icons" "font"
-                                                    "outfilesuffix" ".adoc"
-                                                    "showtitle" true})))]
+               (.setAttributes
+                 (java.util.HashMap.
+                   {"env-cljdoc" true
+                    "sectlinks" true
+                    "experimental" true ;; don't let the "experimental" worry you,
+                                        ;; it now only means enable the stable
+                                        ;; kbd, menu and button macros
+                    "icons" "font"
+                    "outfilesuffix" ".adoc"
+                    "showtitle" true})))]
     (-> (.convert adoc-container file-content opts)
         sanitize/clean)))
 

--- a/src/cljdoc/render/sanitize.clj
+++ b/src/cljdoc/render/sanitize.clj
@@ -340,7 +340,13 @@
 
       ;; for callout numbers and and potentially icons on admonitions
       (sanitize-classes
-       ["conum" "icon-important" "icon-warning" "icon-caution" "icon-tip" "icon-note"])
+       ["conum"]
+       ["caret"]
+       ["icon-important"]
+       ["icon-warning"]
+       ["icon-caution"]
+       ["icon-tip"]
+       ["icon-note"])
       (on-tags "i")
 
       (sanitize-classes


### PR DESCRIPTION
Mimicked adoc default styling for menu and & button.
Toned down kbd styling from adoc default css a bit.

Closes #613

md before:
![image](https://user-images.githubusercontent.com/967328/164914613-28146a1d-d812-4168-b890-0c3a68967525.png)

md after:
![image](https://user-images.githubusercontent.com/967328/164914623-4e8766f3-c630-4a92-93ec-2df28b5e0c0a.png)

adoc before:
![image](https://user-images.githubusercontent.com/967328/164914631-9409e6a3-fe3c-4a9c-9c08-88b429d746cb.png)

adoc after:
![image](https://user-images.githubusercontent.com/967328/164914651-e0f2bc06-9cd9-44c4-a151-8b81ea760b19.png)
