### PR TITLE
Hide search results when you click away from the search box

### DIFF
--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -485,6 +485,9 @@ const SingleDocsetSearch = (props: { url: string }) => {
             onBlur={(event: FocusEvent) => {
               const input = event.target as HTMLInputElement;
               input.classList.toggle("b--blue");
+              if (showResults) {
+                setShowResults(false);
+              }
             }}
             onKeyDown={(event: KeyboardEvent) => {
               const input = event.target as HTMLInputElement;


### PR DESCRIPTION
Right now if you click away from the search results box the search results stay visible. Instead we should hide the results when that is the case. This change fixes that.