### PR TITLE
Break down docset search by section headings

### DIFF
--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -8,7 +8,7 @@ import elasticlunr from "elasticlunr";
 
 elasticlunr.tokenizer.setSeperator(/[\s-.>=+\/]+/);
 
-const SEARCHSET_VERSION = 1;
+const SEARCHSET_VERSION = 2;
 
 type Namespace = {
   name: string;

--- a/resources/test_data/searchset.edn
+++ b/resources/test_data/searchset.edn
@@ -3572,76 +3572,5979 @@
    :type :var}],
  :docs
  [{:doc
-   "A library that reads and writes Clojure, ClojureScript and EDN from Clojure and ClojureScript in a whitespace and comment preserving way. Status Warning: v1 Alpha Release Our first rewrite-clj v1 alpha release was in March of 2021. Since then we have seen wide and successful adoption of rewrite-clj v1 with no show-stoppers. I would drop the alpha status but have not yet seen the following features get a good shake yet in the wild: zippers with :track-position? enabled zippers using :auto-resolve support paredit API See project page for current priorities. Docs User Guide Developer Guide Design Merging rewrite-clj and rewrite-cljs FAQ Used In… Some projects using rewrite-clj v1 ancient-clj 🐥 - Version Metadata Retrieval for Maven Artifacts antq 🐥 - Point out your outdated dependencies babashka 📍 - Native, fast starting Clojure interpreter for scripting carve 🐥 - Carve out the essentials of your Clojure app clerk 🐥 - Local-First Notebooks for Clojure cljfmt 🐥 - A tool for formatting Clojure code cljstyle 🐥 - A tool for formatting Clojure code clojure-lsp 🐥 - Language Server (LSP) for Clojure kusonga 🐥 - Renaming and moving namespaces in Clojure(script) refactor-nrepl 🐥 - nREPL middleware to support refactorings in an editor agnostic way rewrite-edn 🐥 - Utility lib on top of rewrite-clj with common operations to update EDN while preserving whitespace and comments test-doc-blocks 🐥 - Test AsciiDoc and CommonMark code blocks found in articles and docstrings umschreiben-clj 🐥 - Rewrite utilities for refactoring clojure files zprint 🐥 - Executables, uberjar, and library to beautifully format Clojure and Clojurescript source code and s-expressions Some projects using rewrite-clj v0 and/or rewrite-cljs depot 🐥 🩹 - Find newer versions of your dependencies in your deps.edn file kibit 🐥 - There’s a function for that! lein-ancient 🐥 - Check your Projects for outdated Dependencies mranderson 🐥 - Dependency inlining and shadowing mutant 🐥 - Mutation testing for Clojure repl-tooling 📍 - a base package for Clojure’s editor tooling update-leiningen-dependencies-skill 📍 - Track project.clj dependencies across different projects Have an update? Let us know! 🐥 canary tested against rewrite-clj v1 lib test suite 🩹 source required minor change to work with rewrite-clj v1 📍 no easy-peasy way to run automated unit tests found for this project Versioning Rewrite-clj versioning scheme is: major.minor.patch-test-qualifier major increments when a non alpha release API has been broken - something, as a rule, we’d like to avoid. minor increments to convey significant new features have been added. patch indicates bug fixes - it is the total number of commits in the repo. test-qualifier is absent for stable releases. Can be alpha, beta, rc1, etc. People Contributors Founders Current maintainers Changes Licences We honor the original MIT license from rewrite-clj v0. Code has been merged/adapted from: rewrite-cljs which has an MIT license clojure zip which is covered by Eclipse Public License 1.0",
+   "A library that reads and writes Clojure, ClojureScript and EDN from Clojure and ClojureScript in a whitespace and comment preserving way. ",
    :name "Readme",
-   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme"}
+   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#"}
   {:doc
-   "Changelog Table of Contents rewrite-clj v1 rewrite-clj v0 rewrite-clj v1 For a list of breaking changes see breaking changes. Unreleased v1.0.767-alpha fix :end-row :end-col metadata for root node #173 - thanks @mainej! docs: user guide correction, thanks @rgkirch! zip API docstrings now clearer about coercion #168 Gritty details of changes for this release v1.0.699-alpha team update: @borkdude is now officially a co-maintainer of rewrite-clj! Woot woot! rewrite-clj v1 minimum Clojure version is now v1.8.0 (was formerly v1.9.0) #164 internal rewrite-clj developer facing: Migrate from depstar to tools.build Gritty details of changes for this release v1.0.682-alpha update clojure tools.reader dependency to v1.3.6 a zipper created with both a custom :auto-resolve option and the :track-position? true option will now acknowledge and use the custom :auto-resolve #159 a Cons now coerces to a rewrite-clj list node #160 #161 (thanks @borkdude!) internal rewrite-clj developer facing: Now also linting rewrite-clj sources with Eastwood #158 (thanks @vemv!) Gritty details of changes for this release v1.0.644-alpha user guide and docstrings better explain sexpr-able? and what invalid code elements rewrite-clj parses #150 #151 rewrite-clj now exports clj-kondo config for its public API #146 ClojureScript compiler should no longer emit invalid deprecated warnings #153 Internal rewrite-clj developer facing: Switched from babashka scripts to babashka tasks, developer guide updated accordingly Gritty details of changes for this release v1.0.605-alpha rewrite-clj now understands the #! comment, a construct often used in scripts #145 Gritty details of changes for this release v1.0.594-alpha rewrite-clj now explicitly depends on the minimum version of Clojure required, v1.9.0, rather than v1.10.3 #142 Gritty details of changes for this release v1.0.591-alpha namespaced map should allow all Clojure whitespace between prefix and map #140 Beef up docs on node creation #97 Describe subedit in docs #111 Gritty details of changes for this release v1.0.579-alpha Release workflow now creates a GitHub release Gritty details of changes for this release v1.0.574-alpha Docs now render on cljdoc #138 Gritty details of changes for this release v1.0.572-alpha If you wish, you can read nitty gritty details on merging rewrite clj v0 and rewrite cljs. What follows is a summary of changes. Gritty details of changes for this release New A new home under clj-commons. Thanks to @xsc, rewrite-clj will also retain its same maven coordinates on Clojars making for a seamless upgrade path for rewrite-clj v0 users. Now supports ClojureScript, merging in rewrite-cljs specific functionality. Frustrations like not having namespace map support and differences from rewrite-clj, like whitespace parsing, should now be things of the past. Rewrite-cljs users migrating to rewrite-clj v1 are now at, and will remain at, feature parity with rewrite-clj. Additions to the public API: rewrite-clj.paredit - carried over from rewrite-cljs, an API for structured editing of Clojure forms rewrite-clj.zip Exposes the following (accidentally?) omitted functions: append-child* insert-newline-left insert-newline-right insert-space-left insert-space-right subzip Adds functions from rewrite-cljs find-last-by-pos - navigate to node at row/col find-tag-by-pos - navigate to node with tag at row/col position-span - returns start and end row/col for a form remove-preserve-newline - same as remove but preserves newlines Adds namespaced element support functions reapply-context - reapplies (or removes) map qualifier node context from keywords and symbols zipper creation functions now optionally accept an auto-resolve function to support sexpr on namespaced element nodes Other additions sexpr-able? - return true if sexpr is supported for current node rewrite-clj.node Additions: keyword-node? - returns true if form is a rewrite-clj keyword node map-qualifier-node - to create a namespaced map’s map qualifier node manually map-context-apply - apply map qualifier to keyword or symbol map-context-clear - remove map qualifier from keyword or symbol node? - returns true if a form is a rewrite-clj created node sexpr-able? - return true if sexpr is supported for node symbol-node? - return true if node is a rewrite-clj symbol node Updates: sexpr, sepxrs and child-sexprs - now optionally take an options argument to specify an auto-resolve function Many updates to docs and docstrings Fixes OS specific end of line variants in source now normalized consistently to \\newline #93 Postwalk on larger source file no longer throws StackOverflow #69 Postwalk now walks in post order #123 We now preserve newline at end of file #121 Support for garden style selectors #92 Correct and document prefix and suffix functions #91 Positional metadata added by the reader is elided on coercion #90 Can now read ##Inf, ##-Inf and ##Nan #75 Ensure that all rewrite-clj nodes coerce to themselves Strings now coerce to string nodes (instead of to token nodes) #126 Regexes now coerce to regex nodes #128 Regex node now: converts correctly to string #127 reports correct length #130 Moved from potemkin import-vars to static template based version #98: Avoids frustration/mysteries of dynamic import-vars for users and maintainers Argument names now correct in API docs (some were gensymed previously) Also turfed use of custom version of potemkin defprotocol+ in favor of plain old defprotocol. Perhaps I missed something, but I did not see the benefit of defprotocol+ for rewrite-clj v1. Internal changes (developer facing) Tests updated to hit public APIs #106 ClojureScript tests, in addition to being run under node, are now also run under chrome-headless, shadow-cljs, and for self-hosted ClojureScript, under planck. Now testing rewrite-clj compiled under GraalVM native-image in two variants: In a pure form where library and tests are compiled Via sci where a sci exposed rewrite-clj is compiled, then tests are interpreted. Now automatically testing rewrite-clj against popular libs #124 Now linting source with clj-kondo Code coverage reports now generated for Clojure unit test run and sent to codecov.io Can now preview for cljdoc locally via script/cljdoc_preview.clj API diffs for rewrite-clj v1 vs rewrite-clj v0 vs rewrite-cljs can be generated by script/gen_api_diffs.clj Contributors are acknowledged in README and updated via script/update_readme.clj Doc code blocks are automatically tested via script/doc_tests.clj #100 Some tooling and tech replaced: All scripts are written in Clojure and run via Babashka or Clojure. Switched from leiningen project.clj to Clojure tools CLI deps.edn Moved from CommonMark to AsciiDoc for docs Moved from publishing docs locally via codox to publishing to cljdoc Now using CommonMark in docstrings (they render nicely in cljdoc) Moved from TravisCI to GitHub Actions where, in addition to Linux, we also test under macOS and Windows Adopted kaocha for Clojure testing, stuck with doo for regular ClojureScript testing, and added support for ClojureScript watch testing with figwheel main. Potemkin dynamic import-vars replaced with static code generation solution Added GitHub issue templates Fixed a generative test sporadic failure #88 v1 Breaking Changes v1.0.572-alpha Minimum Clojure version bumped from v1.5.1 to v1.9 Minimum ClojureScript version (from whatever is was for rewrite-cljs) bumped to v1.10 Minimum Java version bumped from v7 to v8 Keyword node field namespaced? renamed to auto-resolved? Now using ex-info for explicitly raised exceptions Rewrite-cljs positional support migrated to rewrite-clj’s positional support Namespaced element support reworked v1 changes do not affect node traversal of the namespaced map, number and order of children remain the same. Namespace map prefix, is now stored in a namespaced map qualifier node. Prior to v1, the prefix was parsed to a keyword-node. Let’s look at what interesting node API functions will return for the prefix node in the following namespaced maps. Assume we have parsed the example and traversed down to the prefix node. For example via: (→ \"#:prefix{:a 1}\" z/of-string z/down z/node). node API call rewrite-clj #:prefix{:a 1} #::alias{:a 1} #::{:a 1} string is unchanged v1 \":prefix\" \"::alias\" \"::\" v0 throws on parse tag is different v1 :map-qualifier v0 :token throws on parse inner? still indicates that the node is a leaf node and has no children v1 false v0 false throws on parse sexpr <read on below for discussion on sexpr> Namespaced element sexpr support now relies on user specifiable auto-resolve function to resolve qualifiers Unlike rewrite-clj v0, the default auto-resolve behaviour never consults *ns* An sexpr for keyword node ::alias/foo no longer returns :alias/foo (this could be considered a bug fix, but if your code is expecting this, then you’ll need to make changes) The following namespaced element sexpr examples assume: *ns* is bound to user namespace (important only for rewrite-clj v0): We are using the default auto-resolve function for rewrite-clj v1 That you will refer to the User Guide for more detailed examples of v1 behaviour source sexpr rewrite-clj v1 sexpr rewrite-clj v0 sexpr rewrite-cljs qualified keyword :prefix/foo no change current-ns qualified keyword ::foo :?_current-ns_?/foo :user/foo throws on sexpr ns-alias qualified keyword ::alias/foo :??_alias_??/foo :alias/foo :alias/foo qualified map #:prefix{:a 1} #:prefix{:a 1} #:prefix{:a 1} (read-string \"#:prefix{:a 1}\") current-ns qualified map #::{:b 2} #:?_current-ns_?{:b 2} throws on parse throws on parse ns-alias qualified map #::alias{:c 3} #:??_alias_??{:c 3} throws unless namespace alias alias has been loaded in *ns* if alias in ns resolves to my.ns1: #:my.ns1{:c 3} (read-string \"#::alias{:c 3}\") Let’s dig into prefix and key sub-nodes of a namespaced map to explore v1 differences: Description rewrite-clj v1 rewrite-clj v0 and rewrite-cljs prefix (aka qualifier) qualified (-> \"#:prefix{:a 1}\"\n    z/of-string\n    z/down z/sexpr) prefix :prefix current-ns qualified (-> \"#::{:b 2}\"\n    z/of-string\n    z/down z/sexpr) ?_current-ns_? throws on parse ns-alias qualified (-> \"#::alias{:c 2}\"\n     z/of-string\n     z/down z/sexpr) ??_alias_?? :user/alias rewrite-cljs throws key qualified (-> \"#:prefix{:a 1}\"\n    z/of-string\n    z/down z/right z/down z/sexpr) :prefix/a :a current-ns qualified (-> \"#::{:b 2}\"\n    z/of-string\n    z/down z/right z/down z/sexpr) :?current-ns?/b throws on parse ns-alias qualified (-> \"#::alias{:c 3}\"\n    z/of-string\n    z/down z/right z/down z/sexpr) :??_alias_??/c :c Potentially breaking Some rewrite-cljs optimizations were dropped in favor of a single code base. If performance for rewrite-clj v1 for ClojureScript users is poor with today’s ClojureScript, we shall adapt. Deleted unused rewrite-clj.node.indent #116 Deleted redundant rewrite-clj.parser.util as part of #93. If you were using this internal namespace you can opt to switch to, the also internal, rewrite-clj.reader namespace. rewrite-clj v0 0.6.0 BREAKING: uses a dedicated node type for regular expressions. (see #49 – thanks @ChrisBlom!) implement NodeCoercable for nil. (set #53 – thanks @jespera!) 0.5.2 fixes parsing of splicing reader conditionals #?@…. (see #48) 0.5.1 fixes parsing of multi-line regular expressions. (see #51) 0.5.0 BREAKING: commas will no longer be parsed into :whitespace nodes but :comma. (see #44 - thanks @arrdem!) BREAKING: position will throw exception if not used on rewrite-clj custom zipper. (see #45) BREAKING: drops testing against JDK6. DEPRECATED: append-space in favour of insert-space-right prepend-space in favour of insert-space-left append-newline in favour of insert-newline-right prepend-newline in favour of insert-newline-left fix insertion of nodes in the presence of existing whitespace. (see #33, #34 - thanks @eraserhd!) edn and edn* now take a :track-position? option that activates a custom zipper implementation allowing position to be called on. (see #41, #45 - thanks @eraserhd!) fix parsing of whitespace, e.g. <U+2028>. (see #43) fix serialization of `integer-node`s. (see #37 - thanks @eraserhd!) adds insert-left* and insert-right* to facade. generative tests. (see #41 - thanks @eraserhd!) 0.4.13 Development has branched off, using the 0.4.x branch upgrades dependencies. fixes a compatibility issue when running 'benedekfazekas/mranderson' on a project with both 'rewrite-clj' and 'potemkin'. switch to Clojure 1.8.0 as base Clojure dependency; mark as \"provided\". switch to MIT License. drop support for JDK6. 0.4.12 drop fast-zip and potemkin dependencies. (see #26) 0.4.11 fix handling of symbols with boundary character inside. (see #25) 0.4.10 fix handling of symbols with trailing quote, e.g. x'. (see #24) 0.4.9 fix replace-children for :uneval nodes. (see #23) add rewrite-clj.zip/postwalk. (see #22) 0.4.8 allow parsing of aliased keywords, e.g. ::ns/foo. (see #21) 0.4.7 fixes zipper creation over whitespace-/comment-only data. (see #20) 0.4.6 fixes parsing of empty comments. (see #19) 0.4.5 fixes parsing of comments that are at the end of a file without linebreak. (see #18) 0.4.4 upgrades dependencies. add rewrite-clj.zip/child-sexprs to public API. 0.4.3 fix parsing of backslash \\\\ character. (see #17) 0.4.2 fix :fn nodes (were printable-only? but should actually create an s-sexpression). fix assert-sexpr-count to not actually create the s-expressions. 0.4.1 fixes infinite loop when trying to read a character. 0.4.0 BREAKING rewrite-clj.zip.indent no longer usable. BREAKING node creation/edit has stricter preconditions (e.g. :meta has to contain exactly two non-whitespace forms). BREAKING moved to a type/protocol based implementation of nodes. fix radix support. (see #13) fix handling of spaces between certain forms. (see #7) add node constructor functions. add child-sexprs function. 0.3.12 fix assoc on empty map. (see #16) 0.3.11 drop tests for Clojure 1.4.0. fix behaviour of leftmost. upgrade to fast-zip 0.5.2. 0.3.10 fix behaviour of next and end?. fix prewalk. add row/column metadata. 0.3.9 add end?. allow access to children of quoted forms. (see #6) fix children lookup for zipper (return nil on missing children). (see #5) 0.3.8 add :uneval element type (for #_form elements). fix estimate-length for multi-line strings. 0.3.7 fix zipper creation from file. 0.3.6 upgrade dependencies. fix file parser (UTF-8 characters were not parsed correctly, see #24@xsc/lein-ancient). 0.3.5 upgrade dependencies. cleanup dependency chain. 0.3.4 upgrade dependencies. 0.3.3 Bugfix: parsing of a variety of keywords threw an exception. 0.3.2 Bugfix: :1.4 and others threw an exception. 0.3.1 added namespaced keywords. 0.3.0 added token type :newline to handle linebreak characters. rewrite-clj.zip/edn wraps everything into [:forms …] node, but the initial location is the node passed to it. new functions in rewrite-clj.zip.core: length move-to-node edit→>, edit-node subedit→, subedit→>, edit-children leftmost?, rightmost? new functions in rewrite-clj.zip.edit: splice-or-remove prefix, suffix (formerly rewrite-clj.zip.utils) rewrite-clj.zip.edit/remove now handles whitespace appropriately. indentation-aware modification functions in rewrite-clj.zip.indent: indent indent-children replace edit insert-left insert-right remove splice fast-zip utility functions in rewrite-clj.zip.utils 0.2.0 added more expressive error handling to parser. added multi-line string handling (node type: :multi-line) new functions in rewrite-clj.printer: →string estimate-length new functions in rewrite-clj.zip: of-string, of-file print, print-root →string, →root-string append-space, prepend-space append-newline, prepend-newline right*, left*, … (delegating to fast-zip.core/right, …) new token type :forms new functions in rewrite-clj.parser: parse-all parse-string-all parse-file-all zipper utility functions in rewrite-clj.zip.utils (able to handle multi-line strings): prefix suffix 0.1.0 Initial Release",
+   "Warning: v1 Alpha Release Our first rewrite-clj v1 alpha release was in March of 2021. Since then we have seen wide and successful adoption of rewrite-clj v1 with no show-stoppers. I would drop the alpha status but have not yet seen the following features get a good shake yet in the wild: zippers with :track-position? enabled zippers using :auto-resolve support paredit API See project page for current priorities. ",
+   :name "Readme - Status",
+   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_status"}
+  {:doc
+   "User Guide Developer Guide Design Merging rewrite-clj and rewrite-cljs FAQ ",
+   :name "Readme - Docs",
+   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_docs"}
+  {:doc
+   "Some projects using rewrite-clj v1 ancient-clj 🐥 - Version Metadata Retrieval for Maven Artifacts antq 🐥 - Point out your outdated dependencies babashka 📍 - Native, fast starting Clojure interpreter for scripting carve 🐥 - Carve out the essentials of your Clojure app clerk 🐥 - Local-First Notebooks for Clojure cljfmt 🐥 - A tool for formatting Clojure code cljstyle 🐥 - A tool for formatting Clojure code clojure-lsp 🐥 - Language Server (LSP) for Clojure kusonga 🐥 - Renaming and moving namespaces in Clojure(script) refactor-nrepl 🐥 - nREPL middleware to support refactorings in an editor agnostic way rewrite-edn 🐥 - Utility lib on top of rewrite-clj with common operations to update EDN while preserving whitespace and comments test-doc-blocks 🐥 - Test AsciiDoc and CommonMark code blocks found in articles and docstrings umschreiben-clj 🐥 - Rewrite utilities for refactoring clojure files zprint 🐥 - Executables, uberjar, and library to beautifully format Clojure and Clojurescript source code and s-expressions Some projects using rewrite-clj v0 and/or rewrite-cljs depot 🐥 🩹 - Find newer versions of your dependencies in your deps.edn file kibit 🐥 - There’s a function for that! lein-ancient 🐥 - Check your Projects for outdated Dependencies mranderson 🐥 - Dependency inlining and shadowing mutant 🐥 - Mutation testing for Clojure repl-tooling 📍 - a base package for Clojure’s editor tooling update-leiningen-dependencies-skill 📍 - Track project.clj dependencies across different projects Have an update? Let us know! 🐥 canary tested against rewrite-clj v1 lib test suite 🩹 source required minor change to work with rewrite-clj v1 📍 no easy-peasy way to run automated unit tests found for this project ",
+   :name "Readme - Used In…",
+   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#used-in"}
+  {:doc
+   "Rewrite-clj versioning scheme is: major.minor.patch-test-qualifier major increments when a non alpha release API has been broken - something, as a rule, we’d like to avoid. minor increments to convey significant new features have been added. patch indicates bug fixes - it is the total number of commits in the repo. test-qualifier is absent for stable releases. Can be alpha, beta, rc1, etc. ",
+   :name "Readme - Versioning",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_versioning"}
+  {:doc "",
+   :name "Readme - People",
+   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_people"}
+  {:doc "",
+   :name "Readme - Contributors",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_contributors"}
+  {:doc "",
+   :name "Readme - Founders",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_founders"}
+  {:doc "",
+   :name "Readme - Current maintainers",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_current_maintainers"}
+  {:doc "",
+   :name "Readme - Changes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_changes"}
+  {:doc
+   "We honor the original MIT license from rewrite-clj v0. Code has been merged/adapted from: rewrite-cljs which has an MIT license clojure zip which is covered by Eclipse Public License 1.0 ",
+   :name "Readme - Licences",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/readme#_licences"}
+  {:doc "Changelog Table of Contents rewrite-clj v1 rewrite-clj v0 ",
    :name "Changelog",
-   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog"}
+   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#"}
+  {:doc "For a list of breaking changes see breaking changes. ",
+   :name "Changelog - rewrite-clj v1",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_rewrite_clj_v1"}
+  {:doc "",
+   :name "Changelog - Unreleased",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_unreleased"}
   {:doc
-   "User Guide Table of Contents Introduction Interesting Alternatives History Upgrading from rewrite-clj v0 and/or rewrite-cljs Conventions Terminology Rewrite-clj Nodes Project Setup Tools Deps Leiningen Rewrite-clj APIs Zip API A Brief Introduction to Zippers Finding Elements with the Zip API Familiar Functions for Updating Nodes with the Zip API Sub Editing with the Zip API Tracking Position with the Zip API Zipper Options Parser API Node API Creating Nodes Paredit API Map Nodes Parsing Peculiarities Unbalanced Maps Maps with Duplicate keys Sets with Duplicate values Sexpr Nuances Whitespace Not all Clojure Elements are Sexpr-able Differences in Clojure Platforms Reader Macro Chars Namespaced Elements Recap Rewrite-clj Default Auto-Resolve Handling Custom Auto-Resolve Handling Impact of Auto-Resolve Impact of Namespaced Map Context on Keywords and Symbols Dealing with Reader Generated Metadata Introduction Rewrite-clj is a library that can read, update and write Clojure, ClojureScript and EDN source code while preserving whitespace and comments. Interesting Alternatives If rewrite-clj is not your cup of tea, consider following alternatives: Project Parsing? Writing? Whitespace Preserving? Includes Element Row/Col? parcera yes yes yes yes edamame yes no no yes History @xsc created rewrite-clj in 2013. Its original use was to upgrade dependencies in lein project.clj files. The library quickly took off in popularity and is the default choice for modifying Clojure/EDN from Clojure. @rundis created rewrite-cljs in 2015 to match the features of rewrite-clj for ClojureScript developers. It was originally used for refactoring support in Light Table. In January of 2019, @rundis graciously transferred rewrite-cljs to clj-commons. Seeing an opportunity to give back to the Clojure community, in 2019 @lread, with guidance and help from many friendly Clojurians, started work on rewrite-cljc. In December of 2020, @xsc graciously tranferred rewrite-clj to clj-commons. So rewrite-cljc is now dead, long live rewrite-clj! To distinguish the the versions of rewrite-clj, I’ll use: rewrite-clj v0 to refer to the classic rewrite-clj v1 to refer to the reboot When the distinction is unimportant, I’ll simply use rewrite-clj. The goal of rewrite-clj v1 is to provide a thoughtfully maintained feature-complete library that can be used from either Clojure or ClojureScript. While merging rewrite-clj v0 and rewrite-cljs to create rewrite-clj v1 was not trivial, the real hard work was done over many years in rewrite-clj v0 and rewrite-cljs under the leadership of @xsc and @rundis (thanks guys!). Read Merging rewrite-clj and rewrite-cljs for details on the merge. Upgrading from rewrite-clj v0 and/or rewrite-cljs Thanks to @xsc’s transfer of rewrite-clj to clj-commons we’ll continue on with the rewrite-clj namespace and clojars deploy target. To upgrade to rewrite-clj v1, update your project dependencies. If you were using both rewrite-cljs and rewrite-clj v0 in your project you can now drop the rewrite-cljs dependency. Rewrite-clj unit tests are run against the current version of ClojureScript and Clojure versions >= v1.8.0. We recommend that while bumping your rewrite-clj dependency to v1, that you also bump your Clojure and ClojureScript dependencies to current official releases. The most notable breaking changes from rewrite-clj v0 relate to handling of namespaced elements: Namespaced map handling was incomplete in rewrite-clj, has been reworked a bit and now supports namespaced symbols An sexpr on a namespaced key or symbol should now work even when navigating down to the key node An sexpr that involves auto resolve never consults *ns* you can plugin your own auto-resolve behavior, see namespaced elements Need to know more? See the change log. Conventions As is a common convention, example code shows results of expression evaluation like so: (+ 1 2 3)\n;; => 6 We show distinctions between Clojure and Clojurescript results like so: \\c\n;; =clj=> \\c\n;; =cljs=> \"c\" And we show output like so: (println \"hello there\")\n;; =stdout=>\n; hello there Terminology Rewrite-clj has an sexpr function that returns Clojure forms. Our usage of the terms \"s-expression\" and \"forms\" might be less nuanced than some formal definitions. I think we are in line with Clojure for the Brave and True’s description of forms. To us, a Clojure form is any parsed (but not evaluated) Clojure as it would be returned by the Clojure reader. Rewrite-clj Nodes Rewrite-clj parses Clojure source into rewrite-clj nodes. While reviewing the following example, it helps to remember that Clojure source is data. Each node carries the positional metadata :row, :col, :end-row and :end-col. The positional data is 1-based and :end-col is exclusive. You can parse and work with nodes directly or take advantage of the power of the zip API. Rewrite-clj offers easy conversion from rewrite-clj nodes to Clojure forms and back. This is convenient but does come with some caveats. As you get more experienced with rewrite-clj, you will want to review sexpr nuances. Project Setup Tools Deps Include the following dependency in your deps.edn file: rewrite-clj/rewrite-clj {:mvn/version \"1.0.767-alpha\"} Leiningen Include the following dependency in your project.clj file: [rewrite-clj/rewrite-clj \"1.0.767-alpha\"] Rewrite-clj APIs There are 4 public API namespaces: rewrite-clj.zip rewrite-clj.parser rewrite-clj.node rewrite-clj.paredit Zip API Traverse and modify Clojure/ClojureScript/EDN. This is considered the main rewrite-clj API and might very well be all you need. You’ll optionally use the node API on the rewrite-clj nodes in the zipper. A Brief Introduction to Zippers Rewrite-clj uses a customized version of Clojure’s clojure.zip. If you are not familiar with zippers, you may find the following resources helpful: Clojure overview of zippers Arne Brasseur - The Art of Tree Shaping with Clojure Zippers Tim Baldrige - PivotShare - Series of 7 Videos on Clojure Zippers At a conceptual level, the rewrite-clj zipper holds: a tree of rewrite-clj nodes representing your parsed Clojure source your current location within the zipper Because the zipper holds both the tree and your location within the tree, its variable is commonly named zloc. The zipper is immutable, as such, location changes and node modifications are always returned in a new zipper. You may want to refer to rewrite-clj nodes while reviewing this introductory example: (require '[rewrite-clj.zip :as z])\n\n;; define some test data\n(def data-string\n\"(defn my-function [a]\n  ;; a comment\n  (* a 3))\")\n\n;; parse code to nodes, create a zipper, and navigate to the first non-whitespace node\n(def zloc (z/of-string data-string))\n\n;; explore what we've parsed\n(z/sexpr zloc)\n;; => (defn my-function [a] (* a 3))\n(-> zloc z/down z/right z/node pr)\n;; =stdout=>\n; <token: my-function>\n(-> zloc z/down z/right z/sexpr)\n;; => my-function\n\n;; rename my-function to my-function2 and return resulting s-expression\n(-> zloc\n    z/down\n    z/right\n    (z/edit (comp symbol str) \"2\")\n    z/up\n    z/sexpr)\n;; => (defn my-function2 [a] (* a 3))\n\n;; rename my-function to my-function2 and return updated string from root node\n(-> zloc\n    z/down\n    z/right\n    (z/edit (comp symbol str) \"2\")\n    z/root-string\n    println)\n;; =stdout=>\n; (defn my-function2 [a]\n;   ;; a comment\n;   (* a 3)) The zip location movement functions (right, left, up, down, etc) skip over Clojure whitespace nodes and comment nodes. Remember that Clojure whitespace includes commas. If you want to navigate over all nodes, use the * counterparts (right*, left*, up*, down*, etc). See zip API docs. Finding Elements with the Zip API The rewrite-clj.zip namespace includes find operations to navigate to locations of interest in your zipper. Let’s assume you want to modify the following minimal project.clj by replacing the :description placeholder text with something more meaningful: project.clj snippet (defproject my-project \"0.1.0-SNAPSHOT\"\n  :description \"Enter description\") Most find functions accept an optional location movement function. Use: rewrite-clj.zip/right (the default) - to search sibling nodes to the right rewrite-clj.zip/left to search siblings to left rewrite-clj.zip/next for a depth-first tree search (require '[rewrite-clj.zip :as z])\n\n;; for sake of a runnable example we'll load from a string:\n(def zloc (z/of-string\n\"(defproject my-project \\\"0.1.0-SNAPSHOT\\\"\n  :description \\\"Enter description\\\")\"))\n\n;; loading from a file, looks like so:\n;; (def zloc (z/of-file \"project.clj\")) (1)\n\n;; find defproject by navigating depth-first\n(def zloc-defproject (z/find-value zloc z/next 'defproject))\n;; verify that we are where we think we are\n(z/sexpr zloc-defproject)\n;; => defproject\n\n;; search right for :description and then move one node to the right (2)\n(def zloc-desc (-> zloc-defproject (z/find-value :description) z/right))\n;; check that this worked\n(z/sexpr zloc-desc)\n;; => \"Enter description\"\n\n;; replace node at current location and return the result\n(-> zloc-desc (z/replace \"My first Project.\") z/root-string println)\n;; =stdout=>\n; (defproject my-project \"0.1.0-SNAPSHOT\"\n;   :description \"My first Project.\") 1 reading from a file is only available from Clojure 2 Remember that while whitespace is preserved, it is automatically skipped during navigation. Familiar Functions for Updating Nodes with the Zip API The zip API provides familiar ways to work with parsed Clojure data structures. It offers some functions that correspond to the standard Clojure seq functions, for example: (require '[rewrite-clj.zip :as z])\n\n(def zloc (z/of-string \"[1\\n2\\n3]\"))\n(z/vector? zloc)\n;; => true\n(z/sexpr zloc)\n;; => [1 2 3]\n(-> zloc (z/get 1) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> zloc (z/assoc 1 5) z/sexpr)\n;; => [1 5 3]\n(->> zloc (z/map #(z/edit % + 4)) z/root-string)\n;; => \"[5\\n6\\n7]\"\n\n(def zloc (z/of-string \"{:a 10 :b 20}\"))\n(z/map? zloc)\n;; => true\n(-> zloc (z/get :b) z/node pr)\n;; =stdout=>\n; <token: 20>\n(-> zloc (z/assoc :b 42) z/sexpr)\n;; => {:b 42, :a 10}\n(->> zloc (z/map-vals #(z/edit % inc)) z/root-string)\n;; => \"{:a 11 :b 21}\"\n(->> zloc\n     (z/map-keys #(z/edit %\n                          (fn [v] (keyword \"prefix\" (name v))) ))\n     z/root-string)\n;; => \"{:prefix/a 10 :prefix/b 20}\" Sub Editing with the Zip API Sub editing allows you to effect changes to an isolated subtree (actually a sub zipper) while preserving your original location in the zipper When sub editing, your sub zipper is isolated to the current node and its children. The sub zipper acts like, and is, a full zipper; rewrite-clj.zip/end? will return true when you have navigated to the end of the sub zipper. This can be useful when you: Are interested in restoring your location after digging down deep to make a change Want to restrict your changes to a node and its children. It can be helpful to bound your movement when using functions that also affect current location such as rewrite-clj.zip/remove. (require '[rewrite-clj.zip :as z])\n\n;; A sample to illustrate\n(def zloc (z/of-string \"[a [b [c [d [e [f]]]]] g h]\"))\n\n;; ... and a little helper that navigates our location to the end node:\n(defn to-end [zloc]\n  (->> zloc\n       (iterate z/next)\n       (drop-while (complement z/end?))\n       first))\n\n;; ... and a little editor to show which node was hit:\n(defn update-at-loc [zloc]\n  (z/edit zloc #(symbol \"UPDATED\" (str %))))\n\n;; If we don't use a sub zipper our end node is h:\n(-> zloc\n    to-end\n    update-at-loc\n    z/root-string)\n;; => \"[a [b [c [d [e [f]]]]] g UPDATED/h]\"\n\n;; If we subedit on the first node in the vector, we are restricted to that node.\n;; In our case that node is a:\n(-> zloc\n    z/down\n    (z/subedit->\n     to-end\n     update-at-loc)\n    z/root-string)\n;; => \"[UPDATED/a [b [c [d [e [f]]]]] g h]\"\n\n;; If we subedit on the second node in the vector, we are restricted to that node.\n;; In our case that node is [b [c [d [f]]]] with subedit end node f\n(-> zloc\n    z/down\n    z/right\n    (z/subedit->\n     to-end\n     update-at-loc)\n    z/root-string)\n;; => \"[a [b [c [d [e [UPDATED/f]]]]] g h]\"\n\n;; To show our original location was preserved,\n;; after a subedit of the last node within the 2nd node in the vector,\n;; a movement right brings us to node g\n(-> zloc\n    z/down\n    z/right\n    (z/subedit->\n     to-end\n     (z/edit #(symbol \"UPDATED\" (str %))))\n    z/right\n    z/string)\n;; => \"g\" The zip API walk functions also isolate your work to the current node. Let’s explore: (require '[rewrite-clj.zip :as z])\n\n;; Let's contrive an example with multiple top level forms:\n(def zloc (z/of-string \"(def x 1) (def y [2 3 [4 [5]]])\"))\n\n;; Now let's add 100 to all numbers:\n(-> zloc\n    (z/postwalk (fn select [zloc] (number? (z/sexpr zloc)))\n                (fn visit [zloc] (z/edit zloc + 100)))\n    z/root-string)\n;; => \"(def x 101) (def y [2 3 [4 [5]]])\"\n\n;; Hmmm... what happened? Only the first number was affected.\n;; A new zipper automaticaly navigates to the first non-whitespace/non-comment node.\n;; In our example, this is node (def x 1).\n;; Our walk was isolated to current node (def x 1) so that's all that got updated\n\n;; We can adapt to walk all nodes with a movement up to the top level prior to our walk\n(-> zloc\n    z/up\n    (z/postwalk (fn select [zloc] (number? (z/sexpr zloc)))\n                (fn visit [zloc] (z/edit zloc + 100)))\n    z/root-string)\n;; => \"(def x 101) (def y [102 103 [104 [105]]])\" Tracking Position with the Zip API If you need to track the source row and column while reading and updating your zipper, create your zipper with :track-position true option. Note that the row and column are 1-based. If you have no interest in the zipper updating positions when the zipper changes, but are still interested in node positions, you can use a zipper without :track-positon true option. Read up on positional metadata under rewrite-clj nodes. (require '[rewrite-clj.zip :as z])\n\n;; parse some Clojure into a position tracking zipper\n(def zloc (z/of-string\n           \"(defn sum-me\\n  \\\"Add 'em up!\\\"\\n  [a b c]\\n  (+ a\\n     c))\"\n           {:track-position? true}))\n\n;; let's see what that looks like printed out\n(println (z/root-string zloc))\n;; =stdout=>\n; (defn sum-me\n;   \"Add 'em up!\"\n;   [a b c]\n;   (+ a\n;      c))\n\n;; navigate to second z in zipper\n(def zloc-c (-> zloc\n            (z/find-value z/next '+)\n            (z/find-value z/next 'c)))\n\n;; check if current node is as expected\n(z/string zloc-c)\n;; => \"c\"\n\n;; examine position of second z, it is on 6th column of the 5th row\n(z/position zloc-c)\n;; => [5 6]\n\n;; insert new element b with indentation and alignment\n(def zloc-c2 (-> zloc-c\n                 (z/insert-left 'b)        ;; insert b to the left of c\n                 (z/left)                  ;; move to b\n                 (z/insert-newline-right)  ;; insert a newline after b\n                 (z/right)                 ;; move to c\n                 (z/insert-space-left 4))) ;; c has 1 space before it, add 4 more to line it up\n\n;; we should still be at c\n(z/string zloc-c2)\n\"c\"\n\n;; output our updated Clojure\n(println (z/root-string zloc-c2))\n;; =stdout=>\n; (defn sum-me\n;   \"Add 'em up!\"\n;   [a b c]\n;   (+ a\n;      b\n;      c))\n\n;; and check that location of c has been updated, it should now be on the 6th column of the 6th row\n(z/position zloc-c2)\n;; => [6 6] Zipper Options When creating a new zipper you may optionally include an options map. These options will be carried by the zipper and live for the life of the zipper. Current options are: :track-position - see Tracking Position with the Zip API :auto-resolve - see Custom Auto-Resolve Handling After making changes via a zipper, the final step is typically to call root-string or print-root. Less frequently, one might call root which affects changes and returns the root rewrite-clj node. This node might be fed back into a new zipper. The options passed into the original zipper on creation will not be automatically applied to the new zipper and must be respecified: (require '[rewrite-clj.zip :as z])\n\n;; some contrived options to demonstrate:\n(def zip-opts {:track-position true\n               :auto-resolve (fn [_alias] 'custom-resolved)})\n\n\n(-> \"(+ 10 20 30)\"         ;; <- something more complicated would be here, of course\n    (z/of-string zip-opts) ;; <- our opts are passed in on creation\n    z/down z/right z/right\n    (z/edit inc)\n    z/root                 ;; <- applying changes and getting root node\n    (z/edn zip-opts)       ;; <- pass the original zip-opts on creation of new zipper\n    z/down z/right z/right\n    (z/edit inc)\n    (z/root-string))\n;; => \"(+ 10 22 30)\" Parser API Parses Clojure/ClojureScript/EDN to rewrite-clj nodes. The zip API makes use of the parser API to parse Clojure into zippers. If your focus is parsing instead of rewriting, you might find this lower level API useful. Keep in mind that if you forgo the zip API, you forgo niceties such as the automatic handling of whitespace. You can choose to parse the first, or all forms from a string or a file.[file] Here we parse a single form from a string: (require '[rewrite-clj.parser :as p])\n\n(def form-nodes (p/parse-string \"(defn my-function [a]\\n  (* a 3))\")) You’ll likely use the node API on the returned nodes. See parser API docs. Node API Inspect, analyze, create and render rewrite-clj nodes. (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n(def nodes (p/parse-string \"(defn my-function [a]\\n  (* a 3))\"))\n\n;; Explore what we've parsed\n(n/tag nodes)\n;; => :list\n\n(pr (n/children nodes))\n;; =stdout=>\n; (<token: defn> <whitespace: \" \"> <token: my-function> <whitespace: \" \"> <vector: [a]> <newline: \"\\n\"> <whitespace: \"  \"> <list: (* a 3)>)\n\n(n/sexpr nodes)\n;; => (defn my-function [a] (* a 3))\n\n(n/child-sexprs nodes)\n;; => (defn my-function [a] (* a 3))\n\n;; convert the nodes back to a printable string\n(n/string nodes)\n;; => \"(defn my-function [a]\\n  (* a 3))\"\n\n;; coerce clojure forms to rewrite-clj nodes\n(pr (n/coerce '[a b c]))\n;; =stdout=>\n; <vector: [a b c]>\n\n;; create rewrite-clj nodes by hand\n(pr (n/meta-node\n      (n/token-node :private)\n      (n/token-node 'sym)))\n;; =stdout=>\n; <meta: ^:private sym> See node API docs. Creating Nodes Rewrite-clj nodes can be created in a number of ways: Indirectly via the parser API: (-> (p/parse-string \"[1 2 3]\")\n    n/string)\n;; => \"[1 2 3]\" Indirectly via the zip API (which uses the parser API): (-> (z/of-string \"[1 2 3]\")\n    z/node\n    n/string)\n;; => \"[1 2 3]\" Via coercion from Clojure forms: (-> (n/coerce '[1 2 3])\n     n/string)\n;; => \"[1 2 3]\" By explicitly calling node creation functions. (-> (n/vector-node [(n/token-node 1)\n                    (n/whitespace-node \" \")\n                    (n/token-node 2)\n                    (n/whitespace-node \" \")\n                    (n/token-node 3)])\n    n/string)\n;; => \"[1 2 3]\" The node creation function are what the parser API uses to create nodes. Which technique you use depends on our needs. Coercion is convenient, but doesn’t offer control over whitespace. In some cases coercion might not give you the result you expect: (-> (n/coerce '#(+ %1 %2))\n    n/string)\n;; => \"(fn* [p1__10532# p2__10533#] (+ p1__10532# p2__10533#))\" Be aware that node creation functions do not force you to use rewrite-clj nodes (notice the raw 1 2 and 3): (-> (n/vector-node [1 (n/spaces 1) 2 (n/spaces 1) 3])\n    n/string)\n;; => \"[1 2 3]\" …but no automatic coercion will be done on non rewrite-clj elements and their tag will return unknown. (n/tag 1)\n;; :unknown Finally, there are a handful of node whitespace creation convenience functions such as spaces, newlines, line-separated and comma-separated, see the node API docs for details. Paredit API Structured editing was introduce by rewrite-cljs and carried over to rewrite-clj v1. We might expand this section if there is interest, but the docstrings should get you started. See current paredit API docs. Map Nodes Rewrite-clj parses two types of maps. unqualified {:a 1 :b 2} namespaced #:prefix {:x 1 :y 2} Rewrite-clj models nodes as they appear in the original source. This is convenient when navigating through the source, but when we want to logically treat any map as a map the difference is admittedly bit awkward. Parsing Peculiarities Rewrite-clj can, in some specific cases, parse technically invalid Clojure. Some folks have come to rely on this over the years, so these are behaviours we will preserve. Unbalanced Maps An unbalanced map is one where there is a key with no value. Rewrite-clj can parse and emit unbalanced maps: (require '[rewrite-clj.zip :as z])\n\n(-> \"{:a 1 :b 2 :c}\"\n    z/of-string\n    z/root-string)\n;; => \"{:a 1 :b 2 :c}\" An attempt to convert an unbalanced map to a Clojure form will throw: (try\n  (-> \"{:a 1 :b 2 :c}\"\n      z/of-string\n      z/sexpr)\n  (catch Throwable e\n    (.getMessage e)))\n;; => \"No value supplied for key: :c\" sexpr-able? considers the current node element type only and will return true for all maps, balanced or not. Maps with Duplicate keys Rewrite-clj can parse and emit maps with duplicate keys: (-> \"{:a 1 :b 2 :a 3 :a 4 :a 5 :a 6}\"\n    z/of-string\n    z/root-string)\n;; => \"{:a 1 :b 2 :a 3 :a 4 :a 5 :a 6}\" But when converting to a Clojure form, duplicate keys are not valid in a map, so only the last key/value pair for duplicate keys will be included: (-> \"{:a 1 :b 2 :a 3 :a 4 :a 5 :a 6}\"\n    z/of-string\n    z/sexpr)\n;; => {:b 2, :a 6} Sets with Duplicate values Rewrite-clj can parse and emit sets with duplicate values: (-> \"#{:a :b :a :a :a}\"\n    z/of-string\n    z/root-string)\n;; => \"#{:a :b :a :a :a}\" But when converting to a Clojure form, duplicate values in a set are not valid Clojure, so the duplicates are omitted: (-> \"#{:a :b :a :a :a}\"\n    z/of-string\n    z/sexpr)\n;; => #{:b :a} Sexpr Nuances Rewrite-clj parses arbitrary Clojure/ClojureScript source code into rewrite-clj nodes. Converting rewrite-clj nodes to Clojure forms via sexpr is convenient, but it does come with some caveats. Within reason, Clojure’s read-string and rewrite-clj’s sexpr functions should return equivalent Clojure forms. To illustrate, some code: (require '[rewrite-clj.zip :as z]\n         '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n]\n         #?(:cljs '[cljs.reader :refer [read-string]]))\n\n(defn form-test [s]\n  (let [forms [(-> s read-string)\n               (-> s z/of-string z/sexpr)\n               (-> s p/parse-string n/sexpr)]]\n    (if (apply = forms)\n      (first forms)\n      [:not-equal forms])))\n\n(form-test \"a\")\n;; => a\n(form-test \"[1 2 3]\")\n;; => [1 2 3]\n(form-test \"(defn hello [name] (println \\\"Hello\\\" name))\")\n;; => (defn hello [name] (println \"Hello\" name)) Whitespace The whitespace that a rewrite-clj so carefully preserves is lost when converting to a Clojure form. (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n;; parse some Clojure source\n(def nodes (p/parse-string \"{  :a 1\\n\\n   :b 2}\"))\n\n;; print it out to show the whitespace\n(println (n/string nodes))\n;; =stdout=>\n; {  :a 1\n;\n;    :b 2}\n\n;; print out Clojure forms and notice the loss of the specifics of whitespace and element ordering\n(pr (n/sexpr nodes))\n;; =stdout=>\n; {:b 2, :a 1} Not all Clojure Elements are Sexpr-able Some source code element types are not sexpr-able: Reader ignore/discard #_ (also known as \"uneval\" in rewrite-clj) Comments Clojure whitespace (which includes commas) Both the zip and node APIs include sexpr-able? to check if sexpr is supported for the current node element type. sexpr-able? only looks at the current node element type. This means that sexpr will still throw when: called on a node with an element type that is sepxr-able? but, for whatever reason, has a child node that fails to sexpr, see unbalanced maps. called directly on an unbalanced maps. (require '[rewrite-clj.node :as n]\n         '[rewrite-clj.parser :as p]\n         '[rewrite-clj.zip :as z])\n\n#?(:clj (import clojure.lang.ExceptionInfo))\n\n;;\n;; Most nodes are sexpr-able\n;;\n\n;; we can check sexpr-ability through the node API\n(-> \"hello\" p/parse-string n/sexpr-able?)\n;; => true\n\n;; or through the zip API\n(-> \"hello\" z/of-string z/sexpr-able?)\n;; => true\n\n;;\n;; But some nodes are not sexpr-able\n;;\n\n;; the discard #_ node is not sexpr-able\n(-> \"#_42\" z/of-string z/sexpr-able?)\n;; => false\n\n;; and will throw if an attempt is made to sexpr\n(try\n  (-> \"#_42\" z/of-string z/sexpr)\n  (catch ExceptionInfo e\n    (ex-message e)))\n;; => \"unsupported operation\"\n\n;; comments nodes are not sexpr-able\n(-> \";; can’t sexpr me!\" z/of-string z/next* z/sexpr-able?) (1)\n;; => false\n\n;; and will throw\n(try\n  (-> \";; can’t sexpr me!\" z/of-string z/next* z/sexpr) (1)\n  (catch ExceptionInfo e\n    (ex-message e)))\n;; => \"unsupported operation\"\n\n;; and finally, Clojure whitespace nodes are not sexpr-able\n(-> \" \" z/of-string z/next* z/sexpr-able?) (1)\n;; => false\n\n;; and will throw\n(try\n  (-> \" \" z/of-string z/next* z/sexpr) (1)\n  (catch ExceptionInfo e\n    (ex-message e)))\n;; => \"unsupported operation\" 1 Notice the use of next* to include normally skipped nodes. Remember that child nodes with element types that are not sexpr-able? are skipped for sexpr: (-> (str \"[1 #_:child-discard-will-be-skipped\\n\"\n         \" ;; comment will be skipped\\n\"\n         \" ,,, ,,, ,,, \\n\"\n         \" 2]\")\n    z/of-string\n    z/sexpr)\n;; => [1 2] Differences in Clojure Platforms Clojure and ClojureScript have differences. Some examples of what you might run into when using sexpr are: (require '[rewrite-clj.zip :as z])\n\n;; ClojureScript has no Ratio type\n(-> (z/of-string \"3/4\") z/sexpr)\n;; =clj=> 3/4\n;; =cljs=> 0.75\n\n;; Integral type and behaviour is defined by host platforms\n(+ 10 (-> (z/of-string \"9007199254740991\") z/sexpr))\n;; =clj=> 9007199254741001\n;; =cljs=> 9007199254741000\n\n;; ClojureScript has no character type, characters are expressed as strings\n(-> (z/of-string \"\\\\a\") z/sexpr)\n;; =clj=> \\a\n;; =cljs=> \"a\" Note that these differences affect sexpr only. Rewrite-clj should be able to parse and rewrite all valid Clojure/ClojureScript code. Reader Macro Chars Rewrite-clj can parse and write all reader macro chars. Be aware though, that it does have limitations when calling sexpr on rewrite-clj nodes representing some of these constructs. Let’s take a look, using Clojure’s reader docs on macro characters as our reference. (headers are description followed by rewrite-clj parsed node tag) Parsed input Node sexpr Quote :quote 'form (quote form) Character :token \\newline \\newline \\space \\space \\tab \\tab Comment :comment ; comment <unsupported operation> Deref :deref @form (deref form) Metadata :meta ^{:a 1 :b 2} [1 2 3] ^{:b 2, :a 1} [1 2 3] ^String x ^{String true} x ^:dynamic x ^{:dynamic true} x Set :set #{1 2 3} #{1 3 2} Regex :regex #\"reg.*ex\" (re-pattern \"reg.*ex\") Var-quote :var #'x (var x) Anonymous function :fn #(println %) (fn* [p12976#] (println p12976#)) Ignore next form :uneval #_ :ignore-me <unsupported operation> Syntax quote :syntax-quote `symbol (quote symbol) Syntax unquote :unquote ~symbol (unquote symbol) Tagged literal :reader-macro #foo/bar [1 2 3] (read-string \"#foo/bar [1 2 3]\") #inst \"2018-03-28T10:48:00.000\" (read-string \"#inst \\\"2018-03-28T10:48:00.000\\\"\") #uuid \"3b8a31ed-fd89-4f1b-a00f-42e3d60cf5ce\" (read-string \"#uuid \\\"3b8a31ed-fd89-4f1b-a00f-42e3d60cf5ce\\\"\") Reader conditional :reader-macro #?(:clj x :cljs y) (read-string \"#?(:clj x :cljs y)\") #@?(:clj [x] :cljs [y]) (read-string \"#@?(:clj [x] :cljs [y])\") Observations: I think it was a design decision of rewrite-clj v0 to return (read-string …) for reader macros it did not want to deal with (or deal with yet). Rewrite-clj v1 will carry on. It seems the idea might have been that the caller could eval the sexpr result if they wanted to? Note for ClojureScript users, read-string is not available under cljs.core, but a version is available under cljs.tools.reader. Tag metadata is returned as boolean metadata. A user could infer the intent through inspection though. Namespaced Elements If the code you are parsing doesn’t use namespaced maps or you have no interest in using sexpr on the keys in those maps, the details in this section probably won’t be of concern to you. Recap In Clojure keywords and symbols can be qualified. A recap via examples: Stand-alone keyword and symbols: keyword symbol unqualified :my-kw 'my-symbol qualified :prefix/my-kw 'prefix/my-symbol auto-resolved current namespace ::my-kw n/a auto-resolved namespaced alias ::my-ns-alias/my-kw n/a Namespaced keyword and symbols: keyword symbol unqualified (via _ prefix) #:prefix{:_/my-kw 1} '#:prefix{_/my-symbol} qualified #:prefix{:my-kw 1} '#:prefix{my-symbol 1} auto-resolved current namespace #::{:my-kw 1} '#::{my-symbol 1} auto-resolved namespaced alias #::my-ns-alias{:my-kw 1} '#::my-ns-alias{my-symbol 1} Rewrite-clj Default Auto-Resolve Handling When calling sepxr on an auto-resolved keyword or symbol node, rewrite-clj will resolve: the current namespace to ?_current-ns_? namespaced alias x to ??_x_?? To illustrate: (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n(-> (p/parse-string \"::kw\") n/sexpr)\n;; => :?_current-ns_?/kw\n(-> (p/parse-string \"#::{:a 1 :b 2 s1 3}\") n/sexpr)\n;; => #:?_current-ns_?{s1 3, :b 2, :a 1}\n(-> (p/parse-string \"::my-alias/kw\") n/sexpr)\n;; => :??_my-alias_??/kw\n(-> (p/parse-string \"#::my-alias{:a 1 :b 2 s1 3}\") n/sexpr)\n;; => #:??_my-alias_??{s1 3, :b 2, :a 1} Custom Auto-Resolve Handling Rewrite-clj will not attempt to determine the current namespace and alias namespace mappings of the code it is parsing. It does, though, allow you to specify your own auto-resolve behavior. The :auto-resolve function takes a single arg alias for lookup and must return symbol. The alias will be: :current for a request for the current namespace otherwise it will be a symbol for the namespace alias to lookup For example, if you know namespace and alias info for the code rewrite-clj is operating on, you can specify it: (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n(defn resolver [alias]\n  (or (get {:current 'my.current.ns\n            'my-alias 'my.aliased.ns} alias)\n      (symbol (str alias \"-unresolved\"))))\n\n(-> (p/parse-string \"::kw\") (n/sexpr {:auto-resolve resolver}))\n;; => :my.current.ns/kw\n(-> (p/parse-string \"#::{:a 1 :b 2 s1 3}\") (n/sexpr {:auto-resolve resolver}))\n;; => #:my.current.ns{s1 3, :b 2, :a 1}\n(-> (p/parse-string \"::my-alias/kw\") (n/sexpr {:auto-resolve resolver}))\n;; => :my.aliased.ns/kw\n(-> (p/parse-string \"#::my-alias{:a 1 :b 2 s1 3}\") (n/sexpr {:auto-resolve resolver}))\n;; => #:my.aliased.ns{s1 3, :b 2, :a 1} The :auto-resolve option is accepted in the opts map arg for: The rewrite-clj.node namespace functions sexpr and child-sexpr. The rewrite-clj.zip namespace zipper creation functions edn*, edn, of-string and of-file. The resulting zipper will then automatically apply your :auto-resolve within any zip operation that makes use of sexpr, namely: sexpr find-value and find-next-value - sexpr is applied to each node to get the \"value\" for comparison edit - the current node is sexpr-ed get and assoc - sexpr is applied to the map key Impact of Auto-Resolve Let’s illustrate how functions that use sexpr internally are affected by exploring rewrite-clj.zip/get: (require '[rewrite-clj.zip :as z])\n\n;; get on unqualified keys is straightforward:\n(-> \"{:a 1 :b 2 c 3}\" z/of-string (z/get :b) z/node pr)\n;; =stdout=>\n; <token: 2>\n\n;; get on qualified keys is also easy to grok\n(-> \"{:a 1 :prefix/b 2 c 3}\" z/of-string (z/get :prefix/b) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> \"#:prefix{:a 1 :b 2 c 3}\" z/of-string (z/get :prefix/b) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> \"#:prefix{:a 1 :b 2 c 3}\" z/of-string (z/get 'prefix/c) z/node pr)\n;; =stdout=>\n; <token: 3>\n\n;; but when we introduce auto-resolved elements, the default resolver comes into play\n;; and must be considered\n(-> \"{::ns-alias/a 1 ::b 2 c 3}\" z/of-string (z/get :?_current-ns_?/b) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> \"{::ns-alias/a 1 ::b 2 c 3}\" z/of-string (z/get :??_ns-alias_??/a) z/node pr)\n;; =stdout=>\n; <token: 1>\n(-> \"#::{:a 1 :b 2 c 3}\" z/of-string (z/get :?_current-ns_?/b) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> \"#::{:a 1 :b 2 c 3}\" z/of-string (z/get '?_current-ns_?/c) z/node pr)\n;; =stdout=>\n; <token: 3> Impact of Namespaced Map Context on Keywords and Symbols Namespaced map context is automatically applied to symbols and keywords in namespaced maps. To illustrate with the zip API: (require '[rewrite-clj.zip :as z])\n\n(def zloc (z/of-string \"#:my-prefix {:a 1 :b 2 c 3}\"))\n\n;; An sexpr on the namespaced map returns the expected Clojure form\n( -> zloc z/sexpr)\n;; => #:my-prefix{:b 2, c 3, :a 1}\n\n;; An sepxr on the an individual key in the namespaced map returns the expected Clojure form\n(-> zloc z/down z/rightmost z/down z/sexpr)\n;; => :my-prefix/a Rewrite-clj applies the namespaced map context the namespaced map node children: at create time (which is also parse time) when the node’s children are replaced This works well with the mechanics of the zipper. Updates are automatically applied when moving up through the zipper: (require '[rewrite-clj.zip :as z])\n\n(def s \"#:prefix {:a 1 :b 2 c 3}\")\n\n;; sexpr works fine on unchanged zipper\n(-> s z/of-string z/sexpr)\n;; => #:prefix{:b 2, c 3, :a 1}\n\n;; changing the namespaced map prefix reapplies the context to the children\n(-> s\n    z/of-string\n    z/down\n    (z/replace (n/map-qualifier-node false \"my-new-prefix\"))\n    z/up\n    z/sexpr)\n;; => #:my-new-prefix{:b 2, c 3, :a 1}\n\n;; a new key/val gets the namespaced map context\n(-> s\n    z/of-string\n    z/down z/rightmost\n    (z/append-child :d)\n    (z/append-child 33)\n    z/up\n    z/sexpr)\n;; => #:prefix{:b 2, c 3, :d 33, :a 1}\n\n;; a replaced key gets namespaced map context\n(-> s\n    z/of-string\n    z/down z/rightmost z/down\n    (z/replace :a2)\n    z/up z/up\n    z/sexpr)\n;; => #:prefix{:a2 1, :b 2, c 3}\n\n;; but... be aware that the context is not applied...\n(-> s\n    z/of-string\n    z/down z/rightmost z/down\n    (z/replace :a2)\n    z/sexpr)\n;; => :a2\n\n;; ... until we move up to the namespaced map node:\n(-> s\n    z/of-string\n    z/down z/rightmost z/down\n    (z/replace :a2)\n    z/up z/up\n    z/down z/rightmost z/down\n    z/sexpr)\n;; => :prefix/a2 Some limitations: Keyword and symbol nodes will continue to hold their namespaced map context even when moved outside a namespaced map. Should you need to, you can use the zip API’s reapply-context to manually apply context from the current node downward. The context auto-update is a feature of the zip API, when working with nodes directly the context will be applied at parse time, and when namespaced map node children are replaced only. Dealing with Reader Generated Metadata Rewrite-clj offers, where it can, transparent coercion from Clojure forms to rewrite-clj nodes. Clojure will, in some cases, add location metadata that is not in the original source code, as illustrated here: REPL session (meta '(1 2 3))\n;; => {:line 1, :column 8} Rewrite-clj will, on coercion from Clojure forms to rewrite-clj nodes, omit location metadata. No rewrite-clj metadata node will will be created if resulting metadata is empty. On conversion from rewrite-clj nodes to Clojure forms via sexpr, I don’t see a way to omit the location metadata. With the assumption that you will generally coerce Clojure forms back to rewrite-clj nodes, this should not cause an issue. To support those using rewrite-clj under sci, in addition to :line and :column rewrite-clj also removes :end-line and :end-column metadata. Note that while Clojure only adds location metadata to quoted lists, sci adds it to all forms that accept metadata.",
+   "fix :end-row :end-col metadata for root node #173 - thanks @mainej! docs: user guide correction, thanks @rgkirch! zip API docstrings now clearer about coercion #168 Gritty details of changes for this release ",
+   :name "Changelog - v1.0.767-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_767_alpha"}
+  {:doc
+   "team update: @borkdude is now officially a co-maintainer of rewrite-clj! Woot woot! rewrite-clj v1 minimum Clojure version is now v1.8.0 (was formerly v1.9.0) #164 internal rewrite-clj developer facing: Migrate from depstar to tools.build Gritty details of changes for this release ",
+   :name "Changelog - v1.0.699-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_699_alpha"}
+  {:doc
+   "update clojure tools.reader dependency to v1.3.6 a zipper created with both a custom :auto-resolve option and the :track-position? true option will now acknowledge and use the custom :auto-resolve #159 a Cons now coerces to a rewrite-clj list node #160 #161 (thanks @borkdude!) internal rewrite-clj developer facing: Now also linting rewrite-clj sources with Eastwood #158 (thanks @vemv!) Gritty details of changes for this release ",
+   :name "Changelog - v1.0.682-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_682_alpha"}
+  {:doc
+   "user guide and docstrings better explain sexpr-able? and what invalid code elements rewrite-clj parses #150 #151 rewrite-clj now exports clj-kondo config for its public API #146 ClojureScript compiler should no longer emit invalid deprecated warnings #153 Internal rewrite-clj developer facing: Switched from babashka scripts to babashka tasks, developer guide updated accordingly Gritty details of changes for this release ",
+   :name "Changelog - v1.0.644-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_644_alpha"}
+  {:doc
+   "rewrite-clj now understands the #! comment, a construct often used in scripts #145 Gritty details of changes for this release ",
+   :name "Changelog - v1.0.605-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_605_alpha"}
+  {:doc
+   "rewrite-clj now explicitly depends on the minimum version of Clojure required, v1.9.0, rather than v1.10.3 #142 Gritty details of changes for this release ",
+   :name "Changelog - v1.0.594-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_594_alpha"}
+  {:doc
+   "namespaced map should allow all Clojure whitespace between prefix and map #140 Beef up docs on node creation #97 Describe subedit in docs #111 Gritty details of changes for this release ",
+   :name "Changelog - v1.0.591-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_591_alpha"}
+  {:doc
+   "Release workflow now creates a GitHub release Gritty details of changes for this release ",
+   :name "Changelog - v1.0.579-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_579_alpha"}
+  {:doc
+   "Docs now render on cljdoc #138 Gritty details of changes for this release ",
+   :name "Changelog - v1.0.574-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_574_alpha"}
+  {:doc
+   "If you wish, you can read nitty gritty details on merging rewrite clj v0 and rewrite cljs. What follows is a summary of changes. Gritty details of changes for this release ",
+   :name "Changelog - v1.0.572-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_572_alpha"}
+  {:doc
+   "A new home under clj-commons. Thanks to @xsc, rewrite-clj will also retain its same maven coordinates on Clojars making for a seamless upgrade path for rewrite-clj v0 users. Now supports ClojureScript, merging in rewrite-cljs specific functionality. Frustrations like not having namespace map support and differences from rewrite-clj, like whitespace parsing, should now be things of the past. Rewrite-cljs users migrating to rewrite-clj v1 are now at, and will remain at, feature parity with rewrite-clj. Additions to the public API: rewrite-clj.paredit - carried over from rewrite-cljs, an API for structured editing of Clojure forms rewrite-clj.zip Exposes the following (accidentally?) omitted functions: append-child* insert-newline-left insert-newline-right insert-space-left insert-space-right subzip Adds functions from rewrite-cljs find-last-by-pos - navigate to node at row/col find-tag-by-pos - navigate to node with tag at row/col position-span - returns start and end row/col for a form remove-preserve-newline - same as remove but preserves newlines Adds namespaced element support functions reapply-context - reapplies (or removes) map qualifier node context from keywords and symbols zipper creation functions now optionally accept an auto-resolve function to support sexpr on namespaced element nodes Other additions sexpr-able? - return true if sexpr is supported for current node rewrite-clj.node Additions: keyword-node? - returns true if form is a rewrite-clj keyword node map-qualifier-node - to create a namespaced map’s map qualifier node manually map-context-apply - apply map qualifier to keyword or symbol map-context-clear - remove map qualifier from keyword or symbol node? - returns true if a form is a rewrite-clj created node sexpr-able? - return true if sexpr is supported for node symbol-node? - return true if node is a rewrite-clj symbol node Updates: sexpr, sepxrs and child-sexprs - now optionally take an options argument to specify an auto-resolve function Many updates to docs and docstrings ",
+   :name "Changelog - New",
+   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_new"}
+  {:doc
+   "OS specific end of line variants in source now normalized consistently to \\newline #93 Postwalk on larger source file no longer throws StackOverflow #69 Postwalk now walks in post order #123 We now preserve newline at end of file #121 Support for garden style selectors #92 Correct and document prefix and suffix functions #91 Positional metadata added by the reader is elided on coercion #90 Can now read ##Inf, ##-Inf and ##Nan #75 Ensure that all rewrite-clj nodes coerce to themselves Strings now coerce to string nodes (instead of to token nodes) #126 Regexes now coerce to regex nodes #128 Regex node now: converts correctly to string #127 reports correct length #130 Moved from potemkin import-vars to static template based version #98: Avoids frustration/mysteries of dynamic import-vars for users and maintainers Argument names now correct in API docs (some were gensymed previously) Also turfed use of custom version of potemkin defprotocol+ in favor of plain old defprotocol. Perhaps I missed something, but I did not see the benefit of defprotocol+ for rewrite-clj v1. ",
+   :name "Changelog - Fixes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_fixes"}
+  {:doc
+   "Tests updated to hit public APIs #106 ClojureScript tests, in addition to being run under node, are now also run under chrome-headless, shadow-cljs, and for self-hosted ClojureScript, under planck. Now testing rewrite-clj compiled under GraalVM native-image in two variants: In a pure form where library and tests are compiled Via sci where a sci exposed rewrite-clj is compiled, then tests are interpreted. Now automatically testing rewrite-clj against popular libs #124 Now linting source with clj-kondo Code coverage reports now generated for Clojure unit test run and sent to codecov.io Can now preview for cljdoc locally via script/cljdoc_preview.clj API diffs for rewrite-clj v1 vs rewrite-clj v0 vs rewrite-cljs can be generated by script/gen_api_diffs.clj Contributors are acknowledged in README and updated via script/update_readme.clj Doc code blocks are automatically tested via script/doc_tests.clj #100 Some tooling and tech replaced: All scripts are written in Clojure and run via Babashka or Clojure. Switched from leiningen project.clj to Clojure tools CLI deps.edn Moved from CommonMark to AsciiDoc for docs Moved from publishing docs locally via codox to publishing to cljdoc Now using CommonMark in docstrings (they render nicely in cljdoc) Moved from TravisCI to GitHub Actions where, in addition to Linux, we also test under macOS and Windows Adopted kaocha for Clojure testing, stuck with doo for regular ClojureScript testing, and added support for ClojureScript watch testing with figwheel main. Potemkin dynamic import-vars replaced with static code generation solution Added GitHub issue templates Fixed a generative test sporadic failure #88 ",
+   :name "Changelog - Internal changes (developer facing)",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_internal_changes_developer_facing"}
+  {:doc "",
+   :name "Changelog - v1 Breaking Changes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#v1-breaking"}
+  {:doc
+   "Minimum Clojure version bumped from v1.5.1 to v1.9 Minimum ClojureScript version (from whatever is was for rewrite-cljs) bumped to v1.10 Minimum Java version bumped from v7 to v8 Keyword node field namespaced? renamed to auto-resolved? Now using ex-info for explicitly raised exceptions Rewrite-cljs positional support migrated to rewrite-clj’s positional support Namespaced element support reworked v1 changes do not affect node traversal of the namespaced map, number and order of children remain the same. Namespace map prefix, is now stored in a namespaced map qualifier node. Prior to v1, the prefix was parsed to a keyword-node. Let’s look at what interesting node API functions will return for the prefix node in the following namespaced maps. Assume we have parsed the example and traversed down to the prefix node. For example via: (→ \"#:prefix{:a 1}\" z/of-string z/down z/node). node API call rewrite-clj #:prefix{:a 1} #::alias{:a 1} #::{:a 1} string is unchanged v1 \":prefix\" \"::alias\" \"::\" v0 throws on parse tag is different v1 :map-qualifier v0 :token throws on parse inner? still indicates that the node is a leaf node and has no children v1 false v0 false throws on parse sexpr <read on below for discussion on sexpr> Namespaced element sexpr support now relies on user specifiable auto-resolve function to resolve qualifiers Unlike rewrite-clj v0, the default auto-resolve behaviour never consults *ns* An sexpr for keyword node ::alias/foo no longer returns :alias/foo (this could be considered a bug fix, but if your code is expecting this, then you’ll need to make changes) The following namespaced element sexpr examples assume: *ns* is bound to user namespace (important only for rewrite-clj v0): We are using the default auto-resolve function for rewrite-clj v1 That you will refer to the User Guide for more detailed examples of v1 behaviour source sexpr rewrite-clj v1 sexpr rewrite-clj v0 sexpr rewrite-cljs qualified keyword :prefix/foo no change current-ns qualified keyword ::foo :?_current-ns_?/foo :user/foo throws on sexpr ns-alias qualified keyword ::alias/foo :??_alias_??/foo :alias/foo :alias/foo qualified map #:prefix{:a 1} #:prefix{:a 1} #:prefix{:a 1} (read-string \"#:prefix{:a 1}\") current-ns qualified map #::{:b 2} #:?_current-ns_?{:b 2} throws on parse throws on parse ns-alias qualified map #::alias{:c 3} #:??_alias_??{:c 3} throws unless namespace alias alias has been loaded in *ns* if alias in ns resolves to my.ns1: #:my.ns1{:c 3} (read-string \"#::alias{:c 3}\") Let’s dig into prefix and key sub-nodes of a namespaced map to explore v1 differences: Description rewrite-clj v1 rewrite-clj v0 and rewrite-cljs prefix (aka qualifier) qualified (-> \"#:prefix{:a 1}\"\n    z/of-string\n    z/down z/sexpr) prefix :prefix current-ns qualified (-> \"#::{:b 2}\"\n    z/of-string\n    z/down z/sexpr) ?_current-ns_? throws on parse ns-alias qualified (-> \"#::alias{:c 2}\"\n     z/of-string\n     z/down z/sexpr) ??_alias_?? :user/alias rewrite-cljs throws key qualified (-> \"#:prefix{:a 1}\"\n    z/of-string\n    z/down z/right z/down z/sexpr) :prefix/a :a current-ns qualified (-> \"#::{:b 2}\"\n    z/of-string\n    z/down z/right z/down z/sexpr) :?current-ns?/b throws on parse ns-alias qualified (-> \"#::alias{:c 3}\"\n    z/of-string\n    z/down z/right z/down z/sexpr) :??_alias_??/c :c Potentially breaking Some rewrite-cljs optimizations were dropped in favor of a single code base. If performance for rewrite-clj v1 for ClojureScript users is poor with today’s ClojureScript, we shall adapt. Deleted unused rewrite-clj.node.indent #116 Deleted redundant rewrite-clj.parser.util as part of #93. If you were using this internal namespace you can opt to switch to, the also internal, rewrite-clj.reader namespace. ",
+   :name "Changelog - v1.0.572-alpha",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_v1_0_572_alpha_2"}
+  {:doc "",
+   :name "Changelog - rewrite-clj v0",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_rewrite_clj_v0"}
+  {:doc
+   "BREAKING: uses a dedicated node type for regular expressions. (see #49 – thanks @ChrisBlom!) implement NodeCoercable for nil. (set #53 – thanks @jespera!) ",
+   :name "Changelog - 0.6.0",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_6_0"}
+  {:doc
+   "fixes parsing of splicing reader conditionals #?@…. (see #48) ",
+   :name "Changelog - 0.5.2",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_5_2"}
+  {:doc "fixes parsing of multi-line regular expressions. (see #51) ",
+   :name "Changelog - 0.5.1",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_5_1"}
+  {:doc
+   "BREAKING: commas will no longer be parsed into :whitespace nodes but :comma. (see #44 - thanks @arrdem!) BREAKING: position will throw exception if not used on rewrite-clj custom zipper. (see #45) BREAKING: drops testing against JDK6. DEPRECATED: append-space in favour of insert-space-right prepend-space in favour of insert-space-left append-newline in favour of insert-newline-right prepend-newline in favour of insert-newline-left fix insertion of nodes in the presence of existing whitespace. (see #33, #34 - thanks @eraserhd!) edn and edn* now take a :track-position? option that activates a custom zipper implementation allowing position to be called on. (see #41, #45 - thanks @eraserhd!) fix parsing of whitespace, e.g. <U+2028>. (see #43) fix serialization of `integer-node`s. (see #37 - thanks @eraserhd!) adds insert-left* and insert-right* to facade. generative tests. (see #41 - thanks @eraserhd!) ",
+   :name "Changelog - 0.5.0",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_5_0"}
+  {:doc
+   "Development has branched off, using the 0.4.x branch upgrades dependencies. fixes a compatibility issue when running 'benedekfazekas/mranderson' on a project with both 'rewrite-clj' and 'potemkin'. switch to Clojure 1.8.0 as base Clojure dependency; mark as \"provided\". switch to MIT License. drop support for JDK6. ",
+   :name "Changelog - 0.4.13",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_13"}
+  {:doc "drop fast-zip and potemkin dependencies. (see #26) ",
+   :name "Changelog - 0.4.12",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_12"}
+  {:doc
+   "fix handling of symbols with boundary character inside. (see #25) ",
+   :name "Changelog - 0.4.11",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_11"}
+  {:doc
+   "fix handling of symbols with trailing quote, e.g. x'. (see #24) ",
+   :name "Changelog - 0.4.10",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_10"}
+  {:doc
+   "fix replace-children for :uneval nodes. (see #23) add rewrite-clj.zip/postwalk. (see #22) ",
+   :name "Changelog - 0.4.9",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_9"}
+  {:doc "allow parsing of aliased keywords, e.g. ::ns/foo. (see #21) ",
+   :name "Changelog - 0.4.8",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_8"}
+  {:doc
+   "fixes zipper creation over whitespace-/comment-only data. (see #20) ",
+   :name "Changelog - 0.4.7",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_7"}
+  {:doc "fixes parsing of empty comments. (see #19) ",
+   :name "Changelog - 0.4.6",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_6"}
+  {:doc
+   "fixes parsing of comments that are at the end of a file without linebreak. (see #18) ",
+   :name "Changelog - 0.4.5",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_5"}
+  {:doc
+   "upgrades dependencies. add rewrite-clj.zip/child-sexprs to public API. ",
+   :name "Changelog - 0.4.4",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_4"}
+  {:doc "fix parsing of backslash \\\\ character. (see #17) ",
+   :name "Changelog - 0.4.3",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_3"}
+  {:doc
+   "fix :fn nodes (were printable-only? but should actually create an s-sexpression). fix assert-sexpr-count to not actually create the s-expressions. ",
+   :name "Changelog - 0.4.2",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_2"}
+  {:doc "fixes infinite loop when trying to read a character. ",
+   :name "Changelog - 0.4.1",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_1"}
+  {:doc
+   "BREAKING rewrite-clj.zip.indent no longer usable. BREAKING node creation/edit has stricter preconditions (e.g. :meta has to contain exactly two non-whitespace forms). BREAKING moved to a type/protocol based implementation of nodes. fix radix support. (see #13) fix handling of spaces between certain forms. (see #7) add node constructor functions. add child-sexprs function. ",
+   :name "Changelog - 0.4.0",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_4_0"}
+  {:doc "fix assoc on empty map. (see #16) ",
+   :name "Changelog - 0.3.12",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_12"}
+  {:doc
+   "drop tests for Clojure 1.4.0. fix behaviour of leftmost. upgrade to fast-zip 0.5.2. ",
+   :name "Changelog - 0.3.11",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_11"}
+  {:doc
+   "fix behaviour of next and end?. fix prewalk. add row/column metadata. ",
+   :name "Changelog - 0.3.10",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_10"}
+  {:doc
+   "add end?. allow access to children of quoted forms. (see #6) fix children lookup for zipper (return nil on missing children). (see #5) ",
+   :name "Changelog - 0.3.9",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_9"}
+  {:doc
+   "add :uneval element type (for #_form elements). fix estimate-length for multi-line strings. ",
+   :name "Changelog - 0.3.8",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_8"}
+  {:doc "fix zipper creation from file. ",
+   :name "Changelog - 0.3.7",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_7"}
+  {:doc
+   "upgrade dependencies. fix file parser (UTF-8 characters were not parsed correctly, see #24@xsc/lein-ancient). ",
+   :name "Changelog - 0.3.6",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_6"}
+  {:doc "upgrade dependencies. cleanup dependency chain. ",
+   :name "Changelog - 0.3.5",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_5"}
+  {:doc "upgrade dependencies. ",
+   :name "Changelog - 0.3.4",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_4"}
+  {:doc
+   "Bugfix: parsing of a variety of keywords threw an exception. ",
+   :name "Changelog - 0.3.3",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_3"}
+  {:doc "Bugfix: :1.4 and others threw an exception. ",
+   :name "Changelog - 0.3.2",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_2"}
+  {:doc "added namespaced keywords. ",
+   :name "Changelog - 0.3.1",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_1"}
+  {:doc
+   "added token type :newline to handle linebreak characters. rewrite-clj.zip/edn wraps everything into [:forms …] node, but the initial location is the node passed to it. new functions in rewrite-clj.zip.core: length move-to-node edit→>, edit-node subedit→, subedit→>, edit-children leftmost?, rightmost? new functions in rewrite-clj.zip.edit: splice-or-remove prefix, suffix (formerly rewrite-clj.zip.utils) rewrite-clj.zip.edit/remove now handles whitespace appropriately. indentation-aware modification functions in rewrite-clj.zip.indent: indent indent-children replace edit insert-left insert-right remove splice fast-zip utility functions in rewrite-clj.zip.utils ",
+   :name "Changelog - 0.3.0",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_3_0"}
+  {:doc
+   "added more expressive error handling to parser. added multi-line string handling (node type: :multi-line) new functions in rewrite-clj.printer: →string estimate-length new functions in rewrite-clj.zip: of-string, of-file print, print-root →string, →root-string append-space, prepend-space append-newline, prepend-newline right*, left*, … (delegating to fast-zip.core/right, …) new token type :forms new functions in rewrite-clj.parser: parse-all parse-string-all parse-file-all zipper utility functions in rewrite-clj.zip.utils (able to handle multi-line strings): prefix suffix ",
+   :name "Changelog - 0.2.0",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_2_0"}
+  {:doc "Initial Release ",
+   :name "Changelog - 0.1.0",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/changelog#_0_1_0"}
+  {:doc
+   "User Guide Table of Contents Introduction Interesting Alternatives History Upgrading from rewrite-clj v0 and/or rewrite-cljs Conventions Terminology Rewrite-clj Nodes Project Setup Tools Deps Leiningen Rewrite-clj APIs Zip API A Brief Introduction to Zippers Finding Elements with the Zip API Familiar Functions for Updating Nodes with the Zip API Sub Editing with the Zip API Tracking Position with the Zip API Zipper Options Parser API Node API Creating Nodes Paredit API Map Nodes Parsing Peculiarities Unbalanced Maps Maps with Duplicate keys Sets with Duplicate values Sexpr Nuances Whitespace Not all Clojure Elements are Sexpr-able Differences in Clojure Platforms Reader Macro Chars Namespaced Elements Recap Rewrite-clj Default Auto-Resolve Handling Custom Auto-Resolve Handling Impact of Auto-Resolve Impact of Namespaced Map Context on Keywords and Symbols Dealing with Reader Generated Metadata ",
    :name "User Guide",
-   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide"}
+   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#"}
   {:doc
-   "Developer Guide Table of Contents Supported Environments Prerequisites Windows Notes Git and newlines Babashka Clojure GraalVM Setup Babashka Tasks Code Generation Testing During Development Clojure ClojureScript Docs Testing Doc Code Blocks Testing Before a Push Unit tests Native image tests Libs test Checking for Outdated Dependencies Linting API diffs Cljdoc Preview Code Coverage Contributors Supported Environments Rewrite-clj is verified on each push on macOS, Ubuntu and Windows via GitHub Actions. All scripts are written in Clojure and most invoked via babashka tasks. This gives us a cross platform scripting language that is familiar, fun and consistent. We make use of planck for cljs bootstrap (aka cljs self-hosted) testing. Planck is currently not available for Windows. We test that rewrite-clj operates as expected when natively compile via GraalVM. Automated testing is setup using GraalVM v22 JDK11. Prerequisites Java JDK 1.8 or above NodeJs v12 or above Clojure v1.10.1.697 or above for clojure command Note that rewrite-clj v1 itself supports Clojure v1.8 and above Babashka v0.3.7 or above GraalVM v22.0.0.2 JDK 11 (if you want to run GraalVM native image tests) Windows Notes Git and newlines The primary development OSes for rewrite-clj are macOS and Linux. Our line endings are LF only. I’m not sure what Windows developers typically want for line endings while working on source. I expect, but don’t know, that most Windows editors automatically handle LF as line ending. Someone let me know if I am wrong. Note that I do explicitly set git’s config core.autocrlf to false on our Windows CI unit test environment. Our import vars code generation checks currently rely on line endings remaining unconverted. Babashka The Clojure story on Windows is still in the early chapters. Scoop offers an easy way to install tools. @littleli is doing a great job w/maintaining scoop apps for Clojure, Babashka and other tools and this is how I installed Babashka. Clojure We all choose our own paths, but for me, using deps.clj instead of Clojure’s PowerShell Module offered me no fuss no muss Clojure on Windows and GitHub Actions on Windows. I decided to install deps.clj not through scoop but through the deps.clj install.ps1 script. This makes it simple to treat deps.exe as if it were the official clojure via a simple rename: Rename-Item $HOME\\deps.clj\\deps.exe clojure.exe GraalVM You’ll have your own preference, but I find it convenient to install GraalVM on Windows via scoop. You’ll need to load the appropriate Visual C++ environment variables for GraalVM’s native-image to do its work. I found it oddly cumbersome to load them from PowerShell, so I work from a cmd shell instead. Here’s what works on my Windows dev environment: call \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat\" Setup After checking out this project from GitHub, Install JavaScript libraries and tools required by doo and shadow-cljs: sudo npm install karma-cli -g\nnpm install If you are on macOS or linux, install planck. Initialize cache for clj-kondo so it can lint against your dependencies bb lint Babashka Tasks We make use of babashka tasks for development related commands. To see all available tasks with a short description run: bb tasks To run a task, for example, the lint task: bb lint Usage help for a task is requested via --help, for example: bb lint --help Tasks are described throughout this document. Code Generation Rewrite-clj v0 used a version of potemkin import-vars. Potemkin import-vars copies specified vars from a specified namespace to the current namespace at load time. Due to often mysterious issues related to import-vars, a general dislike for import-vars in the Clojure community, and associated maintenance costs, we’ve opted to instead generate code for rewrite-clj v1. For any source that used potemkin import-vars, we now have a separate template clj (or cljc) file. For example src/rewrite_clj/zip.cljc is generated by template template/rewrite_clj/zip.cljc. The syntax of import-vars in the template remains familiar. The following old potemkin import-vars syntax: (import-vars\n  [[my.ns1 my-var1 my-var2 my-var3]\n   [my.ns2 my-var4 my-var5]]) Is expressed in our templates as: #_{:import-vars/import\n   {:from [[my.ns1 my-var1 my-var2 my-var3]\n           [my.ns2 my-var4 my-var5]]}} Any :added and :deprecated metadata should be defined in the template and not on the reference var. This keeps the metadata on the public API vars only and avoids having the ClojureScript compiler warn about deprecated calls on internal sources within rewrite-clj: #_{:import-vars/import\n   {:from [[my.ns1\n            ^{:deprecated \"1.2.3\"} obsolete-fn\n            ^{:added \"1.2.4\"} new-fn]]}} We also carry over rewrite-cljc support for :import-vars/import-with-mods, via an optional :opts. See template/rewrite_clj/zip.cljc for example usage. Importing will generate delegates. An import of (defn foo [a b] (+ a b)) from namespace my.ns1 will generate (defn foo [a b] (my.ns1/foo a b)). No generation of requires is done, your template will have to require my.ns1 in normal Clojure code. At this time, we don’t handle destructuring in arglists, and will throw unless args are all symbols. To generate target source from templates run: bb apply-import-vars gen-code You are expected to review the generated changes and commit the generated source to version control. We don’t lint templates, but we do lint the generated code. To perform a read-only check, run: bb apply-import-vars check The check command will exit with 0 if no changes are required, otherwise it will exit with 1. Our build script will run the check command and fail the build if there are any pending changes that have not been applied. Testing During Development Your personal preference will likely be different, but during maintenance and refactoring, I found running tests continuously for Clojure and ClojureScript helpful. Clojure For Clojure, I open a shell terminal window and run: bb test-clj-watch This launches kaocha in watch mode. ClojureScript For ClojureScript, I open a shell terminal window and run: bb test-cljs-watch This launches fighweel main. After initialization, your default web browser will automatically be opened with the figwheel auto-testing page. Docs All documentation is written in AsciiDoc. We follow AsciiDoc best practice of one sentence per line. Images are created and edited with draw.io desktop. We export to .png with a border of 10 and a transparent background. At the time of this writing draw.io does not remember export settings, so you’ll have to enter them in each time. Testing Doc Code Blocks We use test-doc-blocks to verify that code blocks in our documentation are in good working order. bb test-doc This generates tests for doc code blocks and then runs them under Clojure and ClojureScript. Testing Before a Push Before pushing, you likely want to mimic what is run on each push via GitHub Actions. Unit tests Unit tests are run via: bb ci-unit-tests Native image tests We also verify that rewrite-clj functions as expected when compiled via Graal’s native-image. Tests and library natively compiled: bb test-native Library natively compiled and tests interpreted via sci bb test-native-sci Libs test To try to ensure our changes to rewrite-clj do not inadvertently break existing popular libraries, we run their tests, or a portion thereof, against rewrite-clj. bb test-libs run See README for current libs we test against. Additional libs are welcome. To see a list of available libs we currently test against: bb test-libs list If you are troubleshooting locally, and want to only run specific tests, you can specify which ones you’d like to run. For example: bb test-libs run cljfmt zprint Updating the test-libs script to run against current versions of libs is recommended, but care must be taken when updating. We want to make sure we are patching correctly to use rewrite-clj v1 and running a lib’s tests as intended. To check for outdated libs: bb test-libs outdated Notes: The test-libs task was developed on macOS and is run on CI under Linux only under JDK 11 only. We can expand variations at some later date if there is any value to it. We test the current HEAD of rewrite-clj v1 against specific versions (latest at the time of this writing) of libs. We patch lib deps and sometimes code (ex. require for rewrite-cljc becomes rewrite-clj). As folks migrate to rewrite-clj v1, the need for current patches will lessen. Updating what versions we test against is currently a manual, but not an overly burdensome, task. Checking for Outdated Dependencies To see what new dependencies are available, run: bb outdated This task uses: antq for Clojure. npm for JavaScript. It only checks against installed ./node_modules, so you may want to run npm install first. Linting We use clj-kondo and eastwood to lint rewrite-clj source code. We apply whitespace-linter to docs, config, and source code to avoid some annoying whitespace diffs. We fail the build on any lint violations. The CI server runs: bb lint and you can too. The lint script will build the clj-kondo cache when it is missing or stale. If you want to force a rebuild of the cache run: bb lint --rebuild-cache Integrate clj-kondo into your editor to catch mistakes as they happen. You can optionally: bb -lint-whitespace to run only whitespace linting bb -lint-kondo to run only clj-kondo linting bb -lint-eastwood to run only the eastwood linting API diffs Rewrite-clj v1’s primary goals include remaining compatible with rewrite-clj v0 and rewrite-cljs and avoiding breaking changes. To generate reports on differences between rewrite-clj v0, rewrite-cljs and rewrite-clj v1 APIs, run: bb doc-api-diffs This task currently needs love, see #132. Run this script manually on an as-needed basis, and certainly before any official release. Generated reports are to be checked in to version control. Reports are generated to doc/generated/api-diffs/ and include manually written notes from doc/diff-notes/. These reports are referenced from other docs, so if you rename files, be sure to search for links. Makes use of diff-apis. Delete .diff-apis/.cache if you need a clean run. Cljdoc Preview Before a release, it can be comforting to preview what docs will look like on cljdoc. Limitations This task should be considered experimental, I have only tested running on macOS, but am fairly confident it will work on Linux. Not sure about Windows at this time. You have to push your changes to GitHub to preview them. This allows for a full preview that includes any links (source, images, etc) to GitHub. This works fine from branches and forks - in case you don’t want to affect your main development branch for a preview. Start Local Services To start the local cljdoc docker container: bb cljdoc-preview start The local cljdoc server allows your ingested docs to be viewed in your web browser. The start command also automatically checks docker hub for any updates so that our cljdoc preview matches the current production version of cljdoc. Ingest Docs To ingest rewrite-clj API and docs into the local cljdoc database: bb cljdoc-preview ingest The ingest command automatically publishes rewrite-clj to your local maven repository (cljdoc only works with published jars). The locally published version will include a -cljdoc-preview suffix. I find this distinction helps to reduce confusion around locally vs remotely installed artifacts. You’ll have to remember to git commit and git push your changes before ingesting. Repeat these steps any time you want to preview changes. Preview Docs To open a view to the ingested docs in your default web browser: bb cljdoc-preview view If you have just run the start command, be a bit patient, the cljdoc server can take a few moments to start up - especially on macOS due to poor file sharing performance. Stop Local Services When you are done, you’ll want to stop your docker container: bb cljdoc-preview stop This will also delete temporary files created to support your preview session, most notably the local cljdoc database. Note that NO cleanup is done for any rewrite-clj artifacts published to your local maven repository. Container Status If you forget where you are at with your docker containers, run: bb cljdoc-preview status Code Coverage We use cloverage via kaocha to generate code coverage reports via: bb test-coverage Our CI service is setup to automatically generate then upload reports to CodeCov. We have no specific goals for code coverage, but new code is generally expected to have tests. So why measure coverage? It simply offers us some idea of what code our test suite hits. Contributors We honor current and past contributors to rewrite-clj in our README file. To update contributors, update doc/contributors.edn then run: bb doc-update-readme",
+   "Rewrite-clj is a library that can read, update and write Clojure, ClojureScript and EDN source code while preserving whitespace and comments. ",
+   :name "User Guide - Introduction",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_introduction"}
+  {:doc
+   "If rewrite-clj is not your cup of tea, consider following alternatives: Project Parsing? Writing? Whitespace Preserving? Includes Element Row/Col? parcera yes yes yes yes edamame yes no no yes ",
+   :name "User Guide - Interesting Alternatives",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_interesting_alternatives"}
+  {:doc
+   "@xsc created rewrite-clj in 2013. Its original use was to upgrade dependencies in lein project.clj files. The library quickly took off in popularity and is the default choice for modifying Clojure/EDN from Clojure. @rundis created rewrite-cljs in 2015 to match the features of rewrite-clj for ClojureScript developers. It was originally used for refactoring support in Light Table. In January of 2019, @rundis graciously transferred rewrite-cljs to clj-commons. Seeing an opportunity to give back to the Clojure community, in 2019 @lread, with guidance and help from many friendly Clojurians, started work on rewrite-cljc. In December of 2020, @xsc graciously tranferred rewrite-clj to clj-commons. So rewrite-cljc is now dead, long live rewrite-clj! To distinguish the the versions of rewrite-clj, I’ll use: rewrite-clj v0 to refer to the classic rewrite-clj v1 to refer to the reboot When the distinction is unimportant, I’ll simply use rewrite-clj. The goal of rewrite-clj v1 is to provide a thoughtfully maintained feature-complete library that can be used from either Clojure or ClojureScript. While merging rewrite-clj v0 and rewrite-cljs to create rewrite-clj v1 was not trivial, the real hard work was done over many years in rewrite-clj v0 and rewrite-cljs under the leadership of @xsc and @rundis (thanks guys!). Read Merging rewrite-clj and rewrite-cljs for details on the merge. ",
+   :name "User Guide - History",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_history"}
+  {:doc
+   "Thanks to @xsc’s transfer of rewrite-clj to clj-commons we’ll continue on with the rewrite-clj namespace and clojars deploy target. To upgrade to rewrite-clj v1, update your project dependencies. If you were using both rewrite-cljs and rewrite-clj v0 in your project you can now drop the rewrite-cljs dependency. Rewrite-clj unit tests are run against the current version of ClojureScript and Clojure versions >= v1.8.0. We recommend that while bumping your rewrite-clj dependency to v1, that you also bump your Clojure and ClojureScript dependencies to current official releases. The most notable breaking changes from rewrite-clj v0 relate to handling of namespaced elements: Namespaced map handling was incomplete in rewrite-clj, has been reworked a bit and now supports namespaced symbols An sexpr on a namespaced key or symbol should now work even when navigating down to the key node An sexpr that involves auto resolve never consults *ns* you can plugin your own auto-resolve behavior, see namespaced elements Need to know more? See the change log. ",
+   :name
+   "User Guide - Upgrading from rewrite-clj v0 and/or rewrite-cljs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_upgrading_from_rewrite_clj_v0_andor_rewrite_cljs"}
+  {:doc
+   "As is a common convention, example code shows results of expression evaluation like so: (+ 1 2 3)\n;; => 6 We show distinctions between Clojure and Clojurescript results like so: \\c\n;; =clj=> \\c\n;; =cljs=> \"c\" And we show output like so: (println \"hello there\")\n;; =stdout=>\n; hello there ",
+   :name "User Guide - Conventions",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_conventions"}
+  {:doc
+   "Rewrite-clj has an sexpr function that returns Clojure forms. Our usage of the terms \"s-expression\" and \"forms\" might be less nuanced than some formal definitions. I think we are in line with Clojure for the Brave and True’s description of forms. To us, a Clojure form is any parsed (but not evaluated) Clojure as it would be returned by the Clojure reader. ",
+   :name "User Guide - Terminology",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_terminology"}
+  {:doc
+   "Rewrite-clj parses Clojure source into rewrite-clj nodes. While reviewing the following example, it helps to remember that Clojure source is data. Each node carries the positional metadata :row, :col, :end-row and :end-col. The positional data is 1-based and :end-col is exclusive. You can parse and work with nodes directly or take advantage of the power of the zip API. Rewrite-clj offers easy conversion from rewrite-clj nodes to Clojure forms and back. This is convenient but does come with some caveats. As you get more experienced with rewrite-clj, you will want to review sexpr nuances. ",
+   :name "User Guide - Rewrite-clj Nodes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#nodes"}
+  {:doc "",
+   :name "User Guide - Project Setup",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_project_setup"}
+  {:doc
+   "Include the following dependency in your deps.edn file: rewrite-clj/rewrite-clj {:mvn/version \"1.0.767-alpha\"} ",
+   :name "User Guide - Tools Deps",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_tools_deps"}
+  {:doc
+   "Include the following dependency in your project.clj file: [rewrite-clj/rewrite-clj \"1.0.767-alpha\"] ",
+   :name "User Guide - Leiningen",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_leiningen"}
+  {:doc
+   "There are 4 public API namespaces: rewrite-clj.zip rewrite-clj.parser rewrite-clj.node rewrite-clj.paredit ",
+   :name "User Guide - Rewrite-clj APIs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_rewrite_clj_apis"}
+  {:doc
+   "Traverse and modify Clojure/ClojureScript/EDN. This is considered the main rewrite-clj API and might very well be all you need. You’ll optionally use the node API on the rewrite-clj nodes in the zipper. ",
+   :name "User Guide - Zip API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#zip-api"}
+  {:doc
+   "Rewrite-clj uses a customized version of Clojure’s clojure.zip. If you are not familiar with zippers, you may find the following resources helpful: Clojure overview of zippers Arne Brasseur - The Art of Tree Shaping with Clojure Zippers Tim Baldrige - PivotShare - Series of 7 Videos on Clojure Zippers At a conceptual level, the rewrite-clj zipper holds: a tree of rewrite-clj nodes representing your parsed Clojure source your current location within the zipper Because the zipper holds both the tree and your location within the tree, its variable is commonly named zloc. The zipper is immutable, as such, location changes and node modifications are always returned in a new zipper. You may want to refer to rewrite-clj nodes while reviewing this introductory example: (require '[rewrite-clj.zip :as z])\n\n;; define some test data\n(def data-string\n\"(defn my-function [a]\n  ;; a comment\n  (* a 3))\")\n\n;; parse code to nodes, create a zipper, and navigate to the first non-whitespace node\n(def zloc (z/of-string data-string))\n\n;; explore what we've parsed\n(z/sexpr zloc)\n;; => (defn my-function [a] (* a 3))\n(-> zloc z/down z/right z/node pr)\n;; =stdout=>\n; <token: my-function>\n(-> zloc z/down z/right z/sexpr)\n;; => my-function\n\n;; rename my-function to my-function2 and return resulting s-expression\n(-> zloc\n    z/down\n    z/right\n    (z/edit (comp symbol str) \"2\")\n    z/up\n    z/sexpr)\n;; => (defn my-function2 [a] (* a 3))\n\n;; rename my-function to my-function2 and return updated string from root node\n(-> zloc\n    z/down\n    z/right\n    (z/edit (comp symbol str) \"2\")\n    z/root-string\n    println)\n;; =stdout=>\n; (defn my-function2 [a]\n;   ;; a comment\n;   (* a 3)) The zip location movement functions (right, left, up, down, etc) skip over Clojure whitespace nodes and comment nodes. Remember that Clojure whitespace includes commas. If you want to navigate over all nodes, use the * counterparts (right*, left*, up*, down*, etc). See zip API docs. ",
+   :name "User Guide - A Brief Introduction to Zippers",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_a_brief_introduction_to_zippers"}
+  {:doc
+   "The rewrite-clj.zip namespace includes find operations to navigate to locations of interest in your zipper. Let’s assume you want to modify the following minimal project.clj by replacing the :description placeholder text with something more meaningful: project.clj snippet (defproject my-project \"0.1.0-SNAPSHOT\"\n  :description \"Enter description\") Most find functions accept an optional location movement function. Use: rewrite-clj.zip/right (the default) - to search sibling nodes to the right rewrite-clj.zip/left to search siblings to left rewrite-clj.zip/next for a depth-first tree search (require '[rewrite-clj.zip :as z])\n\n;; for sake of a runnable example we'll load from a string:\n(def zloc (z/of-string\n\"(defproject my-project \\\"0.1.0-SNAPSHOT\\\"\n  :description \\\"Enter description\\\")\"))\n\n;; loading from a file, looks like so:\n;; (def zloc (z/of-file \"project.clj\")) (1)\n\n;; find defproject by navigating depth-first\n(def zloc-defproject (z/find-value zloc z/next 'defproject))\n;; verify that we are where we think we are\n(z/sexpr zloc-defproject)\n;; => defproject\n\n;; search right for :description and then move one node to the right (2)\n(def zloc-desc (-> zloc-defproject (z/find-value :description) z/right))\n;; check that this worked\n(z/sexpr zloc-desc)\n;; => \"Enter description\"\n\n;; replace node at current location and return the result\n(-> zloc-desc (z/replace \"My first Project.\") z/root-string println)\n;; =stdout=>\n; (defproject my-project \"0.1.0-SNAPSHOT\"\n;   :description \"My first Project.\") 1 reading from a file is only available from Clojure 2 Remember that while whitespace is preserved, it is automatically skipped during navigation. ",
+   :name "User Guide - Finding Elements with the Zip API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_finding_elements_with_the_zip_api"}
+  {:doc
+   "The zip API provides familiar ways to work with parsed Clojure data structures. It offers some functions that correspond to the standard Clojure seq functions, for example: (require '[rewrite-clj.zip :as z])\n\n(def zloc (z/of-string \"[1\\n2\\n3]\"))\n(z/vector? zloc)\n;; => true\n(z/sexpr zloc)\n;; => [1 2 3]\n(-> zloc (z/get 1) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> zloc (z/assoc 1 5) z/sexpr)\n;; => [1 5 3]\n(->> zloc (z/map #(z/edit % + 4)) z/root-string)\n;; => \"[5\\n6\\n7]\"\n\n(def zloc (z/of-string \"{:a 10 :b 20}\"))\n(z/map? zloc)\n;; => true\n(-> zloc (z/get :b) z/node pr)\n;; =stdout=>\n; <token: 20>\n(-> zloc (z/assoc :b 42) z/sexpr)\n;; => {:b 42, :a 10}\n(->> zloc (z/map-vals #(z/edit % inc)) z/root-string)\n;; => \"{:a 11 :b 21}\"\n(->> zloc\n     (z/map-keys #(z/edit %\n                          (fn [v] (keyword \"prefix\" (name v))) ))\n     z/root-string)\n;; => \"{:prefix/a 10 :prefix/b 20}\" ",
+   :name
+   "User Guide - Familiar Functions for Updating Nodes with the Zip API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_familiar_functions_for_updating_nodes_with_the_zip_api"}
+  {:doc
+   "Sub editing allows you to effect changes to an isolated subtree (actually a sub zipper) while preserving your original location in the zipper When sub editing, your sub zipper is isolated to the current node and its children. The sub zipper acts like, and is, a full zipper; rewrite-clj.zip/end? will return true when you have navigated to the end of the sub zipper. This can be useful when you: Are interested in restoring your location after digging down deep to make a change Want to restrict your changes to a node and its children. It can be helpful to bound your movement when using functions that also affect current location such as rewrite-clj.zip/remove. (require '[rewrite-clj.zip :as z])\n\n;; A sample to illustrate\n(def zloc (z/of-string \"[a [b [c [d [e [f]]]]] g h]\"))\n\n;; ... and a little helper that navigates our location to the end node:\n(defn to-end [zloc]\n  (->> zloc\n       (iterate z/next)\n       (drop-while (complement z/end?))\n       first))\n\n;; ... and a little editor to show which node was hit:\n(defn update-at-loc [zloc]\n  (z/edit zloc #(symbol \"UPDATED\" (str %))))\n\n;; If we don't use a sub zipper our end node is h:\n(-> zloc\n    to-end\n    update-at-loc\n    z/root-string)\n;; => \"[a [b [c [d [e [f]]]]] g UPDATED/h]\"\n\n;; If we subedit on the first node in the vector, we are restricted to that node.\n;; In our case that node is a:\n(-> zloc\n    z/down\n    (z/subedit->\n     to-end\n     update-at-loc)\n    z/root-string)\n;; => \"[UPDATED/a [b [c [d [e [f]]]]] g h]\"\n\n;; If we subedit on the second node in the vector, we are restricted to that node.\n;; In our case that node is [b [c [d [f]]]] with subedit end node f\n(-> zloc\n    z/down\n    z/right\n    (z/subedit->\n     to-end\n     update-at-loc)\n    z/root-string)\n;; => \"[a [b [c [d [e [UPDATED/f]]]]] g h]\"\n\n;; To show our original location was preserved,\n;; after a subedit of the last node within the 2nd node in the vector,\n;; a movement right brings us to node g\n(-> zloc\n    z/down\n    z/right\n    (z/subedit->\n     to-end\n     (z/edit #(symbol \"UPDATED\" (str %))))\n    z/right\n    z/string)\n;; => \"g\" The zip API walk functions also isolate your work to the current node. Let’s explore: (require '[rewrite-clj.zip :as z])\n\n;; Let's contrive an example with multiple top level forms:\n(def zloc (z/of-string \"(def x 1) (def y [2 3 [4 [5]]])\"))\n\n;; Now let's add 100 to all numbers:\n(-> zloc\n    (z/postwalk (fn select [zloc] (number? (z/sexpr zloc)))\n                (fn visit [zloc] (z/edit zloc + 100)))\n    z/root-string)\n;; => \"(def x 101) (def y [2 3 [4 [5]]])\"\n\n;; Hmmm... what happened? Only the first number was affected.\n;; A new zipper automaticaly navigates to the first non-whitespace/non-comment node.\n;; In our example, this is node (def x 1).\n;; Our walk was isolated to current node (def x 1) so that's all that got updated\n\n;; We can adapt to walk all nodes with a movement up to the top level prior to our walk\n(-> zloc\n    z/up\n    (z/postwalk (fn select [zloc] (number? (z/sexpr zloc)))\n                (fn visit [zloc] (z/edit zloc + 100)))\n    z/root-string)\n;; => \"(def x 101) (def y [102 103 [104 [105]]])\" ",
+   :name "User Guide - Sub Editing with the Zip API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#sub-editing"}
+  {:doc
+   "If you need to track the source row and column while reading and updating your zipper, create your zipper with :track-position true option. Note that the row and column are 1-based. If you have no interest in the zipper updating positions when the zipper changes, but are still interested in node positions, you can use a zipper without :track-positon true option. Read up on positional metadata under rewrite-clj nodes. (require '[rewrite-clj.zip :as z])\n\n;; parse some Clojure into a position tracking zipper\n(def zloc (z/of-string\n           \"(defn sum-me\\n  \\\"Add 'em up!\\\"\\n  [a b c]\\n  (+ a\\n     c))\"\n           {:track-position? true}))\n\n;; let's see what that looks like printed out\n(println (z/root-string zloc))\n;; =stdout=>\n; (defn sum-me\n;   \"Add 'em up!\"\n;   [a b c]\n;   (+ a\n;      c))\n\n;; navigate to second z in zipper\n(def zloc-c (-> zloc\n            (z/find-value z/next '+)\n            (z/find-value z/next 'c)))\n\n;; check if current node is as expected\n(z/string zloc-c)\n;; => \"c\"\n\n;; examine position of second z, it is on 6th column of the 5th row\n(z/position zloc-c)\n;; => [5 6]\n\n;; insert new element b with indentation and alignment\n(def zloc-c2 (-> zloc-c\n                 (z/insert-left 'b)        ;; insert b to the left of c\n                 (z/left)                  ;; move to b\n                 (z/insert-newline-right)  ;; insert a newline after b\n                 (z/right)                 ;; move to c\n                 (z/insert-space-left 4))) ;; c has 1 space before it, add 4 more to line it up\n\n;; we should still be at c\n(z/string zloc-c2)\n\"c\"\n\n;; output our updated Clojure\n(println (z/root-string zloc-c2))\n;; =stdout=>\n; (defn sum-me\n;   \"Add 'em up!\"\n;   [a b c]\n;   (+ a\n;      b\n;      c))\n\n;; and check that location of c has been updated, it should now be on the 6th column of the 6th row\n(z/position zloc-c2)\n;; => [6 6] ",
+   :name "User Guide - Tracking Position with the Zip API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#position-tracking"}
+  {:doc
+   "When creating a new zipper you may optionally include an options map. These options will be carried by the zipper and live for the life of the zipper. Current options are: :track-position - see Tracking Position with the Zip API :auto-resolve - see Custom Auto-Resolve Handling After making changes via a zipper, the final step is typically to call root-string or print-root. Less frequently, one might call root which affects changes and returns the root rewrite-clj node. This node might be fed back into a new zipper. The options passed into the original zipper on creation will not be automatically applied to the new zipper and must be respecified: (require '[rewrite-clj.zip :as z])\n\n;; some contrived options to demonstrate:\n(def zip-opts {:track-position true\n               :auto-resolve (fn [_alias] 'custom-resolved)})\n\n\n(-> \"(+ 10 20 30)\"         ;; <- something more complicated would be here, of course\n    (z/of-string zip-opts) ;; <- our opts are passed in on creation\n    z/down z/right z/right\n    (z/edit inc)\n    z/root                 ;; <- applying changes and getting root node\n    (z/edn zip-opts)       ;; <- pass the original zip-opts on creation of new zipper\n    z/down z/right z/right\n    (z/edit inc)\n    (z/root-string))\n;; => \"(+ 10 22 30)\" ",
+   :name "User Guide - Zipper Options",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_zipper_options"}
+  {:doc
+   "Parses Clojure/ClojureScript/EDN to rewrite-clj nodes. The zip API makes use of the parser API to parse Clojure into zippers. If your focus is parsing instead of rewriting, you might find this lower level API useful. Keep in mind that if you forgo the zip API, you forgo niceties such as the automatic handling of whitespace. You can choose to parse the first, or all forms from a string or a file.[file] Here we parse a single form from a string: (require '[rewrite-clj.parser :as p])\n\n(def form-nodes (p/parse-string \"(defn my-function [a]\\n  (* a 3))\")) You’ll likely use the node API on the returned nodes. See parser API docs. ",
+   :name "User Guide - Parser API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#parser-api"}
+  {:doc
+   "Inspect, analyze, create and render rewrite-clj nodes. (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n(def nodes (p/parse-string \"(defn my-function [a]\\n  (* a 3))\"))\n\n;; Explore what we've parsed\n(n/tag nodes)\n;; => :list\n\n(pr (n/children nodes))\n;; =stdout=>\n; (<token: defn> <whitespace: \" \"> <token: my-function> <whitespace: \" \"> <vector: [a]> <newline: \"\\n\"> <whitespace: \"  \"> <list: (* a 3)>)\n\n(n/sexpr nodes)\n;; => (defn my-function [a] (* a 3))\n\n(n/child-sexprs nodes)\n;; => (defn my-function [a] (* a 3))\n\n;; convert the nodes back to a printable string\n(n/string nodes)\n;; => \"(defn my-function [a]\\n  (* a 3))\"\n\n;; coerce clojure forms to rewrite-clj nodes\n(pr (n/coerce '[a b c]))\n;; =stdout=>\n; <vector: [a b c]>\n\n;; create rewrite-clj nodes by hand\n(pr (n/meta-node\n      (n/token-node :private)\n      (n/token-node 'sym)))\n;; =stdout=>\n; <meta: ^:private sym> See node API docs. ",
+   :name "User Guide - Node API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#node-api"}
+  {:doc
+   "Rewrite-clj nodes can be created in a number of ways: Indirectly via the parser API: (-> (p/parse-string \"[1 2 3]\")\n    n/string)\n;; => \"[1 2 3]\" Indirectly via the zip API (which uses the parser API): (-> (z/of-string \"[1 2 3]\")\n    z/node\n    n/string)\n;; => \"[1 2 3]\" Via coercion from Clojure forms: (-> (n/coerce '[1 2 3])\n     n/string)\n;; => \"[1 2 3]\" By explicitly calling node creation functions. (-> (n/vector-node [(n/token-node 1)\n                    (n/whitespace-node \" \")\n                    (n/token-node 2)\n                    (n/whitespace-node \" \")\n                    (n/token-node 3)])\n    n/string)\n;; => \"[1 2 3]\" The node creation function are what the parser API uses to create nodes. Which technique you use depends on our needs. Coercion is convenient, but doesn’t offer control over whitespace. In some cases coercion might not give you the result you expect: (-> (n/coerce '#(+ %1 %2))\n    n/string)\n;; => \"(fn* [p1__10532# p2__10533#] (+ p1__10532# p2__10533#))\" Be aware that node creation functions do not force you to use rewrite-clj nodes (notice the raw 1 2 and 3): (-> (n/vector-node [1 (n/spaces 1) 2 (n/spaces 1) 3])\n    n/string)\n;; => \"[1 2 3]\" …but no automatic coercion will be done on non rewrite-clj elements and their tag will return unknown. (n/tag 1)\n;; :unknown Finally, there are a handful of node whitespace creation convenience functions such as spaces, newlines, line-separated and comma-separated, see the node API docs for details. ",
+   :name "User Guide - Creating Nodes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_creating_nodes"}
+  {:doc
+   "Structured editing was introduce by rewrite-cljs and carried over to rewrite-clj v1. We might expand this section if there is interest, but the docstrings should get you started. See current paredit API docs. ",
+   :name "User Guide - Paredit API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_paredit_api"}
+  {:doc
+   "Rewrite-clj parses two types of maps. unqualified {:a 1 :b 2} namespaced #:prefix {:x 1 :y 2} Rewrite-clj models nodes as they appear in the original source. This is convenient when navigating through the source, but when we want to logically treat any map as a map the difference is admittedly bit awkward. ",
+   :name "User Guide - Map Nodes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_map_nodes"}
+  {:doc
+   "Rewrite-clj can, in some specific cases, parse technically invalid Clojure. Some folks have come to rely on this over the years, so these are behaviours we will preserve. ",
+   :name "User Guide - Parsing Peculiarities",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_parsing_peculiarities"}
+  {:doc
+   "An unbalanced map is one where there is a key with no value. Rewrite-clj can parse and emit unbalanced maps: (require '[rewrite-clj.zip :as z])\n\n(-> \"{:a 1 :b 2 :c}\"\n    z/of-string\n    z/root-string)\n;; => \"{:a 1 :b 2 :c}\" An attempt to convert an unbalanced map to a Clojure form will throw: (try\n  (-> \"{:a 1 :b 2 :c}\"\n      z/of-string\n      z/sexpr)\n  (catch Throwable e\n    (.getMessage e)))\n;; => \"No value supplied for key: :c\" sexpr-able? considers the current node element type only and will return true for all maps, balanced or not. ",
+   :name "User Guide - Unbalanced Maps",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#unbalanced-maps"}
+  {:doc
+   "Rewrite-clj can parse and emit maps with duplicate keys: (-> \"{:a 1 :b 2 :a 3 :a 4 :a 5 :a 6}\"\n    z/of-string\n    z/root-string)\n;; => \"{:a 1 :b 2 :a 3 :a 4 :a 5 :a 6}\" But when converting to a Clojure form, duplicate keys are not valid in a map, so only the last key/value pair for duplicate keys will be included: (-> \"{:a 1 :b 2 :a 3 :a 4 :a 5 :a 6}\"\n    z/of-string\n    z/sexpr)\n;; => {:b 2, :a 6} ",
+   :name "User Guide - Maps with Duplicate keys",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#maps-with-duplicate-keys"}
+  {:doc
+   "Rewrite-clj can parse and emit sets with duplicate values: (-> \"#{:a :b :a :a :a}\"\n    z/of-string\n    z/root-string)\n;; => \"#{:a :b :a :a :a}\" But when converting to a Clojure form, duplicate values in a set are not valid Clojure, so the duplicates are omitted: (-> \"#{:a :b :a :a :a}\"\n    z/of-string\n    z/sexpr)\n;; => #{:b :a} ",
+   :name "User Guide - Sets with Duplicate values",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#sets-with-duplicate-values"}
+  {:doc
+   "Rewrite-clj parses arbitrary Clojure/ClojureScript source code into rewrite-clj nodes. Converting rewrite-clj nodes to Clojure forms via sexpr is convenient, but it does come with some caveats. Within reason, Clojure’s read-string and rewrite-clj’s sexpr functions should return equivalent Clojure forms. To illustrate, some code: (require '[rewrite-clj.zip :as z]\n         '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n]\n         #?(:cljs '[cljs.reader :refer [read-string]]))\n\n(defn form-test [s]\n  (let [forms [(-> s read-string)\n               (-> s z/of-string z/sexpr)\n               (-> s p/parse-string n/sexpr)]]\n    (if (apply = forms)\n      (first forms)\n      [:not-equal forms])))\n\n(form-test \"a\")\n;; => a\n(form-test \"[1 2 3]\")\n;; => [1 2 3]\n(form-test \"(defn hello [name] (println \\\"Hello\\\" name))\")\n;; => (defn hello [name] (println \"Hello\" name)) ",
+   :name "User Guide - Sexpr Nuances",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#sexpr-nuances"}
+  {:doc
+   "The whitespace that a rewrite-clj so carefully preserves is lost when converting to a Clojure form. (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n;; parse some Clojure source\n(def nodes (p/parse-string \"{  :a 1\\n\\n   :b 2}\"))\n\n;; print it out to show the whitespace\n(println (n/string nodes))\n;; =stdout=>\n; {  :a 1\n;\n;    :b 2}\n\n;; print out Clojure forms and notice the loss of the specifics of whitespace and element ordering\n(pr (n/sexpr nodes))\n;; =stdout=>\n; {:b 2, :a 1} ",
+   :name "User Guide - Whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_whitespace"}
+  {:doc
+   "Some source code element types are not sexpr-able: Reader ignore/discard #_ (also known as \"uneval\" in rewrite-clj) Comments Clojure whitespace (which includes commas) Both the zip and node APIs include sexpr-able? to check if sexpr is supported for the current node element type. sexpr-able? only looks at the current node element type. This means that sexpr will still throw when: called on a node with an element type that is sepxr-able? but, for whatever reason, has a child node that fails to sexpr, see unbalanced maps. called directly on an unbalanced maps. (require '[rewrite-clj.node :as n]\n         '[rewrite-clj.parser :as p]\n         '[rewrite-clj.zip :as z])\n\n#?(:clj (import clojure.lang.ExceptionInfo))\n\n;;\n;; Most nodes are sexpr-able\n;;\n\n;; we can check sexpr-ability through the node API\n(-> \"hello\" p/parse-string n/sexpr-able?)\n;; => true\n\n;; or through the zip API\n(-> \"hello\" z/of-string z/sexpr-able?)\n;; => true\n\n;;\n;; But some nodes are not sexpr-able\n;;\n\n;; the discard #_ node is not sexpr-able\n(-> \"#_42\" z/of-string z/sexpr-able?)\n;; => false\n\n;; and will throw if an attempt is made to sexpr\n(try\n  (-> \"#_42\" z/of-string z/sexpr)\n  (catch ExceptionInfo e\n    (ex-message e)))\n;; => \"unsupported operation\"\n\n;; comments nodes are not sexpr-able\n(-> \";; can’t sexpr me!\" z/of-string z/next* z/sexpr-able?) (1)\n;; => false\n\n;; and will throw\n(try\n  (-> \";; can’t sexpr me!\" z/of-string z/next* z/sexpr) (1)\n  (catch ExceptionInfo e\n    (ex-message e)))\n;; => \"unsupported operation\"\n\n;; and finally, Clojure whitespace nodes are not sexpr-able\n(-> \" \" z/of-string z/next* z/sexpr-able?) (1)\n;; => false\n\n;; and will throw\n(try\n  (-> \" \" z/of-string z/next* z/sexpr) (1)\n  (catch ExceptionInfo e\n    (ex-message e)))\n;; => \"unsupported operation\" 1 Notice the use of next* to include normally skipped nodes. Remember that child nodes with element types that are not sexpr-able? are skipped for sexpr: (-> (str \"[1 #_:child-discard-will-be-skipped\\n\"\n         \" ;; comment will be skipped\\n\"\n         \" ,,, ,,, ,,, \\n\"\n         \" 2]\")\n    z/of-string\n    z/sexpr)\n;; => [1 2] ",
+   :name "User Guide - Not all Clojure Elements are Sexpr-able",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#not-all-clojure-is-sexpr-able"}
+  {:doc
+   "Clojure and ClojureScript have differences. Some examples of what you might run into when using sexpr are: (require '[rewrite-clj.zip :as z])\n\n;; ClojureScript has no Ratio type\n(-> (z/of-string \"3/4\") z/sexpr)\n;; =clj=> 3/4\n;; =cljs=> 0.75\n\n;; Integral type and behaviour is defined by host platforms\n(+ 10 (-> (z/of-string \"9007199254740991\") z/sexpr))\n;; =clj=> 9007199254741001\n;; =cljs=> 9007199254741000\n\n;; ClojureScript has no character type, characters are expressed as strings\n(-> (z/of-string \"\\\\a\") z/sexpr)\n;; =clj=> \\a\n;; =cljs=> \"a\" Note that these differences affect sexpr only. Rewrite-clj should be able to parse and rewrite all valid Clojure/ClojureScript code. ",
+   :name "User Guide - Differences in Clojure Platforms",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_differences_in_clojure_platforms"}
+  {:doc
+   "Rewrite-clj can parse and write all reader macro chars. Be aware though, that it does have limitations when calling sexpr on rewrite-clj nodes representing some of these constructs. Let’s take a look, using Clojure’s reader docs on macro characters as our reference. (headers are description followed by rewrite-clj parsed node tag) Parsed input Node sexpr Quote :quote 'form (quote form) Character :token \\newline \\newline \\space \\space \\tab \\tab Comment :comment ; comment <unsupported operation> Deref :deref @form (deref form) Metadata :meta ^{:a 1 :b 2} [1 2 3] ^{:b 2, :a 1} [1 2 3] ^String x ^{String true} x ^:dynamic x ^{:dynamic true} x Set :set #{1 2 3} #{1 3 2} Regex :regex #\"reg.*ex\" (re-pattern \"reg.*ex\") Var-quote :var #'x (var x) Anonymous function :fn #(println %) (fn* [p12976#] (println p12976#)) Ignore next form :uneval #_ :ignore-me <unsupported operation> Syntax quote :syntax-quote `symbol (quote symbol) Syntax unquote :unquote ~symbol (unquote symbol) Tagged literal :reader-macro #foo/bar [1 2 3] (read-string \"#foo/bar [1 2 3]\") #inst \"2018-03-28T10:48:00.000\" (read-string \"#inst \\\"2018-03-28T10:48:00.000\\\"\") #uuid \"3b8a31ed-fd89-4f1b-a00f-42e3d60cf5ce\" (read-string \"#uuid \\\"3b8a31ed-fd89-4f1b-a00f-42e3d60cf5ce\\\"\") Reader conditional :reader-macro #?(:clj x :cljs y) (read-string \"#?(:clj x :cljs y)\") #@?(:clj [x] :cljs [y]) (read-string \"#@?(:clj [x] :cljs [y])\") Observations: I think it was a design decision of rewrite-clj v0 to return (read-string …) for reader macros it did not want to deal with (or deal with yet). Rewrite-clj v1 will carry on. It seems the idea might have been that the caller could eval the sexpr result if they wanted to? Note for ClojureScript users, read-string is not available under cljs.core, but a version is available under cljs.tools.reader. Tag metadata is returned as boolean metadata. A user could infer the intent through inspection though. ",
+   :name "User Guide - Reader Macro Chars",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_reader_macro_chars"}
+  {:doc
+   "If the code you are parsing doesn’t use namespaced maps or you have no interest in using sexpr on the keys in those maps, the details in this section probably won’t be of concern to you. ",
+   :name "User Guide - Namespaced Elements",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#namespaced-elements"}
+  {:doc
+   "In Clojure keywords and symbols can be qualified. A recap via examples: Stand-alone keyword and symbols: keyword symbol unqualified :my-kw 'my-symbol qualified :prefix/my-kw 'prefix/my-symbol auto-resolved current namespace ::my-kw n/a auto-resolved namespaced alias ::my-ns-alias/my-kw n/a Namespaced keyword and symbols: keyword symbol unqualified (via _ prefix) #:prefix{:_/my-kw 1} '#:prefix{_/my-symbol} qualified #:prefix{:my-kw 1} '#:prefix{my-symbol 1} auto-resolved current namespace #::{:my-kw 1} '#::{my-symbol 1} auto-resolved namespaced alias #::my-ns-alias{:my-kw 1} '#::my-ns-alias{my-symbol 1} ",
+   :name "User Guide - Recap",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_recap"}
+  {:doc
+   "When calling sepxr on an auto-resolved keyword or symbol node, rewrite-clj will resolve: the current namespace to ?_current-ns_? namespaced alias x to ??_x_?? To illustrate: (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n(-> (p/parse-string \"::kw\") n/sexpr)\n;; => :?_current-ns_?/kw\n(-> (p/parse-string \"#::{:a 1 :b 2 s1 3}\") n/sexpr)\n;; => #:?_current-ns_?{s1 3, :b 2, :a 1}\n(-> (p/parse-string \"::my-alias/kw\") n/sexpr)\n;; => :??_my-alias_??/kw\n(-> (p/parse-string \"#::my-alias{:a 1 :b 2 s1 3}\") n/sexpr)\n;; => #:??_my-alias_??{s1 3, :b 2, :a 1} ",
+   :name "User Guide - Rewrite-clj Default Auto-Resolve Handling",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_rewrite_clj_default_auto_resolve_handling"}
+  {:doc
+   "Rewrite-clj will not attempt to determine the current namespace and alias namespace mappings of the code it is parsing. It does, though, allow you to specify your own auto-resolve behavior. The :auto-resolve function takes a single arg alias for lookup and must return symbol. The alias will be: :current for a request for the current namespace otherwise it will be a symbol for the namespace alias to lookup For example, if you know namespace and alias info for the code rewrite-clj is operating on, you can specify it: (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n(defn resolver [alias]\n  (or (get {:current 'my.current.ns\n            'my-alias 'my.aliased.ns} alias)\n      (symbol (str alias \"-unresolved\"))))\n\n(-> (p/parse-string \"::kw\") (n/sexpr {:auto-resolve resolver}))\n;; => :my.current.ns/kw\n(-> (p/parse-string \"#::{:a 1 :b 2 s1 3}\") (n/sexpr {:auto-resolve resolver}))\n;; => #:my.current.ns{s1 3, :b 2, :a 1}\n(-> (p/parse-string \"::my-alias/kw\") (n/sexpr {:auto-resolve resolver}))\n;; => :my.aliased.ns/kw\n(-> (p/parse-string \"#::my-alias{:a 1 :b 2 s1 3}\") (n/sexpr {:auto-resolve resolver}))\n;; => #:my.aliased.ns{s1 3, :b 2, :a 1} The :auto-resolve option is accepted in the opts map arg for: The rewrite-clj.node namespace functions sexpr and child-sexpr. The rewrite-clj.zip namespace zipper creation functions edn*, edn, of-string and of-file. The resulting zipper will then automatically apply your :auto-resolve within any zip operation that makes use of sexpr, namely: sexpr find-value and find-next-value - sexpr is applied to each node to get the \"value\" for comparison edit - the current node is sexpr-ed get and assoc - sexpr is applied to the map key ",
+   :name "User Guide - Custom Auto-Resolve Handling",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#custom-auto-resolve"}
+  {:doc
+   "Let’s illustrate how functions that use sexpr internally are affected by exploring rewrite-clj.zip/get: (require '[rewrite-clj.zip :as z])\n\n;; get on unqualified keys is straightforward:\n(-> \"{:a 1 :b 2 c 3}\" z/of-string (z/get :b) z/node pr)\n;; =stdout=>\n; <token: 2>\n\n;; get on qualified keys is also easy to grok\n(-> \"{:a 1 :prefix/b 2 c 3}\" z/of-string (z/get :prefix/b) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> \"#:prefix{:a 1 :b 2 c 3}\" z/of-string (z/get :prefix/b) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> \"#:prefix{:a 1 :b 2 c 3}\" z/of-string (z/get 'prefix/c) z/node pr)\n;; =stdout=>\n; <token: 3>\n\n;; but when we introduce auto-resolved elements, the default resolver comes into play\n;; and must be considered\n(-> \"{::ns-alias/a 1 ::b 2 c 3}\" z/of-string (z/get :?_current-ns_?/b) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> \"{::ns-alias/a 1 ::b 2 c 3}\" z/of-string (z/get :??_ns-alias_??/a) z/node pr)\n;; =stdout=>\n; <token: 1>\n(-> \"#::{:a 1 :b 2 c 3}\" z/of-string (z/get :?_current-ns_?/b) z/node pr)\n;; =stdout=>\n; <token: 2>\n(-> \"#::{:a 1 :b 2 c 3}\" z/of-string (z/get '?_current-ns_?/c) z/node pr)\n;; =stdout=>\n; <token: 3> ",
+   :name "User Guide - Impact of Auto-Resolve",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#impact-of-auto-resolve"}
+  {:doc
+   "Namespaced map context is automatically applied to symbols and keywords in namespaced maps. To illustrate with the zip API: (require '[rewrite-clj.zip :as z])\n\n(def zloc (z/of-string \"#:my-prefix {:a 1 :b 2 c 3}\"))\n\n;; An sexpr on the namespaced map returns the expected Clojure form\n( -> zloc z/sexpr)\n;; => #:my-prefix{:b 2, c 3, :a 1}\n\n;; An sepxr on the an individual key in the namespaced map returns the expected Clojure form\n(-> zloc z/down z/rightmost z/down z/sexpr)\n;; => :my-prefix/a Rewrite-clj applies the namespaced map context the namespaced map node children: at create time (which is also parse time) when the node’s children are replaced This works well with the mechanics of the zipper. Updates are automatically applied when moving up through the zipper: (require '[rewrite-clj.zip :as z])\n\n(def s \"#:prefix {:a 1 :b 2 c 3}\")\n\n;; sexpr works fine on unchanged zipper\n(-> s z/of-string z/sexpr)\n;; => #:prefix{:b 2, c 3, :a 1}\n\n;; changing the namespaced map prefix reapplies the context to the children\n(-> s\n    z/of-string\n    z/down\n    (z/replace (n/map-qualifier-node false \"my-new-prefix\"))\n    z/up\n    z/sexpr)\n;; => #:my-new-prefix{:b 2, c 3, :a 1}\n\n;; a new key/val gets the namespaced map context\n(-> s\n    z/of-string\n    z/down z/rightmost\n    (z/append-child :d)\n    (z/append-child 33)\n    z/up\n    z/sexpr)\n;; => #:prefix{:b 2, c 3, :d 33, :a 1}\n\n;; a replaced key gets namespaced map context\n(-> s\n    z/of-string\n    z/down z/rightmost z/down\n    (z/replace :a2)\n    z/up z/up\n    z/sexpr)\n;; => #:prefix{:a2 1, :b 2, c 3}\n\n;; but... be aware that the context is not applied...\n(-> s\n    z/of-string\n    z/down z/rightmost z/down\n    (z/replace :a2)\n    z/sexpr)\n;; => :a2\n\n;; ... until we move up to the namespaced map node:\n(-> s\n    z/of-string\n    z/down z/rightmost z/down\n    (z/replace :a2)\n    z/up z/up\n    z/down z/rightmost z/down\n    z/sexpr)\n;; => :prefix/a2 Some limitations: Keyword and symbol nodes will continue to hold their namespaced map context even when moved outside a namespaced map. Should you need to, you can use the zip API’s reapply-context to manually apply context from the current node downward. The context auto-update is a feature of the zip API, when working with nodes directly the context will be applied at parse time, and when namespaced map node children are replaced only. ",
+   :name
+   "User Guide - Impact of Namespaced Map Context on Keywords and Symbols",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_impact_of_namespaced_map_context_on_keywords_and_symbols"}
+  {:doc
+   "Rewrite-clj offers, where it can, transparent coercion from Clojure forms to rewrite-clj nodes. Clojure will, in some cases, add location metadata that is not in the original source code, as illustrated here: REPL session (meta '(1 2 3))\n;; => {:line 1, :column 8} Rewrite-clj will, on coercion from Clojure forms to rewrite-clj nodes, omit location metadata. No rewrite-clj metadata node will will be created if resulting metadata is empty. On conversion from rewrite-clj nodes to Clojure forms via sexpr, I don’t see a way to omit the location metadata. With the assumption that you will generally coerce Clojure forms back to rewrite-clj nodes, this should not cause an issue. To support those using rewrite-clj under sci, in addition to :line and :column rewrite-clj also removes :end-line and :end-column metadata. Note that while Clojure only adds location metadata to quoted lists, sci adds it to all forms that accept metadata. ",
+   :name "User Guide - Dealing with Reader Generated Metadata",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#_dealing_with_reader_generated_metadata"}
+  {:doc
+   "Developer Guide Table of Contents Supported Environments Prerequisites Windows Notes Git and newlines Babashka Clojure GraalVM Setup Babashka Tasks Code Generation Testing During Development Clojure ClojureScript Docs Testing Doc Code Blocks Testing Before a Push Unit tests Native image tests Libs test Checking for Outdated Dependencies Linting API diffs Cljdoc Preview Code Coverage Contributors ",
    :name "Developer Guide",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide"}
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#"}
   {:doc
-   "Merging rewrite-clj and rewrite-cljs Table of Contents Introduction Goals Strategic Compromises Changes Detailed API diffs Feature Differences Root namespace of rewrite-clj Projects Using rewrite-clj v0 and/or rewrite-cljs Projects Using rewrite-clj v1 Canary Testing Tooling Build tools Continuous integration Testing and linting tools General Decisions Library version scheme Release Strategy Source directory layout GraalVM Support Technical Issues Windows Tooling Requirements Ram Requirements Questionable Decisions Allowing garden style keywords Not allowing symbols with multiple slashes Clojure/ClojureScript Issues ClojureScript namespace clashes Clojure/ClojureScript Interop Rewrite-clj/cljs Analysis What is the public API? S-expressions Which reader? Potemkin import-vars What I started with What I ended up with Potemkin defprotocol+ Positional support Namespaced maps and keywords Introduction Rewrite-clj v1 is a merge of rewrite-clj v0 and rewrite-cljs giving us a one stop rewrite-clj shop for Clojure and ClojureScript developers. Goals Minimize API breakage. Within reason, maintain API compatibility with both rewrite-clj v0 and rewrite-cljs. I’d like rewrite-clj v1 to be an low friction replacement for rundis/rewrite-cljs (actually now living at clj-commons/rewrite-cljs) and xsc/rewrite-clj v0 (now living a clj-commons/rewrite-clj). Feature parity. Rewrite-cljs has lagged behind rewrite-clj v0. Bring rewrite-cljs up to parity with rewrite-clj v0. Bring any rewrite-cljs specific features over to rewrite-clj v1. Preserve type hints. I will respect and carry over existing type hinting in rewrite-clj v0 and rewrite-cljs. I will not, at this time, evaluate if existing type hinting has value. Improve documentation. I think that rewrite-clj v0 documentation is good, but as I dig deeper into using the library and get feedback on Slack, I see places where guidance could be improved. Document design decisions. I’m not sure what form this will take, but I do like projects that include histories of architectural and design decisions. Perhaps I’ll adopt ADR ala cljdoc. For now you can think of this document as I kind of sloppy-mega ADR for my merge work. Modernize/update test/build. Look at what is available today and make a choice. Define library version scheme. Evaluate options, pick one and document. Find home for this work. We have achieved the ideal here. Rewrite-clj v1 will continue from the same source repo as rewrite-clj v0. We will also continue to deploy to clojars rewrite-clj/rewrite-clj. Strategic Compromises Favor single code base. I will favor a single code base over maintaining ClojureScript specific optimizations from rewrite-cljs. These can be brought in at a later date if needed. Use generic exceptions. This is technically an API breakage, but I will switch to using the Clojure/ClojureScript agnostic ex-info for exceptions. Favor rewrite-clj features when there is overlap. I currently only see one feature that overlaps between the two projects. Rewrite-clj v0 and rewrite-cljs both have positional (row/col) support. Base positional support in rewrite-clj v0 is full featured and updates with any changes made, so we’ll use it instead of rewrite-cljs’s more primitive tools reader based positional support. This technically constitutes an API breakage for rewrite-cljs. We will, though, carry over rewrite-cljs’s higher level positional functions. Changes See change log. Detailed API diffs I’ve used diff-apis to compare apis. Normally I would have excluded any apis tagged with :no-doc metadata, but because many folks used undocumented features in rewrite-clj v0 and rewrite-cljs, I have done a complete comparison of all publics - except where noted. Each report contains some observations under the \"Notes\" header. rewrite-clj v0 vs rewrite-cljs API differences between the projects on which rewrite-clj v1 is based. rewrite-clj v0 vs rewrite-clj v1 how different is rewrite-clj v1 from rewrite-clj v0? rewrite-cljs vs rewrite-clj v1 how different is rewrite-clj v1 from rewrite-cljs? rewrite-clj v1 a look at how cljs and clj sides of rewrite-clj v1 differ rewrite-clj v1 documented apis only a look at how cljs and clj sides of rewrite-clj v1 differ for documented apis. Feature Differences No ability to read from files when using rewrite-clj v1 from ClojureScript. Root namespace of rewrite-clj Both rewrite-clj v0 and rewrite-cljs share the same root namespace of rewrite-clj. We’ll happily continue with rewrite-clj for rewrite-clj v1 work: rewrite-clj v0 was transferred to clj-commons/rewrite-clj rewrite-clj v1 will carry on in clj-commons/rewrite-clj we’ll continue to use the existing rewrite-clj v0 clojars maven coordinates xsc/rewrite-clj for rewrite-clj v1 Projects Using rewrite-clj v0 and/or rewrite-cljs I’ve tried to make note of popular/active projects that make use of rewrite-clj v0 and rewrite-cljs. I’ve linked where I’ve explicitly verified a migration to rewrite-clj v1. See README for up to date list of which libraries directly use so form of rewrite-clj and which ones we are currently canary testing. Project rewrite‑clj? rewrite‑cljs? Notes chlorine yes REPL support for Atom editor. I do not see easy to run unit tests for this project. clj-kondo custom version uses an internal custom version of rewrite-clj cljfmt yes yes source code formatter cljstyle yes source code formatter based on cljfmt clojure-lsp yes language server for Clojure depot yes find newer versions of your deps.edn dependencies kibit yes Finds non-idiomatic Clojure code lein-ancient yes find newer versions of your lein dependencies MrAnderson yes Dependency inliner mutant yes Source code mutator pack (alpha) yes Clojure project packager rebel-readline indirectly via cljfmt smart editing at at the REPL terminal, optionally used in conjunction with figwheel-main REBL indirectly via cljfmt graphical interactive tool for browsing Clojure data refactor-nrepl yes refactoring support used in conjunction with cider repl-tooling yes base package for Clojure editor tooling. Interesting: uses rewrite-clj.reader directly. I do not see easy to run unit tests for this project. update-leiningen-dependencies-skill yes dependency version tracker, great for a migration test of a project that uses shadow-cljs zprint yes yes source code formatter Projects Using rewrite-clj v1 See README for up to date list. Canary Testing I’m not sure if canary testing is exactly the right term here. My goal is to know when changes to rewrite-clj v1 break popular libraries. This would mean running these libraries' tests against rewrite-clj v1 master. After some experimentation, my general strategy is to: Install rewrite-clj HEAD to the local maven repository under a \"canary\" version For each library we want to test: Grab the a specified release of a project from GitHub via zip download Patch deps to Point to rewrite-clj canary release Adjust Clojure version if necessary (we are 1.8 and above) Adjust sources as necessary Ex. rewrite-cljc → rewrite-clj namespace At the time of the writing only zprint v1.1.1. needed a src code hack to get its tests passing. It is the only lib that digs into namespaced maps, and things changed a tad here for rewrite-clj v1 Run any necessary library test prep steps Run libraries tests (or a subset of them) Tooling Build tools I have moved from leiningen to tools cli and deps.edn. Like everything, this change has pros and cons. Overall, I like the simplicity and control it brings. Babashka scripts take the place of lein aliases where I can have the build do exactly what I want it to. Continuous integration The future of Travis CI looked a bit tenuous when I started work on rewrite-clj v1. I initially switched over to CircleCI, but then when GitHub Actions became available decided it was a better fit: in addition to Linux, offers macOS and Windows testing in its free tier 7gb of RAM satisfies GraalVM’s memory hungry native-image Testing and linting tools After looking around, I settled on the following for continuous integration: Kaocha for running Clojure unit tests. moved from lein-doo to cljs-test-runner (which still uses doo under the hood) for running ClojureScript unit tests under node and chrome headless. I considered Kaocha’s cljs support and will reconsider when it matures a bit. I fail the build when a lint with clj-kondo produces any warnings and/or errors. During development, I found the following helpful: kaocha in watch mode for Clojure figwheel main for ClojureScript General Decisions Library version scheme I see plenty of version scheme variations out there these days. Here are a few examples I find interesting: Project Scheme Example Observation ClojureScript major.minor.<commit count since major.minor> 1.10.520 Tracks Clojure version. clj-kondo yyyy-mm-dd-qualifier 2019.07.05-alpha Freshness built into version. cljdoc major.minor.<commit count>-<short git sha> 0.0.1315-c9e9a73 The short-sha safeguards against any potential confusion with duplicate commit counts for builds on different machines. meander meander/<release> 0.0.<commit count> meander/delta 0.0.137 This scheme changes the artifact-id (for example gamma to delta) every time a potentially breaking change is introduced effectively releasing a new product for every breaking change. spec.alpha unimportant unimportant The alpha state is burnt into the project name and library namespace. Rewrite-clj v1 is not a new project. I feel the version should reflect at least some familiarity with its v0 scheme. As of this writing the current version of rewrite-clj is 0.6.1. I am guessing that the 0 is an unused version element, and we have a 0.major.minor scheme. Rewrite-clj v1 is going to switch to a major.minor.<commit count>-<qualifier> scheme. Our first version will be 1.0.451-alpha where 451 is just a wild guess right now. An small awkwardness with this scheme is the change log. The change log should be part of the release but it does reference a git commit count. This will be addressed by automatically updating the change log doc with the release version as part of the release process. Release Strategy We’ll opt not to make SNAPSHOT releases and assume the community is good with testing pre-releases via GitHub coordinates. We can adapt if there is a real need for SNAPSHOT releases. We’ll keep a CHANGELOG.adoc carried on from rewrite-clj v0’s CHANGES.md. Release cadence will be as needed. I don’t want us to feel precious about releases. If there is a benefit to cutting a new release with a small change or fix, even just to docs, we’ll go ahead and do it. Source directory layout When I first started to experiment with a cljc version of rewrite-clj, my directory layout looked like: src/\n  clj/\n    rewrite-clj/\n  cljs/\n    rewrite-clj/\n  cljc/\n    rewrite-clj/\ntest/\n  clj/\n    rewrite-clj/\n  cljs/\n    rewrite-clj/\n  cljc/\n    rewrite-clj/ After a certain amount of work, I realized the majority of the code was cljc so opted for the much simpler: src/\n  rewrite-clj/\ntest/\n  rewrite-clj/ GraalVM Support Some command line tools written in Clojure are using Graal to compile to native executables for fast startup times. Others have done the work to test that rewrite-clj v0 can be compiled with Graal. There is benefit to the community to test that rewrite-clj v1 can also be compiled to native code with Graal. Noticing that there were differing approaches Graalifying Clojure, none of them centrally documented, @borkdude and I created clj-graal-docs to develop and share scripts and tips. My goal is to run the rewrite-clj v1 test suite from a GraalVM native image to give some confidence that rewrite-clj v1 works after compiled with Graal. Technical Issues Windows tooling requirements. Setup for running GraalVM JDK8 on Windows relies on old Microsoft tooling making setup challenging. RAM requirements. GraalVM’s native-image which creates the target executable, can consume a significant amount of RAM. Windows Tooling Requirements I’ve decided that, for now, figuring out how to setup the proper tooling for Windows for GraalVM JDK8 is not worth my effort. We’ll continue to test on Windows but only for GraalVM JDK11. Ram Requirements I spent quite a bit of time trying to figure out how to overcome the RAM limitations of free tiers of continuous integration services. Drone Cloud is the most generous with 64gb of RAM available but only supports Linux. CircleCI offers 3.5gb of RAM and is also Linux only in its free tier. GitHub Actions, offers 7gb of RAM and offers macOS, Linux and Windows. I seriously explored two approaches: natively compile tests and library interpret tests via sci over natively compile library If I had applied Clojure direct linking earlier in my tests, I might have stopped at the first approach. For me, direct linking made approach 1 viable. For now, I am testing using both approaches. Overviews can be found at clj-graal-doc’s testing strategies page. Questionable Decisions Allowing garden style keywords Borkdude is kind enough to ping me when there are issues with the internally forked version of rewrite-clj he uses for clj-kondo. It turns out that clojure.tools.reader.edn does not parse garden-style keywords such as :&::before. The reader sees a double colon as illegal if it is anywhere in the keyword. Borkdude overcame this limitation by allowing a keyword to contain embedded double colons via a customized version of clojure.tools.reader.edn's read-keyword function. I transcribed his work to rewrite-clj v1. The maintenance cost to hacking a 3rd party lib is that upgrades will have to be carefully tracked. That said, we do have a good suite of tests that should uncover any issues. Not allowing symbols with multiple slashes While Clojure reads 'org/clojure/math.numeric-tower, clojure.tools.reader.edn barfs on this and therefore rewrite-clj does as well. It has been documented as illegal for a symbol to have more than one /. I have opted to not, at this time, adapt rewrite-clj v1 to allow parsing of this illegal syntax. This might seem a bit hypocritical because I did, some time ago, innocently raise an issue on clj-kondo for this. Clojure/ClojureScript Issues ClojureScript namespace clashes ClojureScript uses Google Closure under the hood. Because of the way Google Closure handles namespaces, some namespaces that work fine on Clojure clash under ClojureScript. Some rewrite-clj v0 namespaces clash for ClojureScript, for example: rewrite-clj.zip/find rewrite-clj.zip.find The original rewrite-cljs author worked around this problem by renaming namespaces to avoid the clashes. library namespace in rewrite-clj v1 namespace clj? cljs? rewrite-clj rewrite-clj.node.coerce rewrite-clj.node.coerce yes no rewrite-cljs rewrite-clj.node.coercer rewrite-clj.node.coercer yes yes rewrite-clj rewrite-clj.node.string rewrite-clj.node.string yes no rewrite-cljs rewrite-clj.node.stringz rewrite-clj.node.stringz yes yes rewrite-clj rewrite-clj.zip.edit rewrite-clj.zip.edit yes no rewrite-cljs rewrite-clj.zip.editz rewrite-clj.zip.editz yes yes rewrite-clj rewrite-clj.zip.find rewrite-clj.zip.find yes no rewrite-cljs rewrite-clj.zip.findz rewrite-clj.zip.findz yes yes rewrite-clj rewrite-clj.zip.remove rewrite-clj.zip.remove yes no rewrite-cljs rewrite-clj.zip.removez rewrite-clj.zip.removez yes yes rewrite-clj rewrite-clj.zip.seq rewrite-clj.zip.seq yes no rewrite-cljs rewrite-clj.zip.seqz rewrite-clj.zip.seqz yes yes None of these namespaces are part of public APIs, but because I see a lot of code that uses these internal namespaces, I decided to preserve the existing rewrite-clj v0 and rewrite-cljs naming for rewrite-clj v1. Clojure/ClojureScript Interop Where I felt I could get away with it, I localized Clojure/ClojureScript differences in the new rewrite-clj.interop namespace. Although technically an API breakage, I made a choice to switch all rewrite-clj v0 thrown exceptions to the Clojure/ClojureScript compatible ex-info for rewrite-clj v1. Some notes on differences between Clojure and ClojureScript throws and catches, if not using ex-info are different namespace requires cannot use shorthand syntax in cljs macros must (sometimes) be included differently IMetaData and other base types differ (this comes into play for us in coercion support) format not part of cljs standard lib no Character in cljs no ratios in cljs testing for NaN is different different max numerics Rewrite-clj/cljs Analysis What is the public API? rewrite-clj v0 purposefully only generated documentation for specific namespaces. It is reasonable to assume that these namespaces represent the public API: rewrite-clj.parse rewrite-clj.node rewrite-clj.zip I am not sure why rewrite-clj.custom-zipper is included in the documented public API, because its functionality is exposed through rewrite-clj.zip, I expect this was perhaps an oversight, but might be wrong. Because what is public versus what is private was not stressed strongly in the rewrite-clj v0 README, I frequently see private APIs used in code. For this reason, I’ve worked, within reason, not to break what I understand to be private APIs. S-expressions rewrite-clj allows parsed Clojure/ClojureScript/EDN to be converted back and forth to s-expressions. Example from a REPL session: (require '[rewrite-clj.zip :as z])\n\n(def zipper (z/of-string \"[1 2 3]\"))  (1)\n(pr zipper)\n=stdout=> [<vector: [1 2 3]> {:l [], :pnodes [<forms: [1 2 3]>], :ppath nil, :r nil}]\n\n(def s (z/sexpr zipper)) (2)\ns\n=> [1 2 3]\n\n(require '[rewrite-clj.node :as n])\n(pr (n/coerce s)) (3)\n=stdout=> <vector: [1 2 3]> 1 parse string to rewrite-clj nodes and create zipper 2 convert rewrite-clj node at current location in zipper to s-expression 3 convert s-expression to rewrite-clj node While I expect this can be quite convenient, it does come with caveats: What happens when we try to sexpr Clojure specific features from ClojureScript? For example, ratios are available in Clojure but not ClojureScript. If you try to sexpr something that cannot be converted into an s-expression an exception will be thrown. My guidance is use sexpr in only in specific cases, where you know ahead of time what you are parsing. General blind use of sexpr is not recommended. For rewrite-clj v1 itself, I have removed internal problematic uses of sepxr and documented some of its nuances. Which reader? Rewrite-clj makes use of Clojure’s reader. There are a few choices though: clojure.tools.reader clojure.tools.reader.edn clojure.reader clojure/reader-string As I understand it, clojure.tools.reader.edn is the safest choice and rewrite-clj v1 uses it in all cases. Potemkin import-vars Rewrite-clj v0 makes use of a slightly modified version of Potemkin import-vars. The intent of import-vars is to make it easy to expose a public API from a set of internal namespaces. When I first reviewed its usage in rewrite-clj, I found import-vars to be quite elegant. I have since learned that there is quite a bit of strong opinion in the Clojure community surrounding import-vars. Not all of it is rosy. Also, there is no ClojureScript version of import-vars. What I started with That said, I decided, in the beginning, to honor the original rewrite-clj codebase and carry on with it. To be honest, this gave me the (the apparently too tempting to resist) opportunity to learn how to write a version of import-vars for ClojureScript. This led me to discover that while cljdoc did cope fine with import-vars trickery for Clojure code, it did not have any support for it for ClojureScript code. I made the necessary changes to cljdoc’s fork of codox and subsequently cljdoc-analyzer. I also extended import-vars to rewrite-clj’s purposes by adding a facility to rename imported vars and adapt docstrings. All was not rainbows and unicorns, after yet another issue with some Clojure tooling, I decided to drop import-vars. What I ended up with I still like the concept of import-vars. It automatically exposes an API and helps me to avoid silly human errors that would occur should I do this manually for rewrite-clj’s wide APIs. The issues with potemkin import-vars happen because vars are imported at load-time. I have moved to handling import-vars at build time. A build step reads reads an import-vars definition and generates appropriate source. This moves the burden from rewrite-clj users to rewrite-clj developers, which seems appropriate. First stab: Stick with an import-vars-ish syntax. Maybe a clj-kondo-ish style syntax #_{:import-vars/import {:from [[my.ns1 var1 var2 var3] [my.ns2 var4 var5])}}. Perhaps we can tease out a tool someday that is generally useful. Was thinking of having the build step update source in place, but @borkdude shared an idea of using templates. Options: Maybe have src/rewrite_clj.zip.template.cljc that generates/overwrites src/rewrite_clj/zip.cljc. Or a sister dir structure template/rewrite_clj/zip.cljc → src/rewrite_clj/zip.cljc. I’ll start with this, it: keeps templates separate from source. Not great for locality, but makes excluding them from release easier. keeps the ns name the same for template and target. Loses from moving to build-time solution: When you click on view source on cljdoc you go to the implementation and see the code. Now you’ll be directed to the delegator. This won’t be bothersome from an IDE, most will like it better, you’ll be able to flit from delegator to the implementation easily, but a loss from cljdoc. An extra build step is required. This moves the burden from the user to the developer. I’m ok with this. Potentially an extra call. Will this even register as a performance hit? Current import-vars usage. I don’t always use import-vars to expose a public API, I sometimes use it internally to avoid human error. For example rewrite-clj.node.string imports from rewrite-clj.node.stringz; the 2 namespaces exist due to API namespace collision issues in cljs. So what would be a good name for the build step? Maybe apply-import-vars gen-code? I think we’d also want something to read-only verify that the template generated clj is different than the target. We can fail CI build if this is true. Maybe apply-import-vars check? How will we find templates? We’ll start with storing all templates under ./template How will we choose target for templates? We’ll start ./src using, otherwise using same template filename. Extension will match template (clj vs cljc for us). Ok, so what code should we be generating? We want to definitely bring over the docstring (sometimes altered). We’ll have the import definition specify :added and :deprecated metadata. (Original version had this metadata specified on internal source var, cljs compiler warned about calls to internal deprecated fns from public API, which was not nice for folks using rewrite-clj under cljs). For the var itself we have choices. We could simply point to the source var. This is effectively what we do with current import-vars at load-time. We could generate a delegating fn matching the source arities. This would probably be more familiar to folks, and many static analysis tooling? I’ll start with this. And how will I find the info I need? The build step will be Clojure and run under the JVM, the targets are all clj or cljc, so I think we are good. I could use clj-kondo analysis data, but I don’t think that is necessary. What types of vars am I importing? functions - covered above. Note that I am also importing fns from protocols. Not sure if that complicates - think we’ll be OK. macros - I guess I’ll create a delegating macro. dynamic vars - I don’t think I have any of these anymore, so skip for now. I think I’ll repeat, in comments, throughout the generated source that source is generated and from what template. Just to try to avoid edits in generated source. Generated source will be checked in like all other source. Verification: run diff-apis will will save cljdoc-analyzer output to .diff-apis/.cache. Save the .cache. after changes verify that cljdoc-analyzer output is same. we expect :file and :line meta to be different for statically imported items And what technology will we use to rewrite Clojure source? Well… rewrite-clj seems like a good fit. For now, I will use master rewrite-clj to generate rewrite-clj sources from templates. To achieve this, I’ll use non generated sources only. And I’ll adapt rewrite-clj to only use non-generated sources itself. Except for paredit, it is really a higher level API, and I don’t want to uglify it by using rewrite-clj internal nses. We can adapt if my initial solution has warts. Potemkin defprotocol+ Rewrite-clj v0 used a customized version for potemkin defprotocol+. It could be that I missed something, but I did not see how it would benefit rewrite-clj v1. In the spirit of simplifying a cljc code-base, I turfed defprotocol+ in favour of plain old defprotocol. We can reintroduce defprotocol+ if we learn that it does actually help with performance significantly. Positional support Rewrite-clj v0: added a custom zipper to optionally track row/col within Clojure/ClojureScript/EDN files. expresses positions as a [row-number col-number] vector. Rewrite-cljs: made use of the positional support provided by Clojure tools reader. exposed a couple of functions to search by position. expressed positions as a {:row row-number :col col-number} map Because the positional support in rewrite-clj v0 tracks row/col even after zipper modifications, we use it in rewrite-clj v1 instead of rewrite-cljs’s implementation. We: continue to support both rewrite-clj v0 vector and rewrite-cljs map notations for positions on function parameters. use vector notation for position on function returns. I personally prefer the map notation, but, as a rule, favor rewrite-clj v0 over rewrite-cljs because rewrite-clj v0 is the more widely used library and thus changes affect more users. include rewrite-cljs’s positional functions: rewrite-clj.zip/find-last-by-pos and rewrite-clj.zip/find-tag-by-pos. The most glaring breaking change for ClojureScript is that it must now create the zipper with positional support enabled, for example: (z/of-string \"[1 2 3]\" {:track-position true}) Namespaced maps and keywords",
+   "Rewrite-clj is verified on each push on macOS, Ubuntu and Windows via GitHub Actions. All scripts are written in Clojure and most invoked via babashka tasks. This gives us a cross platform scripting language that is familiar, fun and consistent. We make use of planck for cljs bootstrap (aka cljs self-hosted) testing. Planck is currently not available for Windows. We test that rewrite-clj operates as expected when natively compile via GraalVM. Automated testing is setup using GraalVM v22 JDK11. ",
+   :name "Developer Guide - Supported Environments",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_supported_environments"}
+  {:doc
+   "Java JDK 1.8 or above NodeJs v12 or above Clojure v1.10.1.697 or above for clojure command Note that rewrite-clj v1 itself supports Clojure v1.8 and above Babashka v0.3.7 or above GraalVM v22.0.0.2 JDK 11 (if you want to run GraalVM native image tests) ",
+   :name "Developer Guide - Prerequisites",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_prerequisites"}
+  {:doc "",
+   :name "Developer Guide - Windows Notes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_windows_notes"}
+  {:doc
+   "The primary development OSes for rewrite-clj are macOS and Linux. Our line endings are LF only. I’m not sure what Windows developers typically want for line endings while working on source. I expect, but don’t know, that most Windows editors automatically handle LF as line ending. Someone let me know if I am wrong. Note that I do explicitly set git’s config core.autocrlf to false on our Windows CI unit test environment. Our import vars code generation checks currently rely on line endings remaining unconverted. ",
+   :name "Developer Guide - Git and newlines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_git_and_newlines"}
+  {:doc
+   "The Clojure story on Windows is still in the early chapters. Scoop offers an easy way to install tools. @littleli is doing a great job w/maintaining scoop apps for Clojure, Babashka and other tools and this is how I installed Babashka. ",
+   :name "Developer Guide - Babashka",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_babashka"}
+  {:doc
+   "We all choose our own paths, but for me, using deps.clj instead of Clojure’s PowerShell Module offered me no fuss no muss Clojure on Windows and GitHub Actions on Windows. I decided to install deps.clj not through scoop but through the deps.clj install.ps1 script. This makes it simple to treat deps.exe as if it were the official clojure via a simple rename: Rename-Item $HOME\\deps.clj\\deps.exe clojure.exe ",
+   :name "Developer Guide - Clojure",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_clojure"}
+  {:doc
+   "You’ll have your own preference, but I find it convenient to install GraalVM on Windows via scoop. You’ll need to load the appropriate Visual C++ environment variables for GraalVM’s native-image to do its work. I found it oddly cumbersome to load them from PowerShell, so I work from a cmd shell instead. Here’s what works on my Windows dev environment: call \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat\" ",
+   :name "Developer Guide - GraalVM",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_graalvm"}
+  {:doc
+   "After checking out this project from GitHub, Install JavaScript libraries and tools required by doo and shadow-cljs: sudo npm install karma-cli -g\nnpm install If you are on macOS or linux, install planck. Initialize cache for clj-kondo so it can lint against your dependencies bb lint ",
+   :name "Developer Guide - Setup",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_setup"}
+  {:doc
+   "We make use of babashka tasks for development related commands. To see all available tasks with a short description run: bb tasks To run a task, for example, the lint task: bb lint Usage help for a task is requested via --help, for example: bb lint --help Tasks are described throughout this document. ",
+   :name "Developer Guide - Babashka Tasks",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_babashka_tasks"}
+  {:doc
+   "Rewrite-clj v0 used a version of potemkin import-vars. Potemkin import-vars copies specified vars from a specified namespace to the current namespace at load time. Due to often mysterious issues related to import-vars, a general dislike for import-vars in the Clojure community, and associated maintenance costs, we’ve opted to instead generate code for rewrite-clj v1. For any source that used potemkin import-vars, we now have a separate template clj (or cljc) file. For example src/rewrite_clj/zip.cljc is generated by template template/rewrite_clj/zip.cljc. The syntax of import-vars in the template remains familiar. The following old potemkin import-vars syntax: (import-vars\n  [[my.ns1 my-var1 my-var2 my-var3]\n   [my.ns2 my-var4 my-var5]]) Is expressed in our templates as: #_{:import-vars/import\n   {:from [[my.ns1 my-var1 my-var2 my-var3]\n           [my.ns2 my-var4 my-var5]]}} Any :added and :deprecated metadata should be defined in the template and not on the reference var. This keeps the metadata on the public API vars only and avoids having the ClojureScript compiler warn about deprecated calls on internal sources within rewrite-clj: #_{:import-vars/import\n   {:from [[my.ns1\n            ^{:deprecated \"1.2.3\"} obsolete-fn\n            ^{:added \"1.2.4\"} new-fn]]}} We also carry over rewrite-cljc support for :import-vars/import-with-mods, via an optional :opts. See template/rewrite_clj/zip.cljc for example usage. Importing will generate delegates. An import of (defn foo [a b] (+ a b)) from namespace my.ns1 will generate (defn foo [a b] (my.ns1/foo a b)). No generation of requires is done, your template will have to require my.ns1 in normal Clojure code. At this time, we don’t handle destructuring in arglists, and will throw unless args are all symbols. To generate target source from templates run: bb apply-import-vars gen-code You are expected to review the generated changes and commit the generated source to version control. We don’t lint templates, but we do lint the generated code. To perform a read-only check, run: bb apply-import-vars check The check command will exit with 0 if no changes are required, otherwise it will exit with 1. Our build script will run the check command and fail the build if there are any pending changes that have not been applied. ",
+   :name "Developer Guide - Code Generation",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_code_generation"}
+  {:doc
+   "Your personal preference will likely be different, but during maintenance and refactoring, I found running tests continuously for Clojure and ClojureScript helpful. ",
+   :name "Developer Guide - Testing During Development",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_testing_during_development"}
+  {:doc
+   "For Clojure, I open a shell terminal window and run: bb test-clj-watch This launches kaocha in watch mode. ",
+   :name "Developer Guide - Clojure",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_clojure_2"}
+  {:doc
+   "For ClojureScript, I open a shell terminal window and run: bb test-cljs-watch This launches fighweel main. After initialization, your default web browser will automatically be opened with the figwheel auto-testing page. ",
+   :name "Developer Guide - ClojureScript",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_clojurescript"}
+  {:doc
+   "All documentation is written in AsciiDoc. We follow AsciiDoc best practice of one sentence per line. Images are created and edited with draw.io desktop. We export to .png with a border of 10 and a transparent background. At the time of this writing draw.io does not remember export settings, so you’ll have to enter them in each time. ",
+   :name "Developer Guide - Docs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_docs"}
+  {:doc
+   "We use test-doc-blocks to verify that code blocks in our documentation are in good working order. bb test-doc This generates tests for doc code blocks and then runs them under Clojure and ClojureScript. ",
+   :name "Developer Guide - Testing Doc Code Blocks",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_testing_doc_code_blocks"}
+  {:doc
+   "Before pushing, you likely want to mimic what is run on each push via GitHub Actions. ",
+   :name "Developer Guide - Testing Before a Push",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_testing_before_a_push"}
+  {:doc "Unit tests are run via: bb ci-unit-tests ",
+   :name "Developer Guide - Unit tests",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_unit_tests"}
+  {:doc
+   "We also verify that rewrite-clj functions as expected when compiled via Graal’s native-image. Tests and library natively compiled: bb test-native Library natively compiled and tests interpreted via sci bb test-native-sci ",
+   :name "Developer Guide - Native image tests",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_native_image_tests"}
+  {:doc
+   "To try to ensure our changes to rewrite-clj do not inadvertently break existing popular libraries, we run their tests, or a portion thereof, against rewrite-clj. bb test-libs run See README for current libs we test against. Additional libs are welcome. To see a list of available libs we currently test against: bb test-libs list If you are troubleshooting locally, and want to only run specific tests, you can specify which ones you’d like to run. For example: bb test-libs run cljfmt zprint Updating the test-libs script to run against current versions of libs is recommended, but care must be taken when updating. We want to make sure we are patching correctly to use rewrite-clj v1 and running a lib’s tests as intended. To check for outdated libs: bb test-libs outdated Notes: The test-libs task was developed on macOS and is run on CI under Linux only under JDK 11 only. We can expand variations at some later date if there is any value to it. We test the current HEAD of rewrite-clj v1 against specific versions (latest at the time of this writing) of libs. We patch lib deps and sometimes code (ex. require for rewrite-cljc becomes rewrite-clj). As folks migrate to rewrite-clj v1, the need for current patches will lessen. Updating what versions we test against is currently a manual, but not an overly burdensome, task. ",
+   :name "Developer Guide - Libs test",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#libs-test"}
+  {:doc
+   "To see what new dependencies are available, run: bb outdated This task uses: antq for Clojure. npm for JavaScript. It only checks against installed ./node_modules, so you may want to run npm install first. ",
+   :name "Developer Guide - Checking for Outdated Dependencies",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_checking_for_outdated_dependencies"}
+  {:doc
+   "We use clj-kondo and eastwood to lint rewrite-clj source code. We apply whitespace-linter to docs, config, and source code to avoid some annoying whitespace diffs. We fail the build on any lint violations. The CI server runs: bb lint and you can too. The lint script will build the clj-kondo cache when it is missing or stale. If you want to force a rebuild of the cache run: bb lint --rebuild-cache Integrate clj-kondo into your editor to catch mistakes as they happen. You can optionally: bb -lint-whitespace to run only whitespace linting bb -lint-kondo to run only clj-kondo linting bb -lint-eastwood to run only the eastwood linting ",
+   :name "Developer Guide - Linting",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#linting"}
+  {:doc
+   "Rewrite-clj v1’s primary goals include remaining compatible with rewrite-clj v0 and rewrite-cljs and avoiding breaking changes. To generate reports on differences between rewrite-clj v0, rewrite-cljs and rewrite-clj v1 APIs, run: bb doc-api-diffs This task currently needs love, see #132. Run this script manually on an as-needed basis, and certainly before any official release. Generated reports are to be checked in to version control. Reports are generated to doc/generated/api-diffs/ and include manually written notes from doc/diff-notes/. These reports are referenced from other docs, so if you rename files, be sure to search for links. Makes use of diff-apis. Delete .diff-apis/.cache if you need a clean run. ",
+   :name "Developer Guide - API diffs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_api_diffs"}
+  {:doc
+   "Before a release, it can be comforting to preview what docs will look like on cljdoc. Limitations This task should be considered experimental, I have only tested running on macOS, but am fairly confident it will work on Linux. Not sure about Windows at this time. You have to push your changes to GitHub to preview them. This allows for a full preview that includes any links (source, images, etc) to GitHub. This works fine from branches and forks - in case you don’t want to affect your main development branch for a preview. Start Local Services To start the local cljdoc docker container: bb cljdoc-preview start The local cljdoc server allows your ingested docs to be viewed in your web browser. The start command also automatically checks docker hub for any updates so that our cljdoc preview matches the current production version of cljdoc. Ingest Docs To ingest rewrite-clj API and docs into the local cljdoc database: bb cljdoc-preview ingest The ingest command automatically publishes rewrite-clj to your local maven repository (cljdoc only works with published jars). The locally published version will include a -cljdoc-preview suffix. I find this distinction helps to reduce confusion around locally vs remotely installed artifacts. You’ll have to remember to git commit and git push your changes before ingesting. Repeat these steps any time you want to preview changes. Preview Docs To open a view to the ingested docs in your default web browser: bb cljdoc-preview view If you have just run the start command, be a bit patient, the cljdoc server can take a few moments to start up - especially on macOS due to poor file sharing performance. Stop Local Services When you are done, you’ll want to stop your docker container: bb cljdoc-preview stop This will also delete temporary files created to support your preview session, most notably the local cljdoc database. Note that NO cleanup is done for any rewrite-clj artifacts published to your local maven repository. Container Status If you forget where you are at with your docker containers, run: bb cljdoc-preview status ",
+   :name "Developer Guide - Cljdoc Preview",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_cljdoc_preview"}
+  {:doc
+   "We use cloverage via kaocha to generate code coverage reports via: bb test-coverage Our CI service is setup to automatically generate then upload reports to CodeCov. We have no specific goals for code coverage, but new code is generally expected to have tests. So why measure coverage? It simply offers us some idea of what code our test suite hits. ",
+   :name "Developer Guide - Code Coverage",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_code_coverage"}
+  {:doc
+   "We honor current and past contributors to rewrite-clj in our README file. To update contributors, update doc/contributors.edn then run: bb doc-update-readme ",
+   :name "Developer Guide - Contributors",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/developer-guide#_contributors"}
+  {:doc
+   "Merging rewrite-clj and rewrite-cljs Table of Contents Introduction Goals Strategic Compromises Changes Detailed API diffs Feature Differences Root namespace of rewrite-clj Projects Using rewrite-clj v0 and/or rewrite-cljs Projects Using rewrite-clj v1 Canary Testing Tooling Build tools Continuous integration Testing and linting tools General Decisions Library version scheme Release Strategy Source directory layout GraalVM Support Technical Issues Windows Tooling Requirements Ram Requirements Questionable Decisions Allowing garden style keywords Not allowing symbols with multiple slashes Clojure/ClojureScript Issues ClojureScript namespace clashes Clojure/ClojureScript Interop Rewrite-clj/cljs Analysis What is the public API? S-expressions Which reader? Potemkin import-vars What I started with What I ended up with Potemkin defprotocol+ Positional support Namespaced maps and keywords ",
    :name "Merging rewrite-clj and rewrite-cljs",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs"}
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#"}
   {:doc
-   "Namespaced elements Table of Contents Nomenclature What happens now in rewrite-clj v0 and rewrite-cljs? General use of sexpr in rewrite-clj Sexpr support for namespaced elements in rewrite-clj v0 and rewrite-cljs Options for rewrite-clj v1 The Rabbit Hole - Automatically Calculating sexpr for Auto-resolved Elements What will we do for rewrite-clj v1? Platform Support Sexpr Behaviour Sexpr on a Key in a Namespaced Map Sexpr Behaviour from the zip API Node Creation Namespaced Map Node Keyword Node Symbol Node Symbol and Keyword Context Node Traversal Node Interrogation Notes on Coercion Misc Questions Herein we study what rewrite-clj and rewrite-cljs currently do for namespaced elements and explore our options for rewrite-clj v1. You will see a focus on sepxr in this document; it is the primary challenge in supporting namespaced elements. Nomenclature Namespaced Elements Clojure docs describe namespaced elements but I did not see clear terms defined. Alex Miller helped out on Slack, I will use: term my shorthand keyword example map example unqualified :foo {:x 10} qualified :prefix-ns/foo #:prefix-ns{:a 1} auto-resolved current namespace qualified current-ns qualified ::foo #::{:b 2} auto-resolved namespace alias qualified ns-alias qualified ::ns-alias/foo #::ns-alias{:c 3} See: Jeaye’s blog for a refresher on namespaced keywords. CLJ-1910 for details on namespaced maps. Terminology and some history from Alex Miller Because the nuances of namespaced maps are not widely known by even the most experienced Clojure developers, I’ll paste a subset of CLJ-1910 examples here. The _ prefix and the fact that namespaced maps qualify symbols in addition to keywords is not widely understood: ;; same as above - notice you can nest #: maps and this is a case where the printer roundtrips\nuser=> #:person{:first \"Han\" :last \"Solo\" :ship #:ship{:name \"Millenium Falcon\" :model \"YT-1300f light freighter\"}}\n#:person{:first \"Han\" :last \"Solo\" :ship #:ship{:name \"Millenium Falcon\" :model \"YT-1300f light freighter\"}}\n\n;; effects on keywords with ns, without ns, with _ ns, and non-kw\nuser=> #:foo{:kw 1, :n/kw 2, :_/bare 3, 0 4}\n{:foo/kw 1, :n/kw 2, :bare 3, 0 4}\n\n;; auto-resolved namespaces (will use the current namespace, in this case, user as the ns)\nuser=> #::{:kw 1, :n/kw 2, :_/bare 3, 0 4}\n{:user/kw 1, :n/kw 2, :bare 3, 0 4}\n\n;; auto-resolve alias s to clojure.string\nuser=> (require '[clojure.string :as s])\nnil\nuser=> #::s{:kw 1, :n/kw 2, :_/bare 3, 0 4}\n{:clojure.string/kw 1, :n/kw 2, :bare 3, 0 4}\n\n;; to show symbol changes, we'll quote the whole thing to avoid evaluation\nuser=> '#::{a 1, n/b 2, _/c 3}\n{user/a 1, n/b 2, c 3} ClojureScript Flavors ClojureScript has two flavors for which I’ve not found definitive unique terms. I’ll use the following: term description Regular ClojureScript The regular old JVM compiled ClojureScript that most folks are familiar with. Self-hosted ClojureScript ClojureScript that is compiled by ClojureScript, also known as bootstrap ClojureScript. Self-hosted ClojureScript can make runtime use of features that are only available at compile time in Regular ClojureScript. Self-hosted ClojureScript behaves similarly to Clojure around namespaces. What happens now in rewrite-clj v0 and rewrite-cljs? General use of sexpr in rewrite-clj The sexpr function is used to convert a rewrite-clj node to a Clojure form. Clojure forms are more familiar and can be easier to work with than rewrite-clj nodes. Rewrite-clj’s sexpr is also used internally in functions like find-value, find-next-value and edit and some paredit functions inherited from rewrite-cljs. The following rewrite-clj nodes throw an exception for sexpr which is sensible and is as-designed. comment whitespace uneval, which is rewrite-clj’s term for #_ Sexpr support for namespaced elements in rewrite-clj v0 and rewrite-cljs Auto-resolved keywords have been around since at least Clojure 1.0, which was released in May 2009. Namespaced maps were introduced in Clojure 1.9, released in December 2017. When you take into account that rewrite-clj was released in 2013 and rewrite-cljs in 2015, we can understand why support for newer features is spotty. element rewrite-clj v0 rewrite-cljs parse sexpr parse sexpr keyword qualified :prefix/foo supported supported supported supported current‑ns qualified ::foo supported supported, ⚠️ resolves via *ns* supported ⚠️ throws ns-alias qualified ::alias/foo supported ⚠️ incorrectly returns :alias/foo for ::alias/foo supported ⚠️ incorrectly returns :alias/foo for ::alias/foo map qualified #:prefix{:a 1} supported supported ⚠️ somewhat supported with generic reader macro node ⚠️ returns (read‑string \"#:prefix{:a 1}\") current‑ns qualified #::{:b 2} ⚠️ throws ⚠️ not applicable, can’t parse ⚠️ throws ⚠️ not applicable, can’t parse ns-alias qualified #::alias{:c 3} supported ⚠️ awkwardly supported, resolves via (ns‑aliases *ns*) ⚠️ somewhat supported with generic reader macro node ⚠️ returns (read‑string \"#::alias{:c 3}\") Options for rewrite-clj v1 status ref option primary impact / notes ❌ rejected 1 Do nothing both Clojure and ClojureScript users can’t fully parse Clojure/ClojureScript code. ❌ rejected 2 Support parsing and writing, but throw on sexpr breaks existing API compatibility makes general navigation with certain rewrite-clj functions impossible ✅ current choice 3 Support parsing, writing. Have sexpr rely on user provided namespace info. seems like a good compromise ❌ rejected 4 Same as 3 but also ensure backward compatibility with current rewrite-clj implementation decided that backward compatibility for namespaced keywords sexpr is too awkward we’ll not entertain backward compatibility for namespaced maps ❌ rejected 5 Same as 4 but include a rudimentary namespace info resolver that parses namespace info from source had a good chat with borkdude on Slack and concluded that a namespace info resolver: is a potential rabbit hole (well, not potential - if only you knew the number of times I rewrote this section!) could be a separate concern that is addressed if there is a want/need in the future. Option #4 was a candidate, but decided against maintaining/explaining the complexity the current rewrite-clj implementation. The Rabbit Hole - Automatically Calculating sexpr for Auto-resolved Elements Parsing and writing namespaced elements seems relatively straightforward, but automatically parsing and returning a technically correct sexpr for auto-resolved namespaced elements is a rabbit hole that we’ll reject for now. Let’s tumble down the hole a bit to look at some of the complexities that auto-resolved namespaced elements include: The sexpr of a current-ns qualified element will be affected by the current namespace. The sexpr of an ns-alias qualified element will be affected by loaded namespaces aliases. The sexpr of any namespace element can be affected by reader conditionals: within ns declarations surrounding the form being sexpred which can be ambiguous in absence of parsing context of the Clojure platform (clj, cljs, cljr, sci) In turn, the current namespace can be affected by: ns declaration binding to *ns* in-ns Loaded namespace aliases can be affected by: ns declaration require outside ns declaration I expect that macros can be used for generation of at least some of the above elements. Other aspects I have not thought of. I see one example from the wild of an attempt to parse ns declarations from Clojure in cljfmt. Cljfmt can parse ns declarations from source code from which it extracts an alias map. While parsing ns declarations might work well for cljfmt, we won’t entertain it for rewrite-clj v1. What will we do for rewrite-clj v1? Rewrite-clj v1 can easily support sexpr on elements where the context is wholly contained in the form. Auto-resolved namespaced elements are different. They depend on context outside of the form; namely the current namespace and namespace aliases. Rewrite-clj v1 will: NOT take on evaluation of the Clojure code it is parsing to determine namespace info. It will be up to the caller to optionally specify the current namespace and namespace aliases. NOT offer any support for reader conditionals around caller provided namespace info caller specified namespace info will not distinguish for Clojure platforms (clj, cljs, cljr, sci) an sexpr for a namespaced element will NOT evaluate differently if it is wrapped in a reader conditional assume that callers will often have no real interest in an technically correct sexpr on auto-resolved namespaced elements. This means that it will return a result and not throw if the namespace info is not provided/available. break rewrite-clj compatibility for namespaced maps. It was a late and incomplete addition to rewrite-clj. The prefix will be stored in a new map-qualifier-node. Previously the prefix was stored as a keyword. Unlike rewrite-clj, rewrite-clj v1 will not call (ns-aliases *ns*) to lookup namespace aliases. break rewrite-clj compatibility for keywords: node field namespaced? will be renamed to be auto-resolved? to represent what it really is (a grep.app search suggests this won’t be impacting) will no longer do any lookups on ns. break compatibility for sexpr on some namespaced elements, in that it will: no longer throw for formerly unsupported variants have the possibility of returning a more correct Clojure form NOT preserve compatibility for sexpr under the following questionable scenarios, we’ll: NOT fall back to *ns* if the current namespace is not specified by caller. NOT return :alias/foo for ns-alias qualified keyword ::alias/foo when namespace aliases are not specified by caller. forgetting about sexpr, whatever implementation we choose, rewrite-clj v1 must continue to emit the same code as parsed. This should return true for any source we throw at rewrite-clj v1: (require '[rewrite-clj.zip :as z])\n(def source (slurp \"https://raw.githubusercontent.com/clj-kondo/clj-kondo/v2020.12.12/src/pod/borkdude/clj_kondo.clj\"))\n(= source (-> source z/of-string z/root-string))\n=> true + Note: an exception in equality might be newlines, which rewrite-clj v1 might normalize. Platform Support Rewrite-clj v1 supports the following Clojure platforms: Clojure Self-Hosted ClojureScript Regular ClojureScript It also supports Clojure source that includes a mix of the above in .cljc files. Our solution will cover all the above and also be verified when GraalVM natively compiled rewrite-clj v1 and a rewrite-clj v1 exposed via sci. Sexpr Behaviour The caller will optionally convey a namespace :auto-resolve function in opts map argument. The :auto-resolve function will take a single alias lookup arg, alias will be: :current for a request for the current namespace otherwise a request for a lookup for namespaced aliased by alias If not specified, :auto-resolve will default a function that resolves: the current namespace to ?_current-ns_? an aliased namespaced x to ??_x_?? The optionally opts arg will be added to the existing (rewrite-clj/node/sexpr node) If a caller wants their :auto-resolve function to make use of *ns* and/or (ns-aliases *ns*) that’s fine, but unlike rewrite-clj v0, rewrite-clj v1 will not reference *ns*. My guess is that the majority of rewrite-clj v1 users will not make use of :auto-resolve. Condition Result :auto-resolve not specified (require '[rewrite-clj.node :as n]\n         '[rewrite-clj.parser :as p])\n\n(-> (p/parse-string \"::foo\") n/sexpr)\n;; => :?_current-ns_?/foo\n(-> (p/parse-string \"#::{:a 1 :b 2}\") n/sexpr)\n;; => {:?_current-ns_?/a 1 :?_current-ns_?/b 2}\n(-> (p/parse-string \"::str/foo\") n/sexpr)\n;; => :??_str_??/foo\n(-> (p/parse-string \"#::str{:a 1 :b 2}\") n/sexpr)\n;; => {:??_str_??/a 1 :??_str_??/b 2} :auto-resolve specified (require '[rewrite-clj.node :as n]\n         '[rewrite-clj.parser :as p])\n\n(def opts {:auto-resolve (fn [alias]\n                            (get {:current 'my.current.ns\n                                  'str 'clojure.string}\n                                 alias\n                                 (symbol (str alias \"-unresolved\"))))})\n\n(-> (p/parse-string \"::foo\") (n/sexpr opts))\n;; => :my.current.ns/foo\n(-> (p/parse-string \"#::{:a 1 :b 2}\") (n/sexpr opts))\n;; => {:my.current.ns/a 1 :my.current.ns/b 2}\n(-> (p/parse-string \"::str/foo\") (n/sexpr opts))\n;; => :clojure.string/foo\n(-> (p/parse-string \"#::str{:a 1 :b 2}\") (n/sexpr opts))\n;; => {:clojure.string/a 1 :clojure.string/b 2} A benefit of :auto-resolve being a function rather than data, is flexibility. Maybe a caller would like the resolver to throw on an unresolved alias. Callers are free to code up whatever they need. Sexpr on a Key in a Namespaced Map To support sexpr when navigating down to a key in a namespaced map, the key will hold the namespaced map context, namely a copy of the namespaced map qualifier. This context will appropriately applied to symbols and keyword keys in namespaced maps: at parse time when node children are updated The zip API applies updates when moving up through the zipper. The update includes replacing children. Therefore the context will be reapplied to namespaced map keys when moving up through the zipper. We’ll provide some mechanism for zipper users to reapply the context throughout the zipper. This will remove context from any keywords and symbols that are no longer under a namespaced map. Not sure what we’ll provide for non-zipper users. Perhaps just exposing a clear-map-context for keyword and symbol nodes would suffice. Sexpr Behaviour from the zip API The rewrite-clj.zip v0 API exposes functions that make use of sexpr: sexpr - directly exposes rewrite-clj.node/sexpr for the current node in zipper find-value - uses sexpr internally find-next-value - uses sexpr internally edit-node - uses sexpr internally get - uses find-value internally Most of these functions lend themselves to adding an optional opts map for our :auto-resolve. Unfortunately edit-node is variadic. Because all zip API functions operate on the zipper, I’m thinking that we could simply hold the :auto-resolve in the zipper. This idea is already in play to for :track-position?. Node Creation The primary user of rewrite-clj’s node creation functions is the rewrite-clj parser. The functions are also exposed for general use. General usability might not have been a focus. Namespaced Map Node We tweak rewrite-clj v0’s namespaced-map-node. The children will remain: prefix optional whitespace map The prefix will now be encoded as a new map-qualifier-node node which will have auto-resolved? and prefix fields. This cleanly and explicitly adds support for auto-resolve current-ns namespaced maps which will be expressed with auto-resolved? as true and a nil prefix. Keyword Node The current way to create namespaced keyword nodes works, but usage is not entirely self-evident: (require '[rewrite-clj.node :as n])\n\n;; unqualified\n(n/keyword-node :foo false)           ;; => \":foo\"\n;; literally qualified\n(n/keyword-node :prefix-ns/foo false) ;; => \":prefix-ns/foo\"\n;; current-ns qualified\n(n/keyword-node :foo true)            ;; => \"::foo\"\n;; ns-alias qualified\n(n/keyword-node :ns-alias/foo true)   ;; => \"::ns-alias/foo\" Use of booleans in a function signature with more than one argument rarely contributes to readability but we’ll stick with these functions for backward compatibility. Let’s study the rewrite-clj v0 KeywordNode which currently has fields k and namespaced?. (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n(-> (p/parse-string \":kw\") ((juxt :k :namespaced?)))\n;; => [:kw nil]\n(-> (p/parse-string \":qual/kw\") ((juxt :k :namespaced?)))\n;; => [:qual/kw nil]\n(-> (p/parse-string \"::kw\") ((juxt :k :namespaced?)))\n;; => [:kw true]\n(-> (p/parse-string \"::alias/kw\") ((juxt :k :namespaced?)))\n;; => [:alias/kw true] The namespaced? field is, in my opinion, misnamed and should be auto-resolved?. As of this writing a grep.app for :namespaced? returns only clj-kondo and it uses its own custom version of rewrite-clj. I think I could get away with renaming namespaced? to auto-resolved? for rewrite-clj v1 The prefix is not stored separately, it is glommed into keyword field k. This is ok for :qual/kw but, in my opinion, awkward for auto-resolved variants. We’ll preserve this storage behavior for backward compatibility. I will NOT look into adding a prefix field for consistency with maps at this time. Symbol Node For rewrite-clj v1, we’ll separate out a new SymbolNode out from under rewrite-clj v0’s TokenNode. It is probably simplest to have the existing token-node creator fn simply create a SymbolNode when passed value is a Clojure symbol. Symbol and Keyword Context In rewrite-clj v1, the SymbolNode and KeywordNode will be MapQualifiable. This means they will have (set-map-context map-qualifier-node) and (clear-map-context) functions. I don’t think we need to expose the methods to our APIs but am not sure yet. If we do, we might need a (get-map-context). Why not just update/retrieve via the map-qualifier-node node field? Clojure turns a record into a map when a dissoc is done on a field, and I think abstracting away from that nuance makes sense. Node Traversal Keyword node traversal will remain unchanged (no new child nodes). Namespaced map node traversal remains unchanged except: The prefix is now stored as a map-qualifier-node, in rewrite-clj the prefix was encoded in a keyword. Node Interrogation keyword-node? - return true if rewrite-clj node and keyword node symbol-node? - return true if rewrite-clj node and symbol node Both keyword-node and map-qualifier-node will have: auto-resolved? field Notes on Coercion Rewrite-clj supports automatic coercion, how does this look in the context of namespaced elements? I’m not proposing any changes here, just demonstrating how things work. If we try to explicitly coerce a namespaced element, we must remember that the Clojure reader will first evaluate in the context of the current ns before the element is converted to a node. (require '[clojure.string :as str]\n         '[rewrite-clj.node :as n])\n\n(-> (n/coerce :user/foo) n/string) ;; => \":user/foo\"\n(-> (n/coerce ::foo) n/string) ;; => \":user/foo\"\n(-> (n/coerce ::str/foo) n/string) ;; => \":clojure.string/foo\" For namespaced maps, the experience is the same: (require '[clojure.string :as str]\n         '[rewrite-clj.node :as n])\n\n(-> (n/coerce #:user{:a 1}) n/string) ;; => \"{:user/a 1}\"\n(-> (n/coerce #::{:b 2}) n/string)  ;; => \"{:user/b 2}\"\n(-> (n/coerce #::str{:c 3}) n/string) ;; => \"{:clojure.string/c 3}\" Misc Questions Questions I had while writing doc. Q: Does the act of using find-value sometimes blow up if hitting an element that is not sexpressable? A: Nope, find-value only searches token nodes and token nodes are always sexpressable (well after we are done our work they should be).",
+   "Rewrite-clj v1 is a merge of rewrite-clj v0 and rewrite-cljs giving us a one stop rewrite-clj shop for Clojure and ClojureScript developers. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Introduction",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_introduction"}
+  {:doc
+   "Minimize API breakage. Within reason, maintain API compatibility with both rewrite-clj v0 and rewrite-cljs. I’d like rewrite-clj v1 to be an low friction replacement for rundis/rewrite-cljs (actually now living at clj-commons/rewrite-cljs) and xsc/rewrite-clj v0 (now living a clj-commons/rewrite-clj). Feature parity. Rewrite-cljs has lagged behind rewrite-clj v0. Bring rewrite-cljs up to parity with rewrite-clj v0. Bring any rewrite-cljs specific features over to rewrite-clj v1. Preserve type hints. I will respect and carry over existing type hinting in rewrite-clj v0 and rewrite-cljs. I will not, at this time, evaluate if existing type hinting has value. Improve documentation. I think that rewrite-clj v0 documentation is good, but as I dig deeper into using the library and get feedback on Slack, I see places where guidance could be improved. Document design decisions. I’m not sure what form this will take, but I do like projects that include histories of architectural and design decisions. Perhaps I’ll adopt ADR ala cljdoc. For now you can think of this document as I kind of sloppy-mega ADR for my merge work. Modernize/update test/build. Look at what is available today and make a choice. Define library version scheme. Evaluate options, pick one and document. Find home for this work. We have achieved the ideal here. Rewrite-clj v1 will continue from the same source repo as rewrite-clj v0. We will also continue to deploy to clojars rewrite-clj/rewrite-clj. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Goals",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_goals"}
+  {:doc
+   "Favor single code base. I will favor a single code base over maintaining ClojureScript specific optimizations from rewrite-cljs. These can be brought in at a later date if needed. Use generic exceptions. This is technically an API breakage, but I will switch to using the Clojure/ClojureScript agnostic ex-info for exceptions. Favor rewrite-clj features when there is overlap. I currently only see one feature that overlaps between the two projects. Rewrite-clj v0 and rewrite-cljs both have positional (row/col) support. Base positional support in rewrite-clj v0 is full featured and updates with any changes made, so we’ll use it instead of rewrite-cljs’s more primitive tools reader based positional support. This technically constitutes an API breakage for rewrite-cljs. We will, though, carry over rewrite-cljs’s higher level positional functions. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Strategic Compromises",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_strategic_compromises"}
+  {:doc "See change log. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Changes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_changes"}
+  {:doc
+   "I’ve used diff-apis to compare apis. Normally I would have excluded any apis tagged with :no-doc metadata, but because many folks used undocumented features in rewrite-clj v0 and rewrite-cljs, I have done a complete comparison of all publics - except where noted. Each report contains some observations under the \"Notes\" header. rewrite-clj v0 vs rewrite-cljs API differences between the projects on which rewrite-clj v1 is based. rewrite-clj v0 vs rewrite-clj v1 how different is rewrite-clj v1 from rewrite-clj v0? rewrite-cljs vs rewrite-clj v1 how different is rewrite-clj v1 from rewrite-cljs? rewrite-clj v1 a look at how cljs and clj sides of rewrite-clj v1 differ rewrite-clj v1 documented apis only a look at how cljs and clj sides of rewrite-clj v1 differ for documented apis. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Detailed API diffs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_detailed_api_diffs"}
+  {:doc
+   "No ability to read from files when using rewrite-clj v1 from ClojureScript. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Feature Differences",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_feature_differences"}
+  {:doc
+   "Both rewrite-clj v0 and rewrite-cljs share the same root namespace of rewrite-clj. We’ll happily continue with rewrite-clj for rewrite-clj v1 work: rewrite-clj v0 was transferred to clj-commons/rewrite-clj rewrite-clj v1 will carry on in clj-commons/rewrite-clj we’ll continue to use the existing rewrite-clj v0 clojars maven coordinates xsc/rewrite-clj for rewrite-clj v1 ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Root namespace of rewrite-clj",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_root_namespace_of_rewrite_clj"}
+  {:doc
+   "I’ve tried to make note of popular/active projects that make use of rewrite-clj v0 and rewrite-cljs. I’ve linked where I’ve explicitly verified a migration to rewrite-clj v1. See README for up to date list of which libraries directly use so form of rewrite-clj and which ones we are currently canary testing. Project rewrite‑clj? rewrite‑cljs? Notes chlorine yes REPL support for Atom editor. I do not see easy to run unit tests for this project. clj-kondo custom version uses an internal custom version of rewrite-clj cljfmt yes yes source code formatter cljstyle yes source code formatter based on cljfmt clojure-lsp yes language server for Clojure depot yes find newer versions of your deps.edn dependencies kibit yes Finds non-idiomatic Clojure code lein-ancient yes find newer versions of your lein dependencies MrAnderson yes Dependency inliner mutant yes Source code mutator pack (alpha) yes Clojure project packager rebel-readline indirectly via cljfmt smart editing at at the REPL terminal, optionally used in conjunction with figwheel-main REBL indirectly via cljfmt graphical interactive tool for browsing Clojure data refactor-nrepl yes refactoring support used in conjunction with cider repl-tooling yes base package for Clojure editor tooling. Interesting: uses rewrite-clj.reader directly. I do not see easy to run unit tests for this project. update-leiningen-dependencies-skill yes dependency version tracker, great for a migration test of a project that uses shadow-cljs zprint yes yes source code formatter ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Projects Using rewrite-clj v0 and/or rewrite-cljs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#rewrite-clj-legacy-libs"}
+  {:doc "See README for up to date list. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Projects Using rewrite-clj v1",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#rewrite-clj-v1-libs"}
+  {:doc
+   "I’m not sure if canary testing is exactly the right term here. My goal is to know when changes to rewrite-clj v1 break popular libraries. This would mean running these libraries' tests against rewrite-clj v1 master. After some experimentation, my general strategy is to: Install rewrite-clj HEAD to the local maven repository under a \"canary\" version For each library we want to test: Grab the a specified release of a project from GitHub via zip download Patch deps to Point to rewrite-clj canary release Adjust Clojure version if necessary (we are 1.8 and above) Adjust sources as necessary Ex. rewrite-cljc → rewrite-clj namespace At the time of the writing only zprint v1.1.1. needed a src code hack to get its tests passing. It is the only lib that digs into namespaced maps, and things changed a tad here for rewrite-clj v1 Run any necessary library test prep steps Run libraries tests (or a subset of them) ",
+   :name "Merging rewrite-clj and rewrite-cljs - Canary Testing",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#canary-testing"}
+  {:doc "",
+   :name "Merging rewrite-clj and rewrite-cljs - Tooling",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_tooling"}
+  {:doc
+   "I have moved from leiningen to tools cli and deps.edn. Like everything, this change has pros and cons. Overall, I like the simplicity and control it brings. Babashka scripts take the place of lein aliases where I can have the build do exactly what I want it to. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Build tools",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_build_tools"}
+  {:doc
+   "The future of Travis CI looked a bit tenuous when I started work on rewrite-clj v1. I initially switched over to CircleCI, but then when GitHub Actions became available decided it was a better fit: in addition to Linux, offers macOS and Windows testing in its free tier 7gb of RAM satisfies GraalVM’s memory hungry native-image ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Continuous integration",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_continuous_integration"}
+  {:doc
+   "After looking around, I settled on the following for continuous integration: Kaocha for running Clojure unit tests. moved from lein-doo to cljs-test-runner (which still uses doo under the hood) for running ClojureScript unit tests under node and chrome headless. I considered Kaocha’s cljs support and will reconsider when it matures a bit. I fail the build when a lint with clj-kondo produces any warnings and/or errors. During development, I found the following helpful: kaocha in watch mode for Clojure figwheel main for ClojureScript ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Testing and linting tools",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_testing_and_linting_tools"}
+  {:doc "",
+   :name "Merging rewrite-clj and rewrite-cljs - General Decisions",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_general_decisions"}
+  {:doc
+   "I see plenty of version scheme variations out there these days. Here are a few examples I find interesting: Project Scheme Example Observation ClojureScript major.minor.<commit count since major.minor> 1.10.520 Tracks Clojure version. clj-kondo yyyy-mm-dd-qualifier 2019.07.05-alpha Freshness built into version. cljdoc major.minor.<commit count>-<short git sha> 0.0.1315-c9e9a73 The short-sha safeguards against any potential confusion with duplicate commit counts for builds on different machines. meander meander/<release> 0.0.<commit count> meander/delta 0.0.137 This scheme changes the artifact-id (for example gamma to delta) every time a potentially breaking change is introduced effectively releasing a new product for every breaking change. spec.alpha unimportant unimportant The alpha state is burnt into the project name and library namespace. Rewrite-clj v1 is not a new project. I feel the version should reflect at least some familiarity with its v0 scheme. As of this writing the current version of rewrite-clj is 0.6.1. I am guessing that the 0 is an unused version element, and we have a 0.major.minor scheme. Rewrite-clj v1 is going to switch to a major.minor.<commit count>-<qualifier> scheme. Our first version will be 1.0.451-alpha where 451 is just a wild guess right now. An small awkwardness with this scheme is the change log. The change log should be part of the release but it does reference a git commit count. This will be addressed by automatically updating the change log doc with the release version as part of the release process. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Library version scheme",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_library_version_scheme"}
+  {:doc
+   "We’ll opt not to make SNAPSHOT releases and assume the community is good with testing pre-releases via GitHub coordinates. We can adapt if there is a real need for SNAPSHOT releases. We’ll keep a CHANGELOG.adoc carried on from rewrite-clj v0’s CHANGES.md. Release cadence will be as needed. I don’t want us to feel precious about releases. If there is a benefit to cutting a new release with a small change or fix, even just to docs, we’ll go ahead and do it. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Release Strategy",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_release_strategy"}
+  {:doc
+   "When I first started to experiment with a cljc version of rewrite-clj, my directory layout looked like: src/\n  clj/\n    rewrite-clj/\n  cljs/\n    rewrite-clj/\n  cljc/\n    rewrite-clj/\ntest/\n  clj/\n    rewrite-clj/\n  cljs/\n    rewrite-clj/\n  cljc/\n    rewrite-clj/ After a certain amount of work, I realized the majority of the code was cljc so opted for the much simpler: src/\n  rewrite-clj/\ntest/\n  rewrite-clj/ ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Source directory layout",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_source_directory_layout"}
+  {:doc
+   "Some command line tools written in Clojure are using Graal to compile to native executables for fast startup times. Others have done the work to test that rewrite-clj v0 can be compiled with Graal. There is benefit to the community to test that rewrite-clj v1 can also be compiled to native code with Graal. Noticing that there were differing approaches Graalifying Clojure, none of them centrally documented, @borkdude and I created clj-graal-docs to develop and share scripts and tips. My goal is to run the rewrite-clj v1 test suite from a GraalVM native image to give some confidence that rewrite-clj v1 works after compiled with Graal. ",
+   :name "Merging rewrite-clj and rewrite-cljs - GraalVM Support",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_graalvm_support"}
+  {:doc
+   "Windows tooling requirements. Setup for running GraalVM JDK8 on Windows relies on old Microsoft tooling making setup challenging. RAM requirements. GraalVM’s native-image which creates the target executable, can consume a significant amount of RAM. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Technical Issues",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_technical_issues"}
+  {:doc
+   "I’ve decided that, for now, figuring out how to setup the proper tooling for Windows for GraalVM JDK8 is not worth my effort. We’ll continue to test on Windows but only for GraalVM JDK11. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Windows Tooling Requirements",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_windows_tooling_requirements"}
+  {:doc
+   "I spent quite a bit of time trying to figure out how to overcome the RAM limitations of free tiers of continuous integration services. Drone Cloud is the most generous with 64gb of RAM available but only supports Linux. CircleCI offers 3.5gb of RAM and is also Linux only in its free tier. GitHub Actions, offers 7gb of RAM and offers macOS, Linux and Windows. I seriously explored two approaches: natively compile tests and library interpret tests via sci over natively compile library If I had applied Clojure direct linking earlier in my tests, I might have stopped at the first approach. For me, direct linking made approach 1 viable. For now, I am testing using both approaches. Overviews can be found at clj-graal-doc’s testing strategies page. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Ram Requirements",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_ram_requirements"}
+  {:doc "",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Questionable Decisions",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_questionable_decisions"}
+  {:doc
+   "Borkdude is kind enough to ping me when there are issues with the internally forked version of rewrite-clj he uses for clj-kondo. It turns out that clojure.tools.reader.edn does not parse garden-style keywords such as :&::before. The reader sees a double colon as illegal if it is anywhere in the keyword. Borkdude overcame this limitation by allowing a keyword to contain embedded double colons via a customized version of clojure.tools.reader.edn's read-keyword function. I transcribed his work to rewrite-clj v1. The maintenance cost to hacking a 3rd party lib is that upgrades will have to be carefully tracked. That said, we do have a good suite of tests that should uncover any issues. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Allowing garden style keywords",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_allowing_garden_style_keywords"}
+  {:doc
+   "While Clojure reads 'org/clojure/math.numeric-tower, clojure.tools.reader.edn barfs on this and therefore rewrite-clj does as well. It has been documented as illegal for a symbol to have more than one /. I have opted to not, at this time, adapt rewrite-clj v1 to allow parsing of this illegal syntax. This might seem a bit hypocritical because I did, some time ago, innocently raise an issue on clj-kondo for this. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Not allowing symbols with multiple slashes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_not_allowing_symbols_with_multiple_slashes"}
+  {:doc "",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Clojure/ClojureScript Issues",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_clojureclojurescript_issues"}
+  {:doc
+   "ClojureScript uses Google Closure under the hood. Because of the way Google Closure handles namespaces, some namespaces that work fine on Clojure clash under ClojureScript. Some rewrite-clj v0 namespaces clash for ClojureScript, for example: rewrite-clj.zip/find rewrite-clj.zip.find The original rewrite-cljs author worked around this problem by renaming namespaces to avoid the clashes. library namespace in rewrite-clj v1 namespace clj? cljs? rewrite-clj rewrite-clj.node.coerce rewrite-clj.node.coerce yes no rewrite-cljs rewrite-clj.node.coercer rewrite-clj.node.coercer yes yes rewrite-clj rewrite-clj.node.string rewrite-clj.node.string yes no rewrite-cljs rewrite-clj.node.stringz rewrite-clj.node.stringz yes yes rewrite-clj rewrite-clj.zip.edit rewrite-clj.zip.edit yes no rewrite-cljs rewrite-clj.zip.editz rewrite-clj.zip.editz yes yes rewrite-clj rewrite-clj.zip.find rewrite-clj.zip.find yes no rewrite-cljs rewrite-clj.zip.findz rewrite-clj.zip.findz yes yes rewrite-clj rewrite-clj.zip.remove rewrite-clj.zip.remove yes no rewrite-cljs rewrite-clj.zip.removez rewrite-clj.zip.removez yes yes rewrite-clj rewrite-clj.zip.seq rewrite-clj.zip.seq yes no rewrite-cljs rewrite-clj.zip.seqz rewrite-clj.zip.seqz yes yes None of these namespaces are part of public APIs, but because I see a lot of code that uses these internal namespaces, I decided to preserve the existing rewrite-clj v0 and rewrite-cljs naming for rewrite-clj v1. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - ClojureScript namespace clashes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_clojurescript_namespace_clashes"}
+  {:doc
+   "Where I felt I could get away with it, I localized Clojure/ClojureScript differences in the new rewrite-clj.interop namespace. Although technically an API breakage, I made a choice to switch all rewrite-clj v0 thrown exceptions to the Clojure/ClojureScript compatible ex-info for rewrite-clj v1. Some notes on differences between Clojure and ClojureScript throws and catches, if not using ex-info are different namespace requires cannot use shorthand syntax in cljs macros must (sometimes) be included differently IMetaData and other base types differ (this comes into play for us in coercion support) format not part of cljs standard lib no Character in cljs no ratios in cljs testing for NaN is different different max numerics ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Clojure/ClojureScript Interop",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_clojureclojurescript_interop"}
+  {:doc "",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Rewrite-clj/cljs Analysis",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_rewrite_cljcljs_analysis"}
+  {:doc
+   "rewrite-clj v0 purposefully only generated documentation for specific namespaces. It is reasonable to assume that these namespaces represent the public API: rewrite-clj.parse rewrite-clj.node rewrite-clj.zip I am not sure why rewrite-clj.custom-zipper is included in the documented public API, because its functionality is exposed through rewrite-clj.zip, I expect this was perhaps an oversight, but might be wrong. Because what is public versus what is private was not stressed strongly in the rewrite-clj v0 README, I frequently see private APIs used in code. For this reason, I’ve worked, within reason, not to break what I understand to be private APIs. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - What is the public API?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_what_is_the_public_api"}
+  {:doc
+   "rewrite-clj allows parsed Clojure/ClojureScript/EDN to be converted back and forth to s-expressions. Example from a REPL session: (require '[rewrite-clj.zip :as z])\n\n(def zipper (z/of-string \"[1 2 3]\"))  (1)\n(pr zipper)\n=stdout=> [<vector: [1 2 3]> {:l [], :pnodes [<forms: [1 2 3]>], :ppath nil, :r nil}]\n\n(def s (z/sexpr zipper)) (2)\ns\n=> [1 2 3]\n\n(require '[rewrite-clj.node :as n])\n(pr (n/coerce s)) (3)\n=stdout=> <vector: [1 2 3]> 1 parse string to rewrite-clj nodes and create zipper 2 convert rewrite-clj node at current location in zipper to s-expression 3 convert s-expression to rewrite-clj node While I expect this can be quite convenient, it does come with caveats: What happens when we try to sexpr Clojure specific features from ClojureScript? For example, ratios are available in Clojure but not ClojureScript. If you try to sexpr something that cannot be converted into an s-expression an exception will be thrown. My guidance is use sexpr in only in specific cases, where you know ahead of time what you are parsing. General blind use of sexpr is not recommended. For rewrite-clj v1 itself, I have removed internal problematic uses of sepxr and documented some of its nuances. ",
+   :name "Merging rewrite-clj and rewrite-cljs - S-expressions",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_s_expressions"}
+  {:doc
+   "Rewrite-clj makes use of Clojure’s reader. There are a few choices though: clojure.tools.reader clojure.tools.reader.edn clojure.reader clojure/reader-string As I understand it, clojure.tools.reader.edn is the safest choice and rewrite-clj v1 uses it in all cases. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Which reader?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_which_reader"}
+  {:doc
+   "Rewrite-clj v0 makes use of a slightly modified version of Potemkin import-vars. The intent of import-vars is to make it easy to expose a public API from a set of internal namespaces. When I first reviewed its usage in rewrite-clj, I found import-vars to be quite elegant. I have since learned that there is quite a bit of strong opinion in the Clojure community surrounding import-vars. Not all of it is rosy. Also, there is no ClojureScript version of import-vars. ",
+   :name "Merging rewrite-clj and rewrite-cljs - Potemkin import-vars",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_potemkin_import_vars"}
+  {:doc
+   "That said, I decided, in the beginning, to honor the original rewrite-clj codebase and carry on with it. To be honest, this gave me the (the apparently too tempting to resist) opportunity to learn how to write a version of import-vars for ClojureScript. This led me to discover that while cljdoc did cope fine with import-vars trickery for Clojure code, it did not have any support for it for ClojureScript code. I made the necessary changes to cljdoc’s fork of codox and subsequently cljdoc-analyzer. I also extended import-vars to rewrite-clj’s purposes by adding a facility to rename imported vars and adapt docstrings. All was not rainbows and unicorns, after yet another issue with some Clojure tooling, I decided to drop import-vars. ",
+   :name "Merging rewrite-clj and rewrite-cljs - What I started with",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_what_i_started_with"}
+  {:doc
+   "I still like the concept of import-vars. It automatically exposes an API and helps me to avoid silly human errors that would occur should I do this manually for rewrite-clj’s wide APIs. The issues with potemkin import-vars happen because vars are imported at load-time. I have moved to handling import-vars at build time. A build step reads reads an import-vars definition and generates appropriate source. This moves the burden from rewrite-clj users to rewrite-clj developers, which seems appropriate. First stab: Stick with an import-vars-ish syntax. Maybe a clj-kondo-ish style syntax #_{:import-vars/import {:from [[my.ns1 var1 var2 var3] [my.ns2 var4 var5])}}. Perhaps we can tease out a tool someday that is generally useful. Was thinking of having the build step update source in place, but @borkdude shared an idea of using templates. Options: Maybe have src/rewrite_clj.zip.template.cljc that generates/overwrites src/rewrite_clj/zip.cljc. Or a sister dir structure template/rewrite_clj/zip.cljc → src/rewrite_clj/zip.cljc. I’ll start with this, it: keeps templates separate from source. Not great for locality, but makes excluding them from release easier. keeps the ns name the same for template and target. Loses from moving to build-time solution: When you click on view source on cljdoc you go to the implementation and see the code. Now you’ll be directed to the delegator. This won’t be bothersome from an IDE, most will like it better, you’ll be able to flit from delegator to the implementation easily, but a loss from cljdoc. An extra build step is required. This moves the burden from the user to the developer. I’m ok with this. Potentially an extra call. Will this even register as a performance hit? Current import-vars usage. I don’t always use import-vars to expose a public API, I sometimes use it internally to avoid human error. For example rewrite-clj.node.string imports from rewrite-clj.node.stringz; the 2 namespaces exist due to API namespace collision issues in cljs. So what would be a good name for the build step? Maybe apply-import-vars gen-code? I think we’d also want something to read-only verify that the template generated clj is different than the target. We can fail CI build if this is true. Maybe apply-import-vars check? How will we find templates? We’ll start with storing all templates under ./template How will we choose target for templates? We’ll start ./src using, otherwise using same template filename. Extension will match template (clj vs cljc for us). Ok, so what code should we be generating? We want to definitely bring over the docstring (sometimes altered). We’ll have the import definition specify :added and :deprecated metadata. (Original version had this metadata specified on internal source var, cljs compiler warned about calls to internal deprecated fns from public API, which was not nice for folks using rewrite-clj under cljs). For the var itself we have choices. We could simply point to the source var. This is effectively what we do with current import-vars at load-time. We could generate a delegating fn matching the source arities. This would probably be more familiar to folks, and many static analysis tooling? I’ll start with this. And how will I find the info I need? The build step will be Clojure and run under the JVM, the targets are all clj or cljc, so I think we are good. I could use clj-kondo analysis data, but I don’t think that is necessary. What types of vars am I importing? functions - covered above. Note that I am also importing fns from protocols. Not sure if that complicates - think we’ll be OK. macros - I guess I’ll create a delegating macro. dynamic vars - I don’t think I have any of these anymore, so skip for now. I think I’ll repeat, in comments, throughout the generated source that source is generated and from what template. Just to try to avoid edits in generated source. Generated source will be checked in like all other source. Verification: run diff-apis will will save cljdoc-analyzer output to .diff-apis/.cache. Save the .cache. after changes verify that cljdoc-analyzer output is same. we expect :file and :line meta to be different for statically imported items And what technology will we use to rewrite Clojure source? Well… rewrite-clj seems like a good fit. For now, I will use master rewrite-clj to generate rewrite-clj sources from templates. To achieve this, I’ll use non generated sources only. And I’ll adapt rewrite-clj to only use non-generated sources itself. Except for paredit, it is really a higher level API, and I don’t want to uglify it by using rewrite-clj internal nses. We can adapt if my initial solution has warts. ",
+   :name "Merging rewrite-clj and rewrite-cljs - What I ended up with",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_what_i_ended_up_with"}
+  {:doc
+   "Rewrite-clj v0 used a customized version for potemkin defprotocol+. It could be that I missed something, but I did not see how it would benefit rewrite-clj v1. In the spirit of simplifying a cljc code-base, I turfed defprotocol+ in favour of plain old defprotocol. We can reintroduce defprotocol+ if we learn that it does actually help with performance significantly. ",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Potemkin defprotocol+",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_potemkin_defprotocol"}
+  {:doc
+   "Rewrite-clj v0: added a custom zipper to optionally track row/col within Clojure/ClojureScript/EDN files. expresses positions as a [row-number col-number] vector. Rewrite-cljs: made use of the positional support provided by Clojure tools reader. exposed a couple of functions to search by position. expressed positions as a {:row row-number :col col-number} map Because the positional support in rewrite-clj v0 tracks row/col even after zipper modifications, we use it in rewrite-clj v1 instead of rewrite-cljs’s implementation. We: continue to support both rewrite-clj v0 vector and rewrite-cljs map notations for positions on function parameters. use vector notation for position on function returns. I personally prefer the map notation, but, as a rule, favor rewrite-clj v0 over rewrite-cljs because rewrite-clj v0 is the more widely used library and thus changes affect more users. include rewrite-cljs’s positional functions: rewrite-clj.zip/find-last-by-pos and rewrite-clj.zip/find-tag-by-pos. The most glaring breaking change for ClojureScript is that it must now create the zipper with positional support enabled, for example: (z/of-string \"[1 2 3]\" {:track-position true}) ",
+   :name "Merging rewrite-clj and rewrite-cljs - Positional support",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_positional_support"}
+  {:doc "",
+   :name
+   "Merging rewrite-clj and rewrite-cljs - Namespaced maps and keywords",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs#_namespaced_maps_and_keywords"}
+  {:doc
+   "Namespaced elements Table of Contents Nomenclature What happens now in rewrite-clj v0 and rewrite-cljs? General use of sexpr in rewrite-clj Sexpr support for namespaced elements in rewrite-clj v0 and rewrite-cljs Options for rewrite-clj v1 The Rabbit Hole - Automatically Calculating sexpr for Auto-resolved Elements What will we do for rewrite-clj v1? Platform Support Sexpr Behaviour Sexpr on a Key in a Namespaced Map Sexpr Behaviour from the zip API Node Creation Namespaced Map Node Keyword Node Symbol Node Symbol and Keyword Context Node Traversal Node Interrogation Notes on Coercion Misc Questions Herein we study what rewrite-clj and rewrite-cljs currently do for namespaced elements and explore our options for rewrite-clj v1. You will see a focus on sepxr in this document; it is the primary challenge in supporting namespaced elements. ",
    :name "Namespaced Elements",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements"}
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#"}
   {:doc
-   "Diff of rewrite-clj 0.6.1 clj & rewrite-cljs 0.4.5 cljs Diff of apis in: rewrite-clj 0.6.1 clj rewrite-cljs 0.4.5 cljs Options: Option Value :arglists-by :arity-only :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 20 15 8 publics 100 170 79 arglists 0 298 88 Notes: The apis of the last released version of rewrite-cljs and the last released version of rewrite-clj v0 are compared here. In short, rewrite-cljs lagged far behind rewrite-clj v0, but rewrite-cljs had added some features of its own. See rewrite-clj v1’s design docs for more details. Table of diffs: - rewrite-clj.custom-zipper.core -append-child -branch? -children -custom-zipper -custom-zipper? -down -edit -end? -insert-child -insert-left -insert-right -left -leftmost -lefts -make-node -next -node -position -prev -remove -replace -right -rightmost -root -up -zipper - rewrite-clj.custom-zipper.utils -remove-and-move-left -remove-and-move-right -remove-left -remove-left-while -remove-right -remove-right-while ≠ rewrite-clj.node ≠child-sexprs ≠children ≠coerce -comma-node -comma-separated -comma? ≠comment-node ≠comment? -concat-strings ≠deref-node ≠eval-node ≠fn-node ≠forms-node ≠inner? -integer-node ≠keyword-node -leader-length ≠length -line-separated ≠linebreak? ≠list-node ≠map-node ≠meta-node -namespaced-map-node ≠newline-node ≠newlines ≠printable-only? ≠quote-node -raw-meta-node ≠reader-macro-node -regex-node ≠replace-children ≠set-node ≠sexpr -sexprs ≠spaces ≠string ≠string-node ≠syntax-quote-node ≠tag ≠token-node ≠uneval-node ≠unquote-node ≠unquote-splicing-node -value ≠var-node ≠vector-node ≠whitespace-node -whitespace-nodes ≠whitespace? - rewrite-clj.node.coerce + rewrite-clj.node.coercer +node-with-meta +seq-node ≠ rewrite-clj.node.comment =comment-node =comment? =CommentNode ≠ rewrite-clj.node.forms =forms-node =FormsNode - rewrite-clj.node.indent -indent-spaces -indent-tabs -LinePrefixedNode -prefix-lines - rewrite-clj.node.integer -integer-node -IntNode ≠ rewrite-clj.node.keyword =keyword-node =KeywordNode ≠ rewrite-clj.node.meta =meta-node =MetaNode =raw-meta-node ≠ rewrite-clj.node.protocols -+extent ≠assert-sexpr-count ≠assert-single-sexpr ≠concat-strings -extent ≠InnerNode -make-printable! ≠sum-lengths -write-node - rewrite-clj.node.regex -regex-node -RegexNode ≠ rewrite-clj.node.seq =list-node =map-node -namespaced-map-node -NamespacedMapNode =SeqNode =set-node =vector-node +wrap-list +wrap-map +wrap-set +wrap-vec - rewrite-clj.node.string -string-node -StringNode + rewrite-clj.node.stringz +string-node +StringNode ≠ rewrite-clj.node.token ≠token-node =TokenNode ≠ rewrite-clj.node.whitespace =*count-fn* =*newline-fn* -comma-node =comma-separated -comma? -CommaNode =line-separated =linebreak? =newline-node =NewlineNode =newlines =space-separated =spaces =whitespace-node =whitespace-nodes =whitespace? =WhitespaceNode -with-count-fn -with-newline-fn + rewrite-clj.paredit +barf-backward +barf-forward +join +kill +kill-at-pos +kill-one-at-pos +move-n +move-to-prev +raise +slurp-backward +slurp-backward-fully +slurp-forward +slurp-forward-fully +splice +splice-killing-backward +splice-killing-forward +split +split-at-pos +wrap-around +wrap-fully-forward-slurp ≠ rewrite-clj.parser -parse-file -parse-file-all ≠ rewrite-clj.parser.core =parse-next ≠ rewrite-clj.parser.keyword =parse-keyword ≠ rewrite-clj.parser.string =parse-regex =parse-string ≠ rewrite-clj.parser.token =parse-token - rewrite-clj.parser.utils -ignore -linebreak? -read-eol -space? -throw-reader -whitespace? ≠ rewrite-clj.parser.whitespace =parse-whitespace - rewrite-clj.potemkin -defprotocol+ -import-def -import-fn -import-macro -import-vars -link-vars ≠ rewrite-clj.reader =boundary? +buf -comma? -file-reader +get-column-number +get-line-number =ignore +indexing-push-back-reader =linebreak? =next =peek +peek-char -position +read-char =read-include-linebreak +read-keyword =read-n =read-repeatedly +read-string =read-until ≠read-while =read-with-meta =space? =string->edn -string-reader =throw-reader ≠unread =whitespace-or-boundary? =whitespace? ≠ rewrite-clj.zip -->root-string -->string ≠append-child -append-newline -append-space ≠assoc -child-sexprs ≠down -down* ≠edit -edit* -edit-> -edit->> -edit-node -edn -edn* ≠end? ≠find ≠find-depth-first +find-last-by-pos ≠find-next ≠find-next-depth-first ≠find-next-tag ≠find-next-token ≠find-next-value ≠find-tag +find-tag-by-pos ≠find-token ≠find-value ≠get ≠insert-child ≠insert-left -insert-left* ≠insert-right -insert-right* ≠left -left* ≠leftmost -leftmost* ≠leftmost? -length -linebreak? ≠list? ≠map ≠map-keys ≠map-vals ≠map? ≠next -next* ≠node -of-file ≠of-string -position -postwalk ≠prefix -prepend-newline -prepend-space ≠prev -prev* -prewalk -print -print-root ≠remove -remove* +remove-preserve-newline ≠replace -replace* ≠right -right* ≠rightmost -rightmost* ≠rightmost? ≠root ≠root-string ≠seq? ≠set? ≠sexpr -skip -skip-whitespace -skip-whitespace-left ≠splice ≠string -subedit-> -subedit->> -subedit-node ≠suffix ≠tag ≠up -up* -value ≠vector? -whitespace-or-comment? -whitespace? ≠ rewrite-clj.zip.base =child-sexprs ≠edn ≠edn* =length -of-file ≠of-string -print -print-root =root-string =sexpr =string =tag -value - rewrite-clj.zip.edit -edit -prefix -replace -splice -suffix + rewrite-clj.zip.editz +edit +prefix +replace +splice +suffix - rewrite-clj.zip.find -find -find-depth-first -find-next -find-next-depth-first -find-next-tag -find-next-token -find-next-value -find-tag -find-token -find-value + rewrite-clj.zip.findz +find +find-depth-first +find-last-by-pos +find-next +find-next-depth-first +find-next-tag +find-next-token +find-next-value +find-tag +find-tag-by-pos +find-token +find-value +in-range? ≠ rewrite-clj.zip.move =down =end? =left =leftmost =leftmost? =next =prev =right =rightmost =rightmost? =up - rewrite-clj.zip.remove -remove + rewrite-clj.zip.removez +remove +remove-preserve-newline - rewrite-clj.zip.seq -assoc -get -list? -map -map-keys -map-vals -map? -seq? -set? -vector? + rewrite-clj.zip.seqz +assoc +get +list? +map +map-keys +map-vals +map? +seq? +set? +vector? - rewrite-clj.zip.subedit -edit-> -edit->> -edit-node -subedit-> -subedit->> -subedit-node -subzip + rewrite-clj.zip.utils +remove-and-move-left +remove-and-move-right +remove-and-move-up +remove-left +remove-left-while +remove-right +remove-right-while +remove-while - rewrite-clj.zip.walk -postwalk -postwalk-subtree -prewalk ≠ rewrite-clj.zip.whitespace ≠append-newline ≠append-space +comment? -insert-newline-left -insert-newline-right -insert-space-left -insert-space-right =linebreak? ≠prepend-newline ≠prepend-space =skip =skip-whitespace =skip-whitespace-left +whitespace-not-linebreak? =whitespace-or-comment? =whitespace? - rewrite-clj.custom-zipper.core -append-child arglists attributes - [ G__2836 G__2837 ] :type - :var -branch? arglists attributes - [ G__2769 ] :type - :var -children arglists attributes - [ G__2772 ] :type - :var -custom-zipper arglists attributes - [ root ] :type - :var :no-doc - true -custom-zipper? arglists attributes - [ value ] :type - :var :no-doc - true -down arglists attributes - [ G__2782 ] :type - :var -edit arglists attributes - [ loc f & args ] :type - :var -end? arglists attributes - [ G__2851 ] :type - :var -insert-child arglists attributes - [ G__2833 G__2834 ] :type - :var -insert-left arglists attributes - [ G__2821 G__2822 ] :type - :var -insert-right arglists attributes - [ G__2825 G__2826 ] :type - :var -left arglists attributes - [ G__2807 ] :type - :var -leftmost arglists attributes - [ G__2814 ] :type - :var -lefts arglists attributes - [ G__2780 ] :type - :var -make-node arglists attributes - [ G__2775 G__2776 G__2777 ] :type - :var :no-doc - true -next arglists attributes - [ G__2839 ] :type - :var -node arglists attributes - [ G__2766 ] :type - :var -position arglists attributes - [ loc ] :type - :var -prev arglists attributes - [ G__2846 ] :type - :var -remove arglists attributes - [ G__2853 ] :type - :var -replace arglists attributes - [ G__2829 G__2830 ] :type - :var -right arglists attributes - [ G__2797 ] :type - :var -rightmost arglists attributes - [ G__2804 ] :type - :var -root arglists attributes - [ G__2794 ] :type - :var -up arglists attributes - [ G__2791 ] :type - :var -zipper arglists attributes - [ root ] :type - :var :no-doc - true - rewrite-clj.custom-zipper.utils :no-doc = true -remove-and-move-left arglists attributes - [ loc ] :type - :var -remove-and-move-right arglists attributes - [ loc ] :type - :var -remove-left arglists attributes - [ loc ] :type - :var -remove-left-while arglists attributes - [ zloc p? ] :type - :var -remove-right arglists attributes - [ loc ] :type - :var -remove-right-while arglists attributes - [ zloc p? ] :type - :var ≠ rewrite-clj.node ≠child-sexprs arglists attributes - [ node ] :type = :var ≠children arglists attributes - [ _ ] :type = :var ≠coerce arglists attributes - [ _ ] :type = :var -comma-node arglists attributes - [ s ] :type - :var -comma-separated arglists attributes - [ nodes ] :type - :var -comma? arglists attributes - [ node ] :type - :var ≠comment-node arglists attributes - [ s ] :type = :var ≠comment? arglists attributes - [ node ] :type = :var -concat-strings arglists attributes - [ nodes ] :type - :var :no-doc - true ≠deref-node arglists attributes - [ children ] :type = :var ≠eval-node arglists attributes - [ children ] :type = :var ≠fn-node arglists attributes - [ children ] :type = :var ≠forms-node arglists attributes - [ children ] :type = :var ≠inner? arglists attributes - [ _ ] :type = :var -integer-node arglists attributes - [ value ] - [ value base ] :type - :var ≠keyword-node arglists attributes - [ k & [namespaced?] ] :type = :var -leader-length arglists attributes - [ _ ] :type - :var ≠length arglists attributes - [ _ ] :type = :var -line-separated arglists attributes - [ nodes ] :type - :var ≠linebreak? arglists attributes - [ node ] :type = :var ≠list-node arglists attributes - [ children ] :type = :var ≠map-node arglists attributes - [ children ] :type = :var ≠meta-node arglists attributes - [ children ] - [ metadata data ] :type = :var -namespaced-map-node arglists attributes - [ children ] :type - :var ≠newline-node arglists attributes - [ s ] :type = :var ≠newlines arglists attributes - [ n ] :type = :var ≠printable-only? arglists attributes - [ _ ] :type = :var ≠quote-node arglists attributes - [ children ] :type = :var -raw-meta-node arglists attributes - [ children ] - [ metadata data ] :type - :var ≠reader-macro-node arglists attributes - [ children ] - [ macro-node form-node ] :type = :var -regex-node arglists attributes - [ pattern-string ] :type - :var ≠replace-children arglists attributes - [ _ children ] :type = :var ≠set-node arglists attributes - [ children ] :type = :var ≠sexpr arglists attributes - [ _ ] :type = :var -sexprs arglists attributes - [ nodes ] :type - :var ≠spaces arglists attributes - [ n ] :type = :var ≠string arglists attributes - [ _ ] :type = :var ≠string-node arglists attributes - [ lines ] :type = :var ≠syntax-quote-node arglists attributes - [ children ] :type = :var ≠tag arglists attributes - [ _ ] :type = :var ≠token-node arglists attributes - [ value & [string-value] ] :type = :var ≠uneval-node arglists attributes - [ children ] :type = :var ≠unquote-node arglists attributes - [ children ] :type = :var ≠unquote-splicing-node arglists attributes - [ children ] :type = :var -value arglists attributes - [ node ] :type - :var :deprecated - 0.4.0 ≠var-node arglists attributes - [ children ] :type = :var ≠vector-node arglists attributes - [ children ] :type = :var ≠whitespace-node arglists attributes - [ s ] :type = :var -whitespace-nodes arglists attributes - [ s ] :type - :var ≠whitespace? arglists attributes - [ node ] :type = :var - rewrite-clj.node.coerce :no-doc = true + rewrite-clj.node.coercer +node-with-meta arglists attributes + [ n value ] :type + :var +seq-node arglists attributes + [ f sq ] :type + :var ≠ rewrite-clj.node.comment :no-doc - true =comment-node arglists attributes = [ s ] :type = :var =comment? arglists attributes = [ node ] :type = :var =CommentNode attributes :type = :var ≠ rewrite-clj.node.forms :no-doc - true =forms-node arglists attributes = [ children ] :type = :var =FormsNode attributes :type = :var - rewrite-clj.node.indent :no-doc = true -indent-spaces arglists attributes - [ node n ] :type - :var -indent-tabs arglists attributes - [ node n ] :type - :var -LinePrefixedNode attributes :type - :var -prefix-lines arglists attributes - [ node prefix ] :type - :var - rewrite-clj.node.integer :no-doc = true -integer-node arglists attributes - [ value ] - [ value base ] :type - :var -IntNode attributes :type - :var ≠ rewrite-clj.node.keyword :no-doc - true =keyword-node arglists attributes = [ k & [namespaced?] ] :type = :var =KeywordNode attributes :type = :var ≠ rewrite-clj.node.meta :no-doc - true =meta-node arglists attributes = [ children ] = [ metadata data ] :type = :var =MetaNode attributes :type = :var =raw-meta-node arglists attributes = [ children ] = [ metadata data ] :type = :var ≠ rewrite-clj.node.protocols -+extent arglists attributes - [ [row col] [row-extent col-extent] ] :type - :var :no-doc - true ≠assert-sexpr-count arglists attributes = [ nodes c ] :type = :var :no-doc - true ≠assert-single-sexpr arglists attributes = [ nodes ] :type = :var :no-doc - true ≠concat-strings arglists attributes = [ nodes ] :type = :var :no-doc - true -extent arglists attributes - [ node ] :type - :var :no-doc - true ≠InnerNode attributes members name arglists attributes :type = :protocol = children = [ _ ] :type = :var = inner? = [ _ ] :type = :var - leader-length - [ _ ] :type - :var = replace-children = [ _ children ] :type = :var -make-printable! arglists attributes - [ class ] :type - :macro :no-doc - true ≠sum-lengths arglists attributes = [ nodes ] :type = :var :no-doc - true -write-node arglists attributes - [ writer node ] :type - :var :no-doc - true - rewrite-clj.node.regex :no-doc = true -regex-node arglists attributes - [ pattern-string ] :type - :var -RegexNode attributes :type - :var ≠ rewrite-clj.node.seq :no-doc - true =list-node arglists attributes = [ children ] :type = :var =map-node arglists attributes = [ children ] :type = :var -namespaced-map-node arglists attributes - [ children ] :type - :var -NamespacedMapNode attributes :type - :var =SeqNode attributes :type = :var =set-node arglists attributes = [ children ] :type = :var =vector-node arglists attributes = [ children ] :type = :var +wrap-list arglists attributes + [ s ] :type + :var +wrap-map arglists attributes + [ s ] :type + :var +wrap-set arglists attributes + [ s ] :type + :var +wrap-vec arglists attributes + [ s ] :type + :var - rewrite-clj.node.string :no-doc = true -string-node arglists attributes - [ lines ] :type - :var -StringNode attributes :type - :var + rewrite-clj.node.stringz +string-node arglists attributes + [ lines ] :type + :var +StringNode attributes :type + :var ≠ rewrite-clj.node.token :no-doc - true ≠token-node arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var =TokenNode attributes :type = :var ≠ rewrite-clj.node.whitespace :no-doc - true =*count-fn* attributes :type = :var :dynamic = true =*newline-fn* attributes :type = :var :dynamic = true -comma-node arglists attributes - [ s ] :type - :var =comma-separated arglists attributes = [ nodes ] :type = :var -comma? arglists attributes - [ node ] :type - :var -CommaNode attributes :type - :var =line-separated arglists attributes = [ nodes ] :type = :var =linebreak? arglists attributes = [ node ] :type = :var =newline-node arglists attributes = [ s ] :type = :var =NewlineNode attributes :type = :var =newlines arglists attributes = [ n ] :type = :var =space-separated arglists attributes = [ nodes ] :type = :var =spaces arglists attributes = [ n ] :type = :var =whitespace-node arglists attributes = [ s ] :type = :var =whitespace-nodes arglists attributes = [ s ] :type = :var =whitespace? arglists attributes = [ node ] :type = :var =WhitespaceNode attributes :type = :var -with-count-fn arglists attributes - [ f & body ] :type - :macro -with-newline-fn arglists attributes - [ f & body ] :type - :macro + rewrite-clj.paredit +barf-backward arglists attributes + [ zloc ] :type + :var +barf-forward arglists attributes + [ zloc ] :type + :var +join arglists attributes + [ zloc ] :type + :var +kill arglists attributes + [ zloc ] :type + :var +kill-at-pos arglists attributes + [ zloc pos ] :type + :var +kill-one-at-pos arglists attributes + [ zloc pos ] :type + :var +move-n arglists attributes + [ loc f n ] :type + :var :no-doc + true +move-to-prev arglists attributes + [ zloc ] :type + :var +raise arglists attributes + [ zloc ] :type + :var +slurp-backward arglists attributes + [ zloc ] :type + :var +slurp-backward-fully arglists attributes + [ zloc ] :type + :var +slurp-forward arglists attributes + [ zloc ] :type + :var +slurp-forward-fully arglists attributes + [ zloc ] :type + :var +splice attributes :type + :var +splice-killing-backward arglists attributes + [ zloc ] :type + :var +splice-killing-forward arglists attributes + [ zloc ] :type + :var +split arglists attributes + [ zloc ] :type + :var +split-at-pos arglists attributes + [ zloc pos ] :type + :var +wrap-around arglists attributes + [ zloc t ] :type + :var +wrap-fully-forward-slurp arglists attributes + [ zloc t ] :type + :var ≠ rewrite-clj.parser -parse-file arglists attributes - [ f ] :type - :var -parse-file-all arglists attributes - [ f ] :type - :var ≠ rewrite-clj.parser.core :no-doc - true =parse-next arglists attributes = [ reader ] :type = :var ≠ rewrite-clj.parser.keyword :no-doc - true =parse-keyword arglists attributes = [ reader ] :type = :var ≠ rewrite-clj.parser.string :no-doc - true =parse-regex arglists attributes = [ reader ] :type = :var =parse-string arglists attributes = [ reader ] :type = :var ≠ rewrite-clj.parser.token :no-doc - true =parse-token arglists attributes = [ reader ] :type = :var - rewrite-clj.parser.utils :no-doc = true -ignore arglists attributes - [ reader ] :type - :var -linebreak? arglists attributes - [ c ] :type - :var -read-eol arglists attributes - [ reader ] :type - :var -space? arglists attributes - [ c ] :type - :var -throw-reader arglists attributes - [ reader & msg ] :type - :var -whitespace? arglists attributes - [ c ] :type - :var ≠ rewrite-clj.parser.whitespace :no-doc - true =parse-whitespace arglists attributes = [ reader ] :type = :var - rewrite-clj.potemkin :no-doc = true -defprotocol+ arglists attributes - [ name & body ] :type - :macro -import-def arglists attributes - [ sym ] - [ sym name ] :type - :macro -import-fn arglists attributes - [ sym ] - [ sym name ] :type - :macro -import-macro arglists attributes - [ sym ] - [ sym name ] :type - :macro -import-vars arglists attributes - [ & syms ] :type - :macro -link-vars arglists attributes - [ src dst ] :type - :var ≠ rewrite-clj.reader :no-doc - true =boundary? arglists attributes = [ c ] :type = :var +buf attributes :type + :var -comma? arglists attributes - [ c ] :type - :var -file-reader arglists attributes - [ f ] :type - :var +get-column-number attributes :type + :var +get-line-number attributes :type + :var =ignore arglists attributes = [ reader ] :type = :var +indexing-push-back-reader attributes :type + :var =linebreak? arglists attributes = [ c ] :type = :var =next arglists attributes = [ reader ] :type = :var =peek arglists attributes = [ reader ] :type = :var +peek-char attributes :type + :var -position arglists attributes - [ reader row-k col-k ] :type - :var +read-char attributes :type + :var =read-include-linebreak arglists attributes = [ reader ] :type = :var +read-keyword arglists attributes + [ reader initch ] :type + :var =read-n arglists attributes = [ reader node-tag read-fn p? n ] :type = :var =read-repeatedly arglists attributes = [ reader read-fn ] :type = :var +read-string attributes :type + :var =read-until arglists attributes = [ reader p? ] :type = :var ≠read-while arglists attributes + [ reader p? ] + [ reader p? eof? ] - [ reader p? & [eof?] ] :type = :var =read-with-meta arglists attributes = [ reader read-fn ] :type = :var =space? arglists attributes = [ c ] :type = :var =string->edn arglists attributes = [ s ] :type = :var -string-reader arglists attributes - [ s ] :type - :var =throw-reader arglists attributes = [ reader fmt & data ] :type = :var ≠unread arglists attributes - [ reader ch ] :type = :var =whitespace-or-boundary? arglists attributes = [ c ] :type = :var =whitespace? arglists attributes = [ c ] :type = :var ≠ rewrite-clj.zip -->root-string arglists attributes - [ zloc ] :type - :var :deprecated - 0.4.0 -->string arglists attributes - [ zloc ] :type - :var :deprecated - 0.4.0 ≠append-child arglists attributes - [ zloc item ] :type = :var -append-newline arglists attributes - [ zloc & [n] ] :type - :var :deprecated - 0.5.0 -append-space arglists attributes - [ zloc & [n] ] :type - :var :deprecated - 0.5.0 ≠assoc arglists attributes - [ zloc k v ] :type = :var -child-sexprs arglists attributes - [ zloc ] :type - :var ≠down arglists attributes - [ zloc ] :type = :var -down* arglists attributes - [ G__2782 ] :type - :var ≠edit arglists attributes - [ zloc f & args ] :type = :var -edit* arglists attributes - [ loc f & args ] :type - :var -edit-> arglists attributes - [ zloc & body ] :type - :macro -edit->> arglists attributes - [ zloc & body ] :type - :macro -edit-node arglists attributes - [ zloc f ] :type - :var -edn arglists attributes - [ node ] - [ node {} ] :type - :var -edn* arglists attributes - [ node ] - [ node {} ] :type - :var ≠end? arglists attributes - [ zloc ] :type = :var ≠find arglists attributes - [ zloc p? ] - [ zloc f p? ] :type = :var ≠find-depth-first arglists attributes - [ zloc p? ] :type = :var +find-last-by-pos attributes :type + :var ≠find-next arglists attributes - [ zloc p? ] - [ zloc f p? ] :type = :var ≠find-next-depth-first arglists attributes - [ zloc p? ] :type = :var ≠find-next-tag arglists attributes - [ zloc t ] - [ zloc f t ] :type = :var ≠find-next-token arglists attributes - [ zloc p? ] - [ zloc f p? ] :type = :var ≠find-next-value arglists attributes - [ zloc v ] - [ zloc f v ] :type = :var ≠find-tag arglists attributes - [ zloc t ] - [ zloc f t ] :type = :var +find-tag-by-pos attributes :type + :var ≠find-token arglists attributes - [ zloc p? ] - [ zloc f p? ] :type = :var ≠find-value arglists attributes - [ zloc v ] - [ zloc f v ] :type = :var ≠get arglists attributes - [ zloc k ] :type = :var ≠insert-child arglists attributes - [ zloc item ] :type = :var ≠insert-left arglists attributes - [ zloc item ] :type = :var -insert-left* arglists attributes - [ G__2821 G__2822 ] :type - :var ≠insert-right arglists attributes - [ zloc item ] :type = :var -insert-right* arglists attributes - [ G__2825 G__2826 ] :type - :var ≠left arglists attributes - [ zloc ] :type = :var -left* arglists attributes - [ G__2807 ] :type - :var ≠leftmost arglists attributes - [ zloc ] :type = :var -leftmost* arglists attributes - [ G__2814 ] :type - :var ≠leftmost? arglists attributes - [ zloc ] :type = :var -length arglists attributes - [ zloc ] :type - :var -linebreak? arglists attributes - [ zloc ] :type - :var ≠list? arglists attributes - [ zloc ] :type = :var ≠map arglists attributes - [ f zloc ] :type = :var ≠map-keys arglists attributes - [ f zloc ] :type = :var ≠map-vals arglists attributes - [ f zloc ] :type = :var ≠map? arglists attributes - [ zloc ] :type = :var ≠next arglists attributes - [ zloc ] :type = :var -next* arglists attributes - [ G__2839 ] :type - :var ≠node arglists attributes - [ G__2766 ] :type = :var -of-file arglists attributes - [ f ] - [ f options ] :type - :var ≠of-string arglists attributes - [ s ] - [ s options ] :type = :var -position arglists attributes - [ loc ] :type - :var -postwalk arglists attributes - [ zloc f ] - [ zloc p? f ] :type - :var ≠prefix arglists attributes - [ zloc s ] :type = :var -prepend-newline arglists attributes - [ zloc & [n] ] :type - :var :deprecated - 0.5.0 -prepend-space arglists attributes - [ zloc & [n] ] :type - :var :deprecated - 0.5.0 ≠prev arglists attributes - [ zloc ] :type = :var -prev* arglists attributes - [ G__2846 ] :type - :var -prewalk arglists attributes - [ zloc f ] - [ zloc p? f ] :type - :var -print arglists attributes - [ zloc & [writer] ] :type - :var -print-root arglists attributes - [ zloc & [writer] ] :type - :var ≠remove arglists attributes - [ zloc ] :type = :var -remove* arglists attributes - [ G__2853 ] :type - :var +remove-preserve-newline attributes :type + :var ≠replace arglists attributes - [ zloc value ] :type = :var -replace* arglists attributes - [ G__2829 G__2830 ] :type - :var ≠right arglists attributes - [ zloc ] :type = :var -right* arglists attributes - [ G__2797 ] :type - :var ≠rightmost arglists attributes - [ zloc ] :type = :var -rightmost* arglists attributes - [ G__2804 ] :type - :var ≠rightmost? arglists attributes - [ zloc ] :type = :var ≠root arglists attributes - [ G__2794 ] :type = :var ≠root-string arglists attributes - [ zloc ] :type = :var ≠seq? arglists attributes - [ zloc ] :type = :var ≠set? arglists attributes - [ zloc ] :type = :var ≠sexpr arglists attributes - [ zloc ] :type = :var -skip arglists attributes - [ f p? zloc ] :type - :var -skip-whitespace arglists attributes - [ zloc ] - [ f zloc ] :type - :var -skip-whitespace-left arglists attributes - [ zloc ] :type - :var ≠splice arglists attributes - [ zloc ] :type = :var ≠string arglists attributes - [ zloc ] :type = :var -subedit-> arglists attributes - [ zloc & body ] :type - :macro -subedit->> arglists attributes - [ zloc & body ] :type - :macro -subedit-node arglists attributes - [ zloc f ] :type - :var ≠suffix arglists attributes - [ zloc s ] :type = :var ≠tag arglists attributes - [ zloc ] :type = :var ≠up arglists attributes - [ zloc ] :type = :var -up* arglists attributes - [ G__2791 ] :type - :var -value arglists attributes - [ zloc ] :type - :var :deprecated - 0.4.0 ≠vector? arglists attributes - [ zloc ] :type = :var -whitespace-or-comment? arglists attributes - [ zloc ] :type - :var -whitespace? arglists attributes - [ zloc ] :type - :var ≠ rewrite-clj.zip.base :no-doc - true =child-sexprs arglists attributes = [ zloc ] :type = :var ≠edn arglists attributes = [ node ] - [ node {} ] :type = :var ≠edn* arglists attributes = [ node ] - [ node {} ] :type = :var =length arglists attributes = [ zloc ] :type = :var -of-file arglists attributes - [ f ] - [ f options ] :type - :var ≠of-string arglists attributes = [ s ] - [ s options ] :type = :var -print arglists attributes - [ zloc & [writer] ] :type - :var -print-root arglists attributes - [ zloc & [writer] ] :type - :var =root-string arglists attributes = [ zloc ] :type = :var =sexpr arglists attributes = [ zloc ] :type = :var =string arglists attributes = [ zloc ] :type = :var =tag arglists attributes = [ zloc ] :type = :var -value arglists attributes - [ zloc ] :type - :var :deprecated - 0.4.0 - rewrite-clj.zip.edit :no-doc = true -edit arglists attributes - [ zloc f & args ] :type - :var -prefix arglists attributes - [ zloc s ] :type - :var -replace arglists attributes - [ zloc value ] :type - :var -splice arglists attributes - [ zloc ] :type - :var -suffix arglists attributes - [ zloc s ] :type - :var + rewrite-clj.zip.editz +edit arglists attributes + [ zloc f & args ] :type + :var +prefix arglists attributes + [ zloc s ] :type + :var +replace arglists attributes + [ zloc value ] :type + :var +splice arglists attributes + [ zloc ] :type + :var +suffix arglists attributes + [ zloc s ] :type + :var - rewrite-clj.zip.find :no-doc = true -find arglists attributes - [ zloc p? ] - [ zloc f p? ] :type - :var -find-depth-first arglists attributes - [ zloc p? ] :type - :var -find-next arglists attributes - [ zloc p? ] - [ zloc f p? ] :type - :var -find-next-depth-first arglists attributes - [ zloc p? ] :type - :var -find-next-tag arglists attributes - [ zloc t ] - [ zloc f t ] :type - :var -find-next-token arglists attributes - [ zloc p? ] - [ zloc f p? ] :type - :var -find-next-value arglists attributes - [ zloc v ] - [ zloc f v ] :type - :var -find-tag arglists attributes - [ zloc t ] - [ zloc f t ] :type - :var -find-token arglists attributes - [ zloc p? ] - [ zloc f p? ] :type - :var -find-value arglists attributes - [ zloc v ] - [ zloc f v ] :type - :var + rewrite-clj.zip.findz +find arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-depth-first arglists attributes + [ zloc p? ] :type + :var +find-last-by-pos arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var +find-next arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-next-depth-first arglists attributes + [ zloc p? ] :type + :var +find-next-tag arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var +find-next-token arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-next-value arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var +find-tag arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var +find-tag-by-pos arglists attributes + [ zloc pos t ] :type + :var +find-token arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-value arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var +in-range? arglists attributes + [ {} {} ] :type + :var ≠ rewrite-clj.zip.move :no-doc - true =down arglists attributes = [ zloc ] :type = :var =end? arglists attributes = [ zloc ] :type = :var =left arglists attributes = [ zloc ] :type = :var =leftmost arglists attributes = [ zloc ] :type = :var =leftmost? arglists attributes = [ zloc ] :type = :var =next arglists attributes = [ zloc ] :type = :var =prev arglists attributes = [ zloc ] :type = :var =right arglists attributes = [ zloc ] :type = :var =rightmost arglists attributes = [ zloc ] :type = :var =rightmost? arglists attributes = [ zloc ] :type = :var =up arglists attributes = [ zloc ] :type = :var - rewrite-clj.zip.remove :no-doc = true -remove arglists attributes - [ zloc ] :type - :var + rewrite-clj.zip.removez +remove arglists attributes + [ zloc ] :type + :var +remove-preserve-newline arglists attributes + [ zloc ] :type + :var - rewrite-clj.zip.seq :no-doc = true -assoc arglists attributes - [ zloc k v ] :type - :var -get arglists attributes - [ zloc k ] :type - :var -list? arglists attributes - [ zloc ] :type - :var -map arglists attributes - [ f zloc ] :type - :var -map-keys arglists attributes - [ f zloc ] :type - :var -map-vals arglists attributes - [ f zloc ] :type - :var -map? arglists attributes - [ zloc ] :type - :var -seq? arglists attributes - [ zloc ] :type - :var -set? arglists attributes - [ zloc ] :type - :var -vector? arglists attributes - [ zloc ] :type - :var + rewrite-clj.zip.seqz +assoc arglists attributes + [ zloc k v ] :type + :var +get arglists attributes + [ zloc k ] :type + :var +list? arglists attributes + [ zloc ] :type + :var +map arglists attributes + [ f zloc ] :type + :var +map-keys arglists attributes + [ f zloc ] :type + :var +map-vals arglists attributes + [ f zloc ] :type + :var +map? arglists attributes + [ zloc ] :type + :var +seq? arglists attributes + [ zloc ] :type + :var +set? arglists attributes + [ zloc ] :type + :var +vector? arglists attributes + [ zloc ] :type + :var - rewrite-clj.zip.subedit :no-doc = true -edit-> arglists attributes - [ zloc & body ] :type - :macro -edit->> arglists attributes - [ zloc & body ] :type - :macro -edit-node arglists attributes - [ zloc f ] :type - :var -subedit-> arglists attributes - [ zloc & body ] :type - :macro -subedit->> arglists attributes - [ zloc & body ] :type - :macro -subedit-node arglists attributes - [ zloc f ] :type - :var -subzip arglists attributes - [ zloc ] :type - :var + rewrite-clj.zip.utils :no-doc = true +remove-and-move-left arglists attributes + [ [_ {} :as loc] ] :type + :var +remove-and-move-right arglists attributes + [ [_ {} :as loc] ] :type + :var +remove-and-move-up arglists attributes + [ loc ] :type + :var +remove-left arglists attributes + [ loc ] :type + :var +remove-left-while arglists attributes + [ zloc p? ] :type + :var +remove-right arglists attributes + [ loc ] :type + :var +remove-right-while arglists attributes + [ zloc p? ] :type + :var +remove-while arglists attributes + [ zloc p? ] :type + :var - rewrite-clj.zip.walk :no-doc = true -postwalk arglists attributes - [ zloc f ] - [ zloc p? f ] :type - :var -postwalk-subtree arglists attributes - [ p? f loc ] :type - :var -prewalk arglists attributes - [ zloc f ] - [ zloc p? f ] :type - :var ≠ rewrite-clj.zip.whitespace :no-doc - true ≠append-newline arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ≠append-space arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 +comment? arglists attributes + [ zloc ] :type + :var -insert-newline-left arglists attributes - [ zloc ] - [ zloc n ] :type - :var -insert-newline-right arglists attributes - [ zloc ] - [ zloc n ] :type - :var -insert-space-left arglists attributes - [ zloc ] - [ zloc n ] :type - :var -insert-space-right arglists attributes - [ zloc ] - [ zloc n ] :type - :var =linebreak? arglists attributes = [ zloc ] :type = :var ≠prepend-newline arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ≠prepend-space arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 =skip arglists attributes = [ f p? zloc ] :type = :var =skip-whitespace arglists attributes = [ zloc ] = [ f zloc ] :type = :var =skip-whitespace-left arglists attributes = [ zloc ] :type = :var +whitespace-not-linebreak? arglists attributes + [ zloc ] :type + :var =whitespace-or-comment? arglists attributes = [ zloc ] :type = :var =whitespace? arglists attributes = [ zloc ] :type = :var",
+   "Namespaced Elements Clojure docs describe namespaced elements but I did not see clear terms defined. Alex Miller helped out on Slack, I will use: term my shorthand keyword example map example unqualified :foo {:x 10} qualified :prefix-ns/foo #:prefix-ns{:a 1} auto-resolved current namespace qualified current-ns qualified ::foo #::{:b 2} auto-resolved namespace alias qualified ns-alias qualified ::ns-alias/foo #::ns-alias{:c 3} See: Jeaye’s blog for a refresher on namespaced keywords. CLJ-1910 for details on namespaced maps. Terminology and some history from Alex Miller Because the nuances of namespaced maps are not widely known by even the most experienced Clojure developers, I’ll paste a subset of CLJ-1910 examples here. The _ prefix and the fact that namespaced maps qualify symbols in addition to keywords is not widely understood: ;; same as above - notice you can nest #: maps and this is a case where the printer roundtrips\nuser=> #:person{:first \"Han\" :last \"Solo\" :ship #:ship{:name \"Millenium Falcon\" :model \"YT-1300f light freighter\"}}\n#:person{:first \"Han\" :last \"Solo\" :ship #:ship{:name \"Millenium Falcon\" :model \"YT-1300f light freighter\"}}\n\n;; effects on keywords with ns, without ns, with _ ns, and non-kw\nuser=> #:foo{:kw 1, :n/kw 2, :_/bare 3, 0 4}\n{:foo/kw 1, :n/kw 2, :bare 3, 0 4}\n\n;; auto-resolved namespaces (will use the current namespace, in this case, user as the ns)\nuser=> #::{:kw 1, :n/kw 2, :_/bare 3, 0 4}\n{:user/kw 1, :n/kw 2, :bare 3, 0 4}\n\n;; auto-resolve alias s to clojure.string\nuser=> (require '[clojure.string :as s])\nnil\nuser=> #::s{:kw 1, :n/kw 2, :_/bare 3, 0 4}\n{:clojure.string/kw 1, :n/kw 2, :bare 3, 0 4}\n\n;; to show symbol changes, we'll quote the whole thing to avoid evaluation\nuser=> '#::{a 1, n/b 2, _/c 3}\n{user/a 1, n/b 2, c 3} ClojureScript Flavors ClojureScript has two flavors for which I’ve not found definitive unique terms. I’ll use the following: term description Regular ClojureScript The regular old JVM compiled ClojureScript that most folks are familiar with. Self-hosted ClojureScript ClojureScript that is compiled by ClojureScript, also known as bootstrap ClojureScript. Self-hosted ClojureScript can make runtime use of features that are only available at compile time in Regular ClojureScript. Self-hosted ClojureScript behaves similarly to Clojure around namespaces. ",
+   :name "Namespaced Elements - Nomenclature",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_nomenclature"}
+  {:doc "",
+   :name
+   "Namespaced Elements - What happens now in rewrite-clj v0 and rewrite-cljs?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_what_happens_now_in_rewrite_clj_v0_and_rewrite_cljs"}
+  {:doc
+   "The sexpr function is used to convert a rewrite-clj node to a Clojure form. Clojure forms are more familiar and can be easier to work with than rewrite-clj nodes. Rewrite-clj’s sexpr is also used internally in functions like find-value, find-next-value and edit and some paredit functions inherited from rewrite-cljs. The following rewrite-clj nodes throw an exception for sexpr which is sensible and is as-designed. comment whitespace uneval, which is rewrite-clj’s term for #_ ",
+   :name "Namespaced Elements - General use of sexpr in rewrite-clj",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_general_use_of_sexpr_in_rewrite_clj"}
+  {:doc
+   "Auto-resolved keywords have been around since at least Clojure 1.0, which was released in May 2009. Namespaced maps were introduced in Clojure 1.9, released in December 2017. When you take into account that rewrite-clj was released in 2013 and rewrite-cljs in 2015, we can understand why support for newer features is spotty. element rewrite-clj v0 rewrite-cljs parse sexpr parse sexpr keyword qualified :prefix/foo supported supported supported supported current‑ns qualified ::foo supported supported, ⚠️ resolves via *ns* supported ⚠️ throws ns-alias qualified ::alias/foo supported ⚠️ incorrectly returns :alias/foo for ::alias/foo supported ⚠️ incorrectly returns :alias/foo for ::alias/foo map qualified #:prefix{:a 1} supported supported ⚠️ somewhat supported with generic reader macro node ⚠️ returns (read‑string \"#:prefix{:a 1}\") current‑ns qualified #::{:b 2} ⚠️ throws ⚠️ not applicable, can’t parse ⚠️ throws ⚠️ not applicable, can’t parse ns-alias qualified #::alias{:c 3} supported ⚠️ awkwardly supported, resolves via (ns‑aliases *ns*) ⚠️ somewhat supported with generic reader macro node ⚠️ returns (read‑string \"#::alias{:c 3}\") ",
+   :name
+   "Namespaced Elements - Sexpr support for namespaced elements in rewrite-clj v0 and rewrite-cljs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_sexpr_support_for_namespaced_elements_in_rewrite_clj_v0_and_rewrite_cljs"}
+  {:doc
+   "status ref option primary impact / notes ❌ rejected 1 Do nothing both Clojure and ClojureScript users can’t fully parse Clojure/ClojureScript code. ❌ rejected 2 Support parsing and writing, but throw on sexpr breaks existing API compatibility makes general navigation with certain rewrite-clj functions impossible ✅ current choice 3 Support parsing, writing. Have sexpr rely on user provided namespace info. seems like a good compromise ❌ rejected 4 Same as 3 but also ensure backward compatibility with current rewrite-clj implementation decided that backward compatibility for namespaced keywords sexpr is too awkward we’ll not entertain backward compatibility for namespaced maps ❌ rejected 5 Same as 4 but include a rudimentary namespace info resolver that parses namespace info from source had a good chat with borkdude on Slack and concluded that a namespace info resolver: is a potential rabbit hole (well, not potential - if only you knew the number of times I rewrote this section!) could be a separate concern that is addressed if there is a want/need in the future. Option #4 was a candidate, but decided against maintaining/explaining the complexity the current rewrite-clj implementation. ",
+   :name "Namespaced Elements - Options for rewrite-clj v1",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_options_for_rewrite_clj_v1"}
+  {:doc
+   "Parsing and writing namespaced elements seems relatively straightforward, but automatically parsing and returning a technically correct sexpr for auto-resolved namespaced elements is a rabbit hole that we’ll reject for now. Let’s tumble down the hole a bit to look at some of the complexities that auto-resolved namespaced elements include: The sexpr of a current-ns qualified element will be affected by the current namespace. The sexpr of an ns-alias qualified element will be affected by loaded namespaces aliases. The sexpr of any namespace element can be affected by reader conditionals: within ns declarations surrounding the form being sexpred which can be ambiguous in absence of parsing context of the Clojure platform (clj, cljs, cljr, sci) In turn, the current namespace can be affected by: ns declaration binding to *ns* in-ns Loaded namespace aliases can be affected by: ns declaration require outside ns declaration I expect that macros can be used for generation of at least some of the above elements. Other aspects I have not thought of. I see one example from the wild of an attempt to parse ns declarations from Clojure in cljfmt. Cljfmt can parse ns declarations from source code from which it extracts an alias map. While parsing ns declarations might work well for cljfmt, we won’t entertain it for rewrite-clj v1. ",
+   :name
+   "Namespaced Elements - The Rabbit Hole - Automatically Calculating sexpr for Auto-resolved Elements",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#sexpr-rabbit-hole"}
+  {:doc
+   "Rewrite-clj v1 can easily support sexpr on elements where the context is wholly contained in the form. Auto-resolved namespaced elements are different. They depend on context outside of the form; namely the current namespace and namespace aliases. Rewrite-clj v1 will: NOT take on evaluation of the Clojure code it is parsing to determine namespace info. It will be up to the caller to optionally specify the current namespace and namespace aliases. NOT offer any support for reader conditionals around caller provided namespace info caller specified namespace info will not distinguish for Clojure platforms (clj, cljs, cljr, sci) an sexpr for a namespaced element will NOT evaluate differently if it is wrapped in a reader conditional assume that callers will often have no real interest in an technically correct sexpr on auto-resolved namespaced elements. This means that it will return a result and not throw if the namespace info is not provided/available. break rewrite-clj compatibility for namespaced maps. It was a late and incomplete addition to rewrite-clj. The prefix will be stored in a new map-qualifier-node. Previously the prefix was stored as a keyword. Unlike rewrite-clj, rewrite-clj v1 will not call (ns-aliases *ns*) to lookup namespace aliases. break rewrite-clj compatibility for keywords: node field namespaced? will be renamed to be auto-resolved? to represent what it really is (a grep.app search suggests this won’t be impacting) will no longer do any lookups on ns. break compatibility for sexpr on some namespaced elements, in that it will: no longer throw for formerly unsupported variants have the possibility of returning a more correct Clojure form NOT preserve compatibility for sexpr under the following questionable scenarios, we’ll: NOT fall back to *ns* if the current namespace is not specified by caller. NOT return :alias/foo for ns-alias qualified keyword ::alias/foo when namespace aliases are not specified by caller. forgetting about sexpr, whatever implementation we choose, rewrite-clj v1 must continue to emit the same code as parsed. This should return true for any source we throw at rewrite-clj v1: (require '[rewrite-clj.zip :as z])\n(def source (slurp \"https://raw.githubusercontent.com/clj-kondo/clj-kondo/v2020.12.12/src/pod/borkdude/clj_kondo.clj\"))\n(= source (-> source z/of-string z/root-string))\n=> true + Note: an exception in equality might be newlines, which rewrite-clj v1 might normalize. ",
+   :name "Namespaced Elements - What will we do for rewrite-clj v1?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_what_will_we_do_for_rewrite_clj_v1"}
+  {:doc
+   "Rewrite-clj v1 supports the following Clojure platforms: Clojure Self-Hosted ClojureScript Regular ClojureScript It also supports Clojure source that includes a mix of the above in .cljc files. Our solution will cover all the above and also be verified when GraalVM natively compiled rewrite-clj v1 and a rewrite-clj v1 exposed via sci. ",
+   :name "Namespaced Elements - Platform Support",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_platform_support"}
+  {:doc
+   "The caller will optionally convey a namespace :auto-resolve function in opts map argument. The :auto-resolve function will take a single alias lookup arg, alias will be: :current for a request for the current namespace otherwise a request for a lookup for namespaced aliased by alias If not specified, :auto-resolve will default a function that resolves: the current namespace to ?_current-ns_? an aliased namespaced x to ??_x_?? The optionally opts arg will be added to the existing (rewrite-clj/node/sexpr node) If a caller wants their :auto-resolve function to make use of *ns* and/or (ns-aliases *ns*) that’s fine, but unlike rewrite-clj v0, rewrite-clj v1 will not reference *ns*. My guess is that the majority of rewrite-clj v1 users will not make use of :auto-resolve. Condition Result :auto-resolve not specified (require '[rewrite-clj.node :as n]\n         '[rewrite-clj.parser :as p])\n\n(-> (p/parse-string \"::foo\") n/sexpr)\n;; => :?_current-ns_?/foo\n(-> (p/parse-string \"#::{:a 1 :b 2}\") n/sexpr)\n;; => {:?_current-ns_?/a 1 :?_current-ns_?/b 2}\n(-> (p/parse-string \"::str/foo\") n/sexpr)\n;; => :??_str_??/foo\n(-> (p/parse-string \"#::str{:a 1 :b 2}\") n/sexpr)\n;; => {:??_str_??/a 1 :??_str_??/b 2} :auto-resolve specified (require '[rewrite-clj.node :as n]\n         '[rewrite-clj.parser :as p])\n\n(def opts {:auto-resolve (fn [alias]\n                            (get {:current 'my.current.ns\n                                  'str 'clojure.string}\n                                 alias\n                                 (symbol (str alias \"-unresolved\"))))})\n\n(-> (p/parse-string \"::foo\") (n/sexpr opts))\n;; => :my.current.ns/foo\n(-> (p/parse-string \"#::{:a 1 :b 2}\") (n/sexpr opts))\n;; => {:my.current.ns/a 1 :my.current.ns/b 2}\n(-> (p/parse-string \"::str/foo\") (n/sexpr opts))\n;; => :clojure.string/foo\n(-> (p/parse-string \"#::str{:a 1 :b 2}\") (n/sexpr opts))\n;; => {:clojure.string/a 1 :clojure.string/b 2} A benefit of :auto-resolve being a function rather than data, is flexibility. Maybe a caller would like the resolver to throw on an unresolved alias. Callers are free to code up whatever they need. ",
+   :name "Namespaced Elements - Sexpr Behaviour",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#sexpr-behavior"}
+  {:doc
+   "To support sexpr when navigating down to a key in a namespaced map, the key will hold the namespaced map context, namely a copy of the namespaced map qualifier. This context will appropriately applied to symbols and keyword keys in namespaced maps: at parse time when node children are updated The zip API applies updates when moving up through the zipper. The update includes replacing children. Therefore the context will be reapplied to namespaced map keys when moving up through the zipper. We’ll provide some mechanism for zipper users to reapply the context throughout the zipper. This will remove context from any keywords and symbols that are no longer under a namespaced map. Not sure what we’ll provide for non-zipper users. Perhaps just exposing a clear-map-context for keyword and symbol nodes would suffice. ",
+   :name "Namespaced Elements - Sexpr on a Key in a Namespaced Map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_sexpr_on_a_key_in_a_namespaced_map"}
+  {:doc
+   "The rewrite-clj.zip v0 API exposes functions that make use of sexpr: sexpr - directly exposes rewrite-clj.node/sexpr for the current node in zipper find-value - uses sexpr internally find-next-value - uses sexpr internally edit-node - uses sexpr internally get - uses find-value internally Most of these functions lend themselves to adding an optional opts map for our :auto-resolve. Unfortunately edit-node is variadic. Because all zip API functions operate on the zipper, I’m thinking that we could simply hold the :auto-resolve in the zipper. This idea is already in play to for :track-position?. ",
+   :name "Namespaced Elements - Sexpr Behaviour from the zip API",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_sexpr_behaviour_from_the_zip_api"}
+  {:doc
+   "The primary user of rewrite-clj’s node creation functions is the rewrite-clj parser. The functions are also exposed for general use. General usability might not have been a focus. ",
+   :name "Namespaced Elements - Node Creation",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_node_creation"}
+  {:doc
+   "We tweak rewrite-clj v0’s namespaced-map-node. The children will remain: prefix optional whitespace map The prefix will now be encoded as a new map-qualifier-node node which will have auto-resolved? and prefix fields. This cleanly and explicitly adds support for auto-resolve current-ns namespaced maps which will be expressed with auto-resolved? as true and a nil prefix. ",
+   :name "Namespaced Elements - Namespaced Map Node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_namespaced_map_node"}
+  {:doc
+   "The current way to create namespaced keyword nodes works, but usage is not entirely self-evident: (require '[rewrite-clj.node :as n])\n\n;; unqualified\n(n/keyword-node :foo false)           ;; => \":foo\"\n;; literally qualified\n(n/keyword-node :prefix-ns/foo false) ;; => \":prefix-ns/foo\"\n;; current-ns qualified\n(n/keyword-node :foo true)            ;; => \"::foo\"\n;; ns-alias qualified\n(n/keyword-node :ns-alias/foo true)   ;; => \"::ns-alias/foo\" Use of booleans in a function signature with more than one argument rarely contributes to readability but we’ll stick with these functions for backward compatibility. Let’s study the rewrite-clj v0 KeywordNode which currently has fields k and namespaced?. (require '[rewrite-clj.parser :as p]\n         '[rewrite-clj.node :as n])\n\n(-> (p/parse-string \":kw\") ((juxt :k :namespaced?)))\n;; => [:kw nil]\n(-> (p/parse-string \":qual/kw\") ((juxt :k :namespaced?)))\n;; => [:qual/kw nil]\n(-> (p/parse-string \"::kw\") ((juxt :k :namespaced?)))\n;; => [:kw true]\n(-> (p/parse-string \"::alias/kw\") ((juxt :k :namespaced?)))\n;; => [:alias/kw true] The namespaced? field is, in my opinion, misnamed and should be auto-resolved?. As of this writing a grep.app for :namespaced? returns only clj-kondo and it uses its own custom version of rewrite-clj. I think I could get away with renaming namespaced? to auto-resolved? for rewrite-clj v1 The prefix is not stored separately, it is glommed into keyword field k. This is ok for :qual/kw but, in my opinion, awkward for auto-resolved variants. We’ll preserve this storage behavior for backward compatibility. I will NOT look into adding a prefix field for consistency with maps at this time. ",
+   :name "Namespaced Elements - Keyword Node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_keyword_node"}
+  {:doc
+   "For rewrite-clj v1, we’ll separate out a new SymbolNode out from under rewrite-clj v0’s TokenNode. It is probably simplest to have the existing token-node creator fn simply create a SymbolNode when passed value is a Clojure symbol. ",
+   :name "Namespaced Elements - Symbol Node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_symbol_node"}
+  {:doc
+   "In rewrite-clj v1, the SymbolNode and KeywordNode will be MapQualifiable. This means they will have (set-map-context map-qualifier-node) and (clear-map-context) functions. I don’t think we need to expose the methods to our APIs but am not sure yet. If we do, we might need a (get-map-context). Why not just update/retrieve via the map-qualifier-node node field? Clojure turns a record into a map when a dissoc is done on a field, and I think abstracting away from that nuance makes sense. ",
+   :name "Namespaced Elements - Symbol and Keyword Context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_symbol_and_keyword_context"}
+  {:doc
+   "Keyword node traversal will remain unchanged (no new child nodes). Namespaced map node traversal remains unchanged except: The prefix is now stored as a map-qualifier-node, in rewrite-clj the prefix was encoded in a keyword. ",
+   :name "Namespaced Elements - Node Traversal",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_node_traversal"}
+  {:doc
+   "keyword-node? - return true if rewrite-clj node and keyword node symbol-node? - return true if rewrite-clj node and symbol node Both keyword-node and map-qualifier-node will have: auto-resolved? field ",
+   :name "Namespaced Elements - Node Interrogation",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_node_interrogation"}
+  {:doc
+   "Rewrite-clj supports automatic coercion, how does this look in the context of namespaced elements? I’m not proposing any changes here, just demonstrating how things work. If we try to explicitly coerce a namespaced element, we must remember that the Clojure reader will first evaluate in the context of the current ns before the element is converted to a node. (require '[clojure.string :as str]\n         '[rewrite-clj.node :as n])\n\n(-> (n/coerce :user/foo) n/string) ;; => \":user/foo\"\n(-> (n/coerce ::foo) n/string) ;; => \":user/foo\"\n(-> (n/coerce ::str/foo) n/string) ;; => \":clojure.string/foo\" For namespaced maps, the experience is the same: (require '[clojure.string :as str]\n         '[rewrite-clj.node :as n])\n\n(-> (n/coerce #:user{:a 1}) n/string) ;; => \"{:user/a 1}\"\n(-> (n/coerce #::{:b 2}) n/string)  ;; => \"{:user/b 2}\"\n(-> (n/coerce #::str{:c 3}) n/string) ;; => \"{:clojure.string/c 3}\" ",
+   :name "Namespaced Elements - Notes on Coercion",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_notes_on_coercion"}
+  {:doc
+   "Questions I had while writing doc. Q: Does the act of using find-value sometimes blow up if hitting an element that is not sexpressable? A: Nope, find-value only searches token nodes and token nodes are always sexpressable (well after we are done our work they should be). ",
+   :name "Namespaced Elements - Misc Questions",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/merging-rewrite-clj-and-rewrite-cljs/namespaced-elements#_misc_questions"}
+  {:doc
+   "Diff of rewrite-clj 0.6.1 clj & rewrite-cljs 0.4.5 cljs Diff of apis in: rewrite-clj 0.6.1 clj rewrite-cljs 0.4.5 cljs Options: Option Value :arglists-by :arity-only :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 20 15 8 publics 100 170 79 arglists 0 298 88 Notes: The apis of the last released version of rewrite-cljs and the last released version of rewrite-clj v0 are compared here. In short, rewrite-cljs lagged far behind rewrite-clj v0, but rewrite-cljs had added some features of its own. See rewrite-clj v1’s design docs for more details. Table of diffs: - rewrite-clj.custom-zipper.core -append-child -branch? -children -custom-zipper -custom-zipper? -down -edit -end? -insert-child -insert-left -insert-right -left -leftmost -lefts -make-node -next -node -position -prev -remove -replace -right -rightmost -root -up -zipper - rewrite-clj.custom-zipper.utils -remove-and-move-left -remove-and-move-right -remove-left -remove-left-while -remove-right -remove-right-while ≠ rewrite-clj.node ≠child-sexprs ≠children ≠coerce -comma-node -comma-separated -comma? ≠comment-node ≠comment? -concat-strings ≠deref-node ≠eval-node ≠fn-node ≠forms-node ≠inner? -integer-node ≠keyword-node -leader-length ≠length -line-separated ≠linebreak? ≠list-node ≠map-node ≠meta-node -namespaced-map-node ≠newline-node ≠newlines ≠printable-only? ≠quote-node -raw-meta-node ≠reader-macro-node -regex-node ≠replace-children ≠set-node ≠sexpr -sexprs ≠spaces ≠string ≠string-node ≠syntax-quote-node ≠tag ≠token-node ≠uneval-node ≠unquote-node ≠unquote-splicing-node -value ≠var-node ≠vector-node ≠whitespace-node -whitespace-nodes ≠whitespace? - rewrite-clj.node.coerce + rewrite-clj.node.coercer +node-with-meta +seq-node ≠ rewrite-clj.node.comment =comment-node =comment? =CommentNode ≠ rewrite-clj.node.forms =forms-node =FormsNode - rewrite-clj.node.indent -indent-spaces -indent-tabs -LinePrefixedNode -prefix-lines - rewrite-clj.node.integer -integer-node -IntNode ≠ rewrite-clj.node.keyword =keyword-node =KeywordNode ≠ rewrite-clj.node.meta =meta-node =MetaNode =raw-meta-node ≠ rewrite-clj.node.protocols -+extent ≠assert-sexpr-count ≠assert-single-sexpr ≠concat-strings -extent ≠InnerNode -make-printable! ≠sum-lengths -write-node - rewrite-clj.node.regex -regex-node -RegexNode ≠ rewrite-clj.node.seq =list-node =map-node -namespaced-map-node -NamespacedMapNode =SeqNode =set-node =vector-node +wrap-list +wrap-map +wrap-set +wrap-vec - rewrite-clj.node.string -string-node -StringNode + rewrite-clj.node.stringz +string-node +StringNode ≠ rewrite-clj.node.token ≠token-node =TokenNode ≠ rewrite-clj.node.whitespace =*count-fn* =*newline-fn* -comma-node =comma-separated -comma? -CommaNode =line-separated =linebreak? =newline-node =NewlineNode =newlines =space-separated =spaces =whitespace-node =whitespace-nodes =whitespace? =WhitespaceNode -with-count-fn -with-newline-fn + rewrite-clj.paredit +barf-backward +barf-forward +join +kill +kill-at-pos +kill-one-at-pos +move-n +move-to-prev +raise +slurp-backward +slurp-backward-fully +slurp-forward +slurp-forward-fully +splice +splice-killing-backward +splice-killing-forward +split +split-at-pos +wrap-around +wrap-fully-forward-slurp ≠ rewrite-clj.parser -parse-file -parse-file-all ≠ rewrite-clj.parser.core =parse-next ≠ rewrite-clj.parser.keyword =parse-keyword ≠ rewrite-clj.parser.string =parse-regex =parse-string ≠ rewrite-clj.parser.token =parse-token - rewrite-clj.parser.utils -ignore -linebreak? -read-eol -space? -throw-reader -whitespace? ≠ rewrite-clj.parser.whitespace =parse-whitespace - rewrite-clj.potemkin -defprotocol+ -import-def -import-fn -import-macro -import-vars -link-vars ≠ rewrite-clj.reader =boundary? +buf -comma? -file-reader +get-column-number +get-line-number =ignore +indexing-push-back-reader =linebreak? =next =peek +peek-char -position +read-char =read-include-linebreak +read-keyword =read-n =read-repeatedly +read-string =read-until ≠read-while =read-with-meta =space? =string->edn -string-reader =throw-reader ≠unread =whitespace-or-boundary? =whitespace? ≠ rewrite-clj.zip -->root-string -->string ≠append-child -append-newline -append-space ≠assoc -child-sexprs ≠down -down* ≠edit -edit* -edit-> -edit->> -edit-node -edn -edn* ≠end? ≠find ≠find-depth-first +find-last-by-pos ≠find-next ≠find-next-depth-first ≠find-next-tag ≠find-next-token ≠find-next-value ≠find-tag +find-tag-by-pos ≠find-token ≠find-value ≠get ≠insert-child ≠insert-left -insert-left* ≠insert-right -insert-right* ≠left -left* ≠leftmost -leftmost* ≠leftmost? -length -linebreak? ≠list? ≠map ≠map-keys ≠map-vals ≠map? ≠next -next* ≠node -of-file ≠of-string -position -postwalk ≠prefix -prepend-newline -prepend-space ≠prev -prev* -prewalk -print -print-root ≠remove -remove* +remove-preserve-newline ≠replace -replace* ≠right -right* ≠rightmost -rightmost* ≠rightmost? ≠root ≠root-string ≠seq? ≠set? ≠sexpr -skip -skip-whitespace -skip-whitespace-left ≠splice ≠string -subedit-> -subedit->> -subedit-node ≠suffix ≠tag ≠up -up* -value ≠vector? -whitespace-or-comment? -whitespace? ≠ rewrite-clj.zip.base =child-sexprs ≠edn ≠edn* =length -of-file ≠of-string -print -print-root =root-string =sexpr =string =tag -value - rewrite-clj.zip.edit -edit -prefix -replace -splice -suffix + rewrite-clj.zip.editz +edit +prefix +replace +splice +suffix - rewrite-clj.zip.find -find -find-depth-first -find-next -find-next-depth-first -find-next-tag -find-next-token -find-next-value -find-tag -find-token -find-value + rewrite-clj.zip.findz +find +find-depth-first +find-last-by-pos +find-next +find-next-depth-first +find-next-tag +find-next-token +find-next-value +find-tag +find-tag-by-pos +find-token +find-value +in-range? ≠ rewrite-clj.zip.move =down =end? =left =leftmost =leftmost? =next =prev =right =rightmost =rightmost? =up - rewrite-clj.zip.remove -remove + rewrite-clj.zip.removez +remove +remove-preserve-newline - rewrite-clj.zip.seq -assoc -get -list? -map -map-keys -map-vals -map? -seq? -set? -vector? + rewrite-clj.zip.seqz +assoc +get +list? +map +map-keys +map-vals +map? +seq? +set? +vector? - rewrite-clj.zip.subedit -edit-> -edit->> -edit-node -subedit-> -subedit->> -subedit-node -subzip + rewrite-clj.zip.utils +remove-and-move-left +remove-and-move-right +remove-and-move-up +remove-left +remove-left-while +remove-right +remove-right-while +remove-while - rewrite-clj.zip.walk -postwalk -postwalk-subtree -prewalk ≠ rewrite-clj.zip.whitespace ≠append-newline ≠append-space +comment? -insert-newline-left -insert-newline-right -insert-space-left -insert-space-right =linebreak? ≠prepend-newline ≠prepend-space =skip =skip-whitespace =skip-whitespace-left +whitespace-not-linebreak? =whitespace-or-comment? =whitespace? ",
    :name "rwt-clj v0 vs rwt-cljs",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs"}
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.custom-zipper.core",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_custom_zipper_core"}
+  {:doc "arglists attributes - [ G__2836 G__2837 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -append-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_append_child"}
+  {:doc "arglists attributes - [ G__2769 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -branch?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_branch"}
+  {:doc "arglists attributes - [ G__2772 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -children",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_children"}
+  {:doc "arglists attributes - [ root ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -custom-zipper",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_custom_zipper"}
+  {:doc "arglists attributes - [ value ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -custom-zipper?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_custom_zipper_2"}
+  {:doc "arglists attributes - [ G__2782 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -down",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_down"}
+  {:doc "arglists attributes - [ loc f & args ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit"}
+  {:doc "arglists attributes - [ G__2851 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -end?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_end"}
+  {:doc "arglists attributes - [ G__2833 G__2834 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_child"}
+  {:doc "arglists attributes - [ G__2821 G__2822 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_left"}
+  {:doc "arglists attributes - [ G__2825 G__2826 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_right"}
+  {:doc "arglists attributes - [ G__2807 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_left"}
+  {:doc "arglists attributes - [ G__2814 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -leftmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_leftmost"}
+  {:doc "arglists attributes - [ G__2780 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -lefts",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_lefts"}
   {:doc
-   "Diff of rewrite-clj 0.6.1 & 1.0.0-alpha Diff of apis in: rewrite-clj 0.6.1 clj rewrite-clj 1.0.0-alpha clj Options: Option Value :arglists-by :arity-only :exclude-namespaces [\"rewrite-clj\"\n \"rewrite-clj.potemkin\"\n \"rewrite-clj.custom-zipper.switchable\"\n \"rewrite-clj.interop\"] :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 16 3 11 publics 37 14 110 arglists 0 29 163 Notes: The api of the last released version of rewrite-clj v0 was used as a reference for rewrite-clj v1. As such, you’ll notice the apis are almost the same. I assume that rewrite-clj.custom-zipper.core is internal and marked it as such with :no-doc. There were some features unique to rewrite-cljs (such as paredit and some positional searching) which were brought over to rewrite-clj v1. The internal rewrite-cljs namespaces that were renamed to avoid cljs namespace collisions also occur in the clj side of rewrite-clj v1. All other differences are considered internal refactorings. Table of diffs: ≠ rewrite-clj.custom-zipper.core =append-child =branch? =children ≠custom-zipper ≠custom-zipper? =down =edit =end? =insert-child =insert-left =insert-right =left =leftmost =lefts ≠make-node =next =node =position +position-span =prev =remove =replace =right =rightmost =root =up ≠zipper ≠ rewrite-clj.custom-zipper.utils +remove-and-move-up ≠ rewrite-clj.node ≠child-sexprs -concat-strings ≠keyword-node +keyword-node? +map-context-apply +map-context-clear +map-qualifier-node +node? ≠sexpr +sexpr-able? ≠sexprs +symbol-node? ≠token-node - rewrite-clj.node.coerce + rewrite-clj.node.coercer +node-with-meta + rewrite-clj.node.extras +whitespace-or-comment? - rewrite-clj.node.indent -indent-spaces -indent-tabs -LinePrefixedNode -prefix-lines ≠ rewrite-clj.node.keyword ≠keyword-node +keyword-node? +keyword-sexpr +kw-qualifier + rewrite-clj.node.namespaced-map +map-qualifier-node +MapQualifierNode +namespaced-map-node +NamespacedMapNode +reapply-namespaced-map-context ≠ rewrite-clj.node.protocols ≠+extent ≠assert-sexpr-count ≠assert-single-sexpr ≠child-sexprs ≠concat-strings +default-auto-resolve ≠extent =InnerNode ≠make-printable! +make-printable-clj! +MapQualifiable +meta-elided ≠Node +node? =NodeCoerceable +sexpr +sexpr-able? ≠sexprs ≠sum-lengths +value +without-whitespace ≠write-node ≠ rewrite-clj.node.regex +pattern-string-for-regex ≠ rewrite-clj.node.seq -namespaced-map-node -NamespacedMapNode ≠ rewrite-clj.node.string -StringNode + rewrite-clj.node.stringz +string-node +StringNode ≠ rewrite-clj.node.token +symbol-node? +SymbolNode ≠token-node + rewrite-clj.paredit +barf-backward +barf-forward +join +kill +kill-at-pos +kill-one-at-pos +move-to-prev +raise +slurp-backward +slurp-backward-fully +slurp-forward +slurp-forward-fully +splice +splice-killing-backward +splice-killing-forward +split +split-at-pos +wrap-around +wrap-fully-forward-slurp ≠ rewrite-clj.parser ≠parse ≠parse-all + rewrite-clj.parser.namespaced-map +parse-namespaced-map - rewrite-clj.parser.utils -ignore -linebreak? -read-eol -space? -throw-reader -whitespace? ≠ rewrite-clj.reader +newline-normalizing-reader +read-keyword ≠read-while ≠ rewrite-clj.zip +append-child* ≠append-newline ≠append-space +find-last-by-pos +find-tag-by-pos +insert-child* +insert-newline-left +insert-newline-right +insert-space-left +insert-space-right +namespaced-map? +position-span ≠prepend-newline ≠prepend-space ≠print ≠print-root +reapply-context +remove-preserve-newline +sexpr-able? +subzip ≠ rewrite-clj.zip.base +->root-string +->string +get-opts ≠print ≠print-root +set-opts +sexpr-able? + rewrite-clj.zip.context +reapply-context + rewrite-clj.zip.editz +edit +prefix +replace +splice +suffix ≠ rewrite-clj.zip.find +find-last-by-pos +find-tag-by-pos + rewrite-clj.zip.findz +find +find-depth-first +find-last-by-pos +find-next +find-next-depth-first +find-next-tag +find-next-token +find-next-value +find-tag +find-tag-by-pos +find-token +find-value ≠ rewrite-clj.zip.remove +remove-preserve-newline + rewrite-clj.zip.removez +remove +remove-preserve-newline + rewrite-clj.zip.seqz +assoc +get +list? +map +map-keys +map-vals +map? +namespaced-map? +seq? +set? +vector? ≠ rewrite-clj.zip.whitespace ≠append-newline ≠append-space +comment? ≠prepend-newline ≠prepend-space +whitespace-not-linebreak? ≠ rewrite-clj.custom-zipper.core :no-doc + true =append-child arglists attributes = [ G__2836 G__2837 ] :type = :var =branch? arglists attributes = [ G__2769 ] :type = :var =children arglists attributes = [ G__2772 ] :type = :var ≠custom-zipper arglists attributes = [ root ] :type = :var :no-doc - true ≠custom-zipper? arglists attributes = [ value ] :type = :var :no-doc - true =down arglists attributes = [ G__2782 ] :type = :var =edit arglists attributes = [ loc f & args ] :type = :var =end? arglists attributes = [ G__2851 ] :type = :var =insert-child arglists attributes = [ G__2833 G__2834 ] :type = :var =insert-left arglists attributes = [ G__2821 G__2822 ] :type = :var =insert-right arglists attributes = [ G__2825 G__2826 ] :type = :var =left arglists attributes = [ G__2807 ] :type = :var =leftmost arglists attributes = [ G__2814 ] :type = :var =lefts arglists attributes = [ G__2780 ] :type = :var ≠make-node arglists attributes = [ G__2775 G__2776 G__2777 ] :type = :var :no-doc - true =next arglists attributes = [ G__2839 ] :type = :var =node arglists attributes = [ G__2766 ] :type = :var =position arglists attributes = [ loc ] :type = :var +position-span arglists attributes + [ zloc ] :type + :var =prev arglists attributes = [ G__2846 ] :type = :var =remove arglists attributes = [ G__2853 ] :type = :var =replace arglists attributes = [ G__2829 G__2830 ] :type = :var =right arglists attributes = [ G__2797 ] :type = :var =rightmost arglists attributes = [ G__2804 ] :type = :var =root arglists attributes = [ G__2794 ] :type = :var =up arglists attributes = [ G__2791 ] :type = :var ≠zipper arglists attributes = [ root ] :type = :var :no-doc - true ≠ rewrite-clj.custom-zipper.utils :no-doc = true +remove-and-move-up arglists attributes + [ loc ] :type + :var ≠ rewrite-clj.node ≠child-sexprs arglists attributes = [ node ] + [ node opts ] :type = :var -concat-strings arglists attributes - [ nodes ] :type - :var :no-doc - true ≠keyword-node arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var +keyword-node? arglists attributes + [ n ] :type + :var +map-context-apply arglists attributes + [ node map-qualifier ] :type + :var +map-context-clear arglists attributes + [ node ] :type + :var +map-qualifier-node arglists attributes + [ auto-resolved? prefix ] :type + :var +node? arglists attributes + [ x ] :type + :var ≠sexpr arglists attributes = [ _ ] + [ node opts ] :type = :var +sexpr-able? arglists attributes + [ node ] :type + :var ≠sexprs arglists attributes = [ nodes ] + [ nodes opts ] :type = :var +symbol-node? arglists attributes + [ n ] :type + :var ≠token-node arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var - rewrite-clj.node.coerce :no-doc = true + rewrite-clj.node.coercer :no-doc = true +node-with-meta arglists attributes + [ n value ] :type + :var + rewrite-clj.node.extras :no-doc = true +whitespace-or-comment? arglists attributes + [ node ] :type + :var - rewrite-clj.node.indent :no-doc = true -indent-spaces arglists attributes - [ node n ] :type - :var -indent-tabs arglists attributes - [ node n ] :type - :var -LinePrefixedNode attributes :type - :var -prefix-lines arglists attributes - [ node prefix ] :type - :var ≠ rewrite-clj.node.keyword :no-doc = true ≠keyword-node arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var +keyword-node? arglists attributes + [ n ] :type + :var +keyword-sexpr arglists attributes + [ kw kw-auto-resolved? map-qualifier {} ] :type + :var +kw-qualifier arglists attributes + [ k auto-resolved? ] :type + :var + rewrite-clj.node.namespaced-map :no-doc = true +map-qualifier-node arglists attributes + [ auto-resolved? prefix ] :type + :var +MapQualifierNode attributes :type + :var +namespaced-map-node arglists attributes + [ children ] :type + :var +NamespacedMapNode attributes :type + :var +reapply-namespaced-map-context arglists attributes + [ n ] :type + :var ≠ rewrite-clj.node.protocols :no-doc + true ≠+extent arglists attributes = [ [row col] [row-extent col-extent] ] :type = :var :no-doc - true ≠assert-sexpr-count arglists attributes = [ nodes c ] :type = :var :no-doc - true ≠assert-single-sexpr arglists attributes = [ nodes ] :type = :var :no-doc - true ≠child-sexprs arglists attributes = [ node ] + [ node opts ] :type = :var ≠concat-strings arglists attributes = [ nodes ] :type = :var :no-doc - true +default-auto-resolve arglists attributes + [ alias ] :type + :var ≠extent arglists attributes = [ node ] :type = :var :no-doc - true =InnerNode attributes members name arglists attributes :type = :protocol = children = [ _ ] :type = :var = inner? = [ _ ] :type = :var = leader-length = [ _ ] :type = :var = replace-children = [ _ children ] :type = :var ≠make-printable! arglists attributes = [ class ] :type = :macro :no-doc - true +make-printable-clj! arglists attributes + [ class ] :type + :macro +MapQualifiable attributes members name arglists attributes :type + :protocol + map-context-apply + [ node map-qualifier ] :type + :var + map-context-clear + [ node ] :type + :var +meta-elided arglists attributes + [ form ] :type + :var ≠Node attributes members name arglists attributes :type = :protocol = length = [ _ ] :type = :var + node-type + [ node ] :type + :var = printable-only? = [ _ ] :type = :var - sexpr - [ _ ] :type - :var + sexpr* + [ node opts ] :type + :var = string = [ _ ] :type = :var = tag = [ _ ] :type = :var +node? arglists attributes + [ x ] :type + :var =NodeCoerceable attributes members name arglists attributes :type = :protocol = coerce = [ _ ] :type = :var +sexpr arglists attributes + [ node ] + [ node opts ] :type + :var +sexpr-able? arglists attributes + [ node ] :type + :var ≠sexprs arglists attributes = [ nodes ] + [ nodes opts ] :type = :var ≠sum-lengths arglists attributes = [ nodes ] :type = :var :no-doc - true +value arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 +without-whitespace arglists attributes + [ nodes ] :type + :var ≠write-node arglists attributes = [ writer node ] :type = :var :no-doc - true ≠ rewrite-clj.node.regex :no-doc = true +pattern-string-for-regex arglists attributes + [ regex ] :type + :var ≠ rewrite-clj.node.seq :no-doc = true -namespaced-map-node arglists attributes - [ children ] :type - :var -NamespacedMapNode attributes :type - :var ≠ rewrite-clj.node.string :no-doc = true -StringNode attributes :type - :var + rewrite-clj.node.stringz :no-doc = true +string-node arglists attributes + [ lines ] :type + :var +StringNode attributes :type + :var ≠ rewrite-clj.node.token :no-doc = true +symbol-node? arglists attributes + [ n ] :type + :var +SymbolNode attributes :type + :var ≠token-node arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var + rewrite-clj.paredit +barf-backward arglists attributes + [ zloc ] :type + :var +barf-forward arglists attributes + [ zloc ] :type + :var +join arglists attributes + [ zloc ] :type + :var +kill arglists attributes + [ zloc ] :type + :var +kill-at-pos arglists attributes + [ zloc pos ] :type + :var +kill-one-at-pos arglists attributes + [ zloc pos ] :type + :var +move-to-prev arglists attributes + [ zloc ] :type + :var +raise arglists attributes + [ zloc ] :type + :var +slurp-backward arglists attributes + [ zloc ] :type + :var +slurp-backward-fully arglists attributes + [ zloc ] :type + :var +slurp-forward arglists attributes + [ zloc ] :type + :var +slurp-forward-fully arglists attributes + [ zloc ] :type + :var +splice attributes :type + :var +splice-killing-backward arglists attributes + [ zloc ] :type + :var +splice-killing-forward arglists attributes + [ zloc ] :type + :var +split arglists attributes + [ zloc ] :type + :var +split-at-pos arglists attributes + [ zloc pos ] :type + :var +wrap-around arglists attributes + [ zloc t ] :type + :var +wrap-fully-forward-slurp arglists attributes + [ zloc t ] :type + :var ≠ rewrite-clj.parser ≠parse arglists attributes = [ reader ] :type = :var :no-doc + true ≠parse-all arglists attributes = [ reader ] :type = :var :no-doc + true + rewrite-clj.parser.namespaced-map :no-doc = true +parse-namespaced-map arglists attributes + [ reader read-next ] :type + :var - rewrite-clj.parser.utils :no-doc = true -ignore arglists attributes - [ reader ] :type - :var -linebreak? arglists attributes - [ c ] :type - :var -read-eol arglists attributes - [ reader ] :type - :var -space? arglists attributes - [ c ] :type - :var -throw-reader arglists attributes - [ reader & msg ] :type - :var -whitespace? arglists attributes - [ c ] :type - :var ≠ rewrite-clj.reader :no-doc = true +newline-normalizing-reader arglists attributes + [ rdr ] :type + :var +read-keyword arglists attributes + [ reader ] :type + :var ≠read-while arglists attributes + [ reader p? ] + [ reader p? eof? ] - [ reader p? & [eof?] ] :type = :var ≠ rewrite-clj.zip +append-child* arglists attributes + [ zloc item ] :type + :var ≠append-newline arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ≠append-space arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 +find-last-by-pos arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var +find-tag-by-pos arglists attributes + [ zloc pos t ] :type + :var +insert-child* arglists attributes + [ zloc item ] :type + :var +insert-newline-left arglists attributes + [ zloc ] + [ zloc n ] :type + :var +insert-newline-right arglists attributes + [ zloc ] + [ zloc n ] :type + :var +insert-space-left arglists attributes + [ zloc ] + [ zloc n ] :type + :var +insert-space-right arglists attributes + [ zloc ] + [ zloc n ] :type + :var +namespaced-map? arglists attributes + [ zloc ] :type + :var +position-span arglists attributes + [ zloc ] :type + :var ≠prepend-newline arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ≠prepend-space arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ≠print arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ≠print-root arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var +reapply-context arglists attributes + [ zloc ] :type + :var +remove-preserve-newline arglists attributes + [ zloc ] :type + :var +sexpr-able? arglists attributes + [ zloc ] :type + :var +subzip arglists attributes + [ zloc ] :type + :var ≠ rewrite-clj.zip.base :no-doc = true +->root-string arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 +->string arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 +get-opts arglists attributes + [ zloc ] :type + :var ≠print arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ≠print-root arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var +set-opts arglists attributes + [ zloc opts ] :type + :var +sexpr-able? arglists attributes + [ zloc ] :type + :var + rewrite-clj.zip.context :no-doc = true +reapply-context arglists attributes + [ zloc ] :type + :var + rewrite-clj.zip.editz :no-doc = true +edit arglists attributes + [ zloc f & args ] :type + :var +prefix arglists attributes + [ zloc s ] :type + :var +replace arglists attributes + [ zloc value ] :type + :var +splice arglists attributes + [ zloc ] :type + :var +suffix arglists attributes + [ zloc s ] :type + :var ≠ rewrite-clj.zip.find :no-doc = true +find-last-by-pos arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var +find-tag-by-pos arglists attributes + [ zloc pos t ] :type + :var + rewrite-clj.zip.findz :no-doc = true +find arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-depth-first arglists attributes + [ zloc p? ] :type + :var +find-last-by-pos arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var +find-next arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-next-depth-first arglists attributes + [ zloc p? ] :type + :var +find-next-tag arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var +find-next-token arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-next-value arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var +find-tag arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var +find-tag-by-pos arglists attributes + [ zloc pos t ] :type + :var +find-token arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-value arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ≠ rewrite-clj.zip.remove :no-doc = true +remove-preserve-newline arglists attributes + [ zloc ] :type + :var + rewrite-clj.zip.removez :no-doc = true +remove arglists attributes + [ zloc ] :type + :var +remove-preserve-newline arglists attributes + [ zloc ] :type + :var + rewrite-clj.zip.seqz :no-doc = true +assoc arglists attributes + [ zloc k v ] :type + :var +get arglists attributes + [ zloc k ] :type + :var +list? arglists attributes + [ zloc ] :type + :var +map arglists attributes + [ f zloc ] :type + :var +map-keys arglists attributes + [ f zloc ] :type + :var +map-vals arglists attributes + [ f zloc ] :type + :var +map? arglists attributes + [ zloc ] :type + :var +namespaced-map? arglists attributes + [ zloc ] :type + :var +seq? arglists attributes + [ zloc ] :type + :var +set? arglists attributes + [ zloc ] :type + :var +vector? arglists attributes + [ zloc ] :type + :var ≠ rewrite-clj.zip.whitespace :no-doc = true ≠append-newline arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ≠append-space arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 +comment? arglists attributes + [ zloc ] :type + :var ≠prepend-newline arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ≠prepend-space arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 +whitespace-not-linebreak? arglists attributes + [ zloc ] :type + :var",
+   "arglists attributes - [ G__2775 G__2776 G__2777 ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -make-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_make_node"}
+  {:doc "arglists attributes - [ G__2839 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_next"}
+  {:doc "arglists attributes - [ G__2766 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_node"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -position",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_position"}
+  {:doc "arglists attributes - [ G__2846 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prev"}
+  {:doc "arglists attributes - [ G__2853 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove"}
+  {:doc "arglists attributes - [ G__2829 G__2830 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_replace"}
+  {:doc "arglists attributes - [ G__2797 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_right"}
+  {:doc "arglists attributes - [ G__2804 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -rightmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rightmost"}
+  {:doc "arglists attributes - [ G__2794 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_root"}
+  {:doc "arglists attributes - [ G__2791 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_up"}
+  {:doc "arglists attributes - [ root ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -zipper",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_zipper"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.custom-zipper.utils",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_custom_zipper_utils"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove-and-move-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_and_move_left"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove-and-move-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_and_move_right"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_left"}
+  {:doc "arglists attributes - [ zloc p? ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove-left-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_left_while"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_right"}
+  {:doc "arglists attributes - [ zloc p? ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove-right-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_right_while"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node"}
+  {:doc "arglists attributes - [ node ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_child_sexprs"}
+  {:doc "arglists attributes - [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠children",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_children_2"}
+  {:doc "arglists attributes - [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠coerce",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_coerce"}
+  {:doc "arglists attributes - [ s ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -comma-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comma_node"}
+  {:doc "arglists attributes - [ nodes ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -comma-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comma_separated"}
+  {:doc "arglists attributes - [ node ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -comma?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comma"}
+  {:doc "arglists attributes - [ s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠comment-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comment_node"}
+  {:doc "arglists attributes - [ node ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comment"}
+  {:doc "arglists attributes - [ nodes ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -concat-strings",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_concat_strings"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠deref-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_deref_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠eval-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_eval_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠fn-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_fn_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠forms-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_forms_node"}
+  {:doc "arglists attributes - [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠inner?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_inner"}
+  {:doc
+   "arglists attributes - [ value ] - [ value base ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -integer-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_integer_node"}
+  {:doc "arglists attributes - [ k & [namespaced?] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠keyword-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_keyword_node"}
+  {:doc "arglists attributes - [ _ ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -leader-length",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_leader_length"}
+  {:doc "arglists attributes - [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠length",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_length"}
+  {:doc "arglists attributes - [ nodes ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -line-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_line_separated"}
+  {:doc "arglists attributes - [ node ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_linebreak"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠list-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_list_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_node"}
+  {:doc
+   "arglists attributes - [ children ] - [ metadata data ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠meta-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_meta_node"}
+  {:doc "arglists attributes - [ children ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -namespaced-map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_namespaced_map_node"}
+  {:doc "arglists attributes - [ s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠newline-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_newline_node"}
+  {:doc "arglists attributes - [ n ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠newlines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_newlines"}
+  {:doc "arglists attributes - [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠printable-only?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_printable_only"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠quote-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_quote_node"}
+  {:doc
+   "arglists attributes - [ children ] - [ metadata data ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -raw-meta-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_raw_meta_node"}
+  {:doc
+   "arglists attributes - [ children ] - [ macro-node form-node ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠reader-macro-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_reader_macro_node"}
+  {:doc "arglists attributes - [ pattern-string ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -regex-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_regex_node"}
+  {:doc "arglists attributes - [ _ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠replace-children",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_replace_children"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠set-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_set_node"}
+  {:doc "arglists attributes - [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_sexpr"}
+  {:doc "arglists attributes - [ nodes ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_sexprs"}
+  {:doc "arglists attributes - [ n ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠spaces",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_spaces"}
+  {:doc "arglists attributes - [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string"}
+  {:doc "arglists attributes - [ lines ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠string-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠syntax-quote-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_syntax_quote_node"}
+  {:doc "arglists attributes - [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_tag"}
+  {:doc
+   "arglists attributes - [ value & [string-value] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠token-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_token_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠uneval-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_uneval_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠unquote-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_unquote_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠unquote-splicing-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_unquote_splicing_node"}
+  {:doc
+   "arglists attributes - [ node ] :type - :var :deprecated - 0.4.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_value"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠var-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_var_node"}
+  {:doc "arglists attributes - [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠vector-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_vector_node"}
+  {:doc "arglists attributes - [ s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠whitespace-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_node"}
+  {:doc "arglists attributes - [ s ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -whitespace-nodes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_nodes"}
+  {:doc "arglists attributes - [ node ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.node.coerce",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_coerce"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.node.coercer",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_coercer"}
+  {:doc "arglists attributes + [ n value ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +node-with-meta",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_node_with_meta"}
+  {:doc "arglists attributes + [ f sq ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +seq-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_seq_node"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node.comment",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_comment"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =comment-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comment_node_2"}
+  {:doc "arglists attributes = [ node ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comment_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =CommentNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_commentnode"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node.forms",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_forms"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =forms-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_forms_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =FormsNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_formsnode"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.node.indent",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_indent"}
+  {:doc "arglists attributes - [ node n ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -indent-spaces",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_indent_spaces"}
+  {:doc "arglists attributes - [ node n ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -indent-tabs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_indent_tabs"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -LinePrefixedNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_lineprefixednode"}
+  {:doc "arglists attributes - [ node prefix ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -prefix-lines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prefix_lines"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.node.integer",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_integer"}
+  {:doc
+   "arglists attributes - [ value ] - [ value base ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -integer-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_integer_node_2"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -IntNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_intnode"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node.keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_keyword"}
+  {:doc "arglists attributes = [ k & [namespaced?] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =keyword-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_keyword_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =KeywordNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_keywordnode"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node.meta",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_meta"}
+  {:doc
+   "arglists attributes = [ children ] = [ metadata data ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =meta-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_meta_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =MetaNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_metanode"}
+  {:doc
+   "arglists attributes = [ children ] = [ metadata data ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =raw-meta-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_raw_meta_node_2"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node.protocols",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_protocols"}
+  {:doc
+   "arglists attributes - [ [row col] [row-extent col-extent] ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -+extent",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_extent"}
+  {:doc
+   "arglists attributes = [ nodes c ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠assert-sexpr-count",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_assert_sexpr_count"}
+  {:doc "arglists attributes = [ nodes ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠assert-single-sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_assert_single_sexpr"}
+  {:doc "arglists attributes = [ nodes ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠concat-strings",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_concat_strings_2"}
+  {:doc "arglists attributes - [ node ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -extent",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_extent_2"}
+  {:doc
+   "attributes members name arglists attributes :type = :protocol = children = [ _ ] :type = :var = inner? = [ _ ] :type = :var - leader-length - [ _ ] :type - :var = replace-children = [ _ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠InnerNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_innernode"}
+  {:doc
+   "arglists attributes - [ class ] :type - :macro :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -make-printable!",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_make_printable"}
+  {:doc "arglists attributes = [ nodes ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠sum-lengths",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_sum_lengths"}
+  {:doc
+   "arglists attributes - [ writer node ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - -write-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_write_node"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.node.regex",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_regex"}
+  {:doc "arglists attributes - [ pattern-string ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -regex-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_regex_node_2"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -RegexNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_regexnode"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node.seq",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_seq"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =list-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_list_node_2"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_node_2"}
+  {:doc "arglists attributes - [ children ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -namespaced-map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_namespaced_map_node_2"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -NamespacedMapNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_namespacedmapnode"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =SeqNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_seqnode"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =set-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_set_node_2"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =vector-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_vector_node_2"}
+  {:doc "arglists attributes + [ s ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +wrap-list",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_list"}
+  {:doc "arglists attributes + [ s ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +wrap-map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_map"}
+  {:doc "arglists attributes + [ s ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +wrap-set",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_set"}
+  {:doc "arglists attributes + [ s ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +wrap-vec",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_vec"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.node.string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_string"}
+  {:doc "arglists attributes - [ lines ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -string-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_node_2"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -StringNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_stringnode"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.node.stringz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_stringz"}
+  {:doc "arglists attributes + [ lines ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +string-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_node_3"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +StringNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_stringnode_2"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node.token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_token"}
+  {:doc
+   "arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠token-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_token_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =TokenNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_tokennode"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.node.whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_whitespace"}
+  {:doc "attributes :type = :var :dynamic = true ",
+   :name "rwt-clj v0 vs rwt-cljs - =*count-fn*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_count_fn"}
+  {:doc "attributes :type = :var :dynamic = true ",
+   :name "rwt-clj v0 vs rwt-cljs - =*newline-fn*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_newline_fn"}
+  {:doc "arglists attributes - [ s ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -comma-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comma_node_2"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =comma-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comma_separated_2"}
+  {:doc "arglists attributes - [ node ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -comma?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comma_2"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -CommaNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_commanode"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =line-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_line_separated_2"}
+  {:doc "arglists attributes = [ node ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_linebreak_2"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =newline-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_newline_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =NewlineNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_newlinenode"}
+  {:doc "arglists attributes = [ n ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =newlines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_newlines_2"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =space-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_space_separated"}
+  {:doc "arglists attributes = [ n ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =spaces",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_spaces_2"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =whitespace-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_node_2"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =whitespace-nodes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_nodes_2"}
+  {:doc "arglists attributes = [ node ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =WhitespaceNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespacenode"}
+  {:doc "arglists attributes - [ f & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -with-count-fn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_with_count_fn"}
+  {:doc "arglists attributes - [ f & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -with-newline-fn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_with_newline_fn"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.paredit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_paredit"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +barf-backward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_barf_backward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +barf-forward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_barf_forward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +join",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_join"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +kill",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_kill"}
+  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +kill-at-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_kill_at_pos"}
+  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +kill-one-at-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_kill_one_at_pos"}
+  {:doc
+   "arglists attributes + [ loc f n ] :type + :var :no-doc + true ",
+   :name "rwt-clj v0 vs rwt-cljs - +move-n",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_move_n"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +move-to-prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_move_to_prev"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +raise",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_raise"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +slurp-backward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_slurp_backward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +slurp-backward-fully",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_slurp_backward_fully"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +slurp-forward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_slurp_forward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +slurp-forward-fully",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_slurp_forward_fully"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +splice-killing-backward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice_killing_backward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +splice-killing-forward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice_killing_forward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +split",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_split"}
+  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +split-at-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_split_at_pos"}
+  {:doc "arglists attributes + [ zloc t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +wrap-around",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_around"}
+  {:doc "arglists attributes + [ zloc t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +wrap-fully-forward-slurp",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_fully_forward_slurp"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.parser",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_parser"}
+  {:doc "arglists attributes - [ f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -parse-file",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_parse_file"}
+  {:doc "arglists attributes - [ f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -parse-file-all",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_parse_file_all"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.parser.core",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_parser_core"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =parse-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_parse_next"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.parser.keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_parser_keyword"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =parse-keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_parse_keyword"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.parser.string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_parser_string"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =parse-regex",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_parse_regex"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =parse-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_parse_string"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.parser.token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_parser_token"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =parse-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_parse_token"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.parser.utils",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_parser_utils"}
+  {:doc "arglists attributes - [ reader ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -ignore",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_ignore"}
+  {:doc "arglists attributes - [ c ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_linebreak_3"}
+  {:doc "arglists attributes - [ reader ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -read-eol",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_eol"}
+  {:doc "arglists attributes - [ c ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -space?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_space"}
+  {:doc "arglists attributes - [ reader & msg ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -throw-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_throw_reader"}
+  {:doc "arglists attributes - [ c ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_3"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.parser.whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_parser_whitespace"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =parse-whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_parse_whitespace"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.potemkin",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_potemkin"}
+  {:doc "arglists attributes - [ name & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -defprotocol+",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_defprotocol"}
+  {:doc "arglists attributes - [ sym ] - [ sym name ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -import-def",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_import_def"}
+  {:doc "arglists attributes - [ sym ] - [ sym name ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -import-fn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_import_fn"}
+  {:doc "arglists attributes - [ sym ] - [ sym name ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -import-macro",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_import_macro"}
+  {:doc "arglists attributes - [ & syms ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -import-vars",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_import_vars"}
+  {:doc "arglists attributes - [ src dst ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -link-vars",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_link_vars"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_reader"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =boundary?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_boundary"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +buf",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_buf"}
+  {:doc "arglists attributes - [ c ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -comma?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comma_3"}
+  {:doc "arglists attributes - [ f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -file-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_file_reader"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +get-column-number",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_get_column_number"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +get-line-number",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_get_line_number"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =ignore",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_ignore_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +indexing-push-back-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_indexing_push_back_reader"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_linebreak_4"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_next_2"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =peek",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_peek"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +peek-char",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_peek_char"}
+  {:doc "arglists attributes - [ reader row-k col-k ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -position",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_position_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +read-char",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_char"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =read-include-linebreak",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_include_linebreak"}
+  {:doc "arglists attributes + [ reader initch ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +read-keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_keyword"}
+  {:doc
+   "arglists attributes = [ reader node-tag read-fn p? n ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =read-n",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_n"}
+  {:doc "arglists attributes = [ reader read-fn ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =read-repeatedly",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_repeatedly"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +read-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_string"}
+  {:doc "arglists attributes = [ reader p? ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =read-until",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_until"}
+  {:doc
+   "arglists attributes + [ reader p? ] + [ reader p? eof? ] - [ reader p? & [eof?] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠read-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_while"}
+  {:doc "arglists attributes = [ reader read-fn ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =read-with-meta",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_with_meta"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =space?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_space_2"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =string->edn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_edn"}
+  {:doc "arglists attributes - [ s ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -string-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_reader"}
+  {:doc "arglists attributes = [ reader fmt & data ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =throw-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_throw_reader_2"}
+  {:doc "arglists attributes - [ reader ch ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠unread",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_unread"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =whitespace-or-boundary?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_or_boundary"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_4"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.zip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip"}
+  {:doc
+   "arglists attributes - [ zloc ] :type - :var :deprecated - 0.4.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -->root-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_root_string"}
+  {:doc
+   "arglists attributes - [ zloc ] :type - :var :deprecated - 0.4.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -->string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_2"}
+  {:doc "arglists attributes - [ zloc item ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠append-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_append_child_2"}
+  {:doc
+   "arglists attributes - [ zloc & [n] ] :type - :var :deprecated - 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -append-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_append_newline"}
+  {:doc
+   "arglists attributes - [ zloc & [n] ] :type - :var :deprecated - 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -append-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_append_space"}
+  {:doc "arglists attributes - [ zloc k v ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠assoc",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_assoc"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_child_sexprs_2"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠down",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_down_2"}
+  {:doc "arglists attributes - [ G__2782 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -down*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_down_3"}
+  {:doc "arglists attributes - [ zloc f & args ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_2"}
+  {:doc "arglists attributes - [ loc f & args ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_3"}
+  {:doc "arglists attributes - [ zloc & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit->",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_4"}
+  {:doc "arglists attributes - [ zloc & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit->>",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_5"}
+  {:doc "arglists attributes - [ zloc f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_node"}
+  {:doc "arglists attributes - [ node ] - [ node {} ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -edn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edn"}
+  {:doc "arglists attributes - [ node ] - [ node {} ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -edn*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edn_2"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠end?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_end_2"}
+  {:doc
+   "arglists attributes - [ zloc p? ] - [ zloc f p? ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find"}
+  {:doc "arglists attributes - [ zloc p? ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_depth_first"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-last-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_last_by_pos"}
+  {:doc
+   "arglists attributes - [ zloc p? ] - [ zloc f p? ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next"}
+  {:doc "arglists attributes - [ zloc p? ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-next-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_depth_first"}
+  {:doc
+   "arglists attributes - [ zloc t ] - [ zloc f t ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-next-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_tag"}
+  {:doc
+   "arglists attributes - [ zloc p? ] - [ zloc f p? ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-next-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_token"}
+  {:doc
+   "arglists attributes - [ zloc v ] - [ zloc f v ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-next-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_value"}
+  {:doc
+   "arglists attributes - [ zloc t ] - [ zloc f t ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-tag-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag_by_pos"}
+  {:doc
+   "arglists attributes - [ zloc p? ] - [ zloc f p? ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_token"}
+  {:doc
+   "arglists attributes - [ zloc v ] - [ zloc f v ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠find-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_value"}
+  {:doc "arglists attributes - [ zloc k ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠get",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_get"}
+  {:doc "arglists attributes - [ zloc item ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠insert-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_child_2"}
+  {:doc "arglists attributes - [ zloc item ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠insert-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_left_2"}
+  {:doc "arglists attributes - [ G__2821 G__2822 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-left*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_left_3"}
+  {:doc "arglists attributes - [ zloc item ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠insert-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_right_2"}
+  {:doc "arglists attributes - [ G__2825 G__2826 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-right*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_right_3"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_left_2"}
+  {:doc "arglists attributes - [ G__2807 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -left*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_left_3"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠leftmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_leftmost_2"}
+  {:doc "arglists attributes - [ G__2814 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -leftmost*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_leftmost_3"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠leftmost?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_leftmost_4"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -length",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_length_2"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_linebreak_5"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠list?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_list"}
+  {:doc "arglists attributes - [ f zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map"}
+  {:doc "arglists attributes - [ f zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠map-keys",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_keys"}
+  {:doc "arglists attributes - [ f zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠map-vals",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_vals"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_2"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_next_3"}
+  {:doc "arglists attributes - [ G__2839 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -next*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_next_4"}
+  {:doc "arglists attributes - [ G__2766 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_node_2"}
+  {:doc "arglists attributes - [ f ] - [ f options ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -of-file",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_of_file"}
+  {:doc "arglists attributes - [ s ] - [ s options ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠of-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_of_string"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -position",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_position_3"}
+  {:doc
+   "arglists attributes - [ zloc f ] - [ zloc p? f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -postwalk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_postwalk"}
+  {:doc "arglists attributes - [ zloc s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠prefix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prefix"}
+  {:doc
+   "arglists attributes - [ zloc & [n] ] :type - :var :deprecated - 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -prepend-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prepend_newline"}
+  {:doc
+   "arglists attributes - [ zloc & [n] ] :type - :var :deprecated - 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -prepend-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prepend_space"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prev_2"}
+  {:doc "arglists attributes - [ G__2846 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -prev*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prev_3"}
+  {:doc
+   "arglists attributes - [ zloc f ] - [ zloc p? f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -prewalk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prewalk"}
+  {:doc "arglists attributes - [ zloc & [writer] ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -print",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_print"}
+  {:doc "arglists attributes - [ zloc & [writer] ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -print-root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_print_root"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_2"}
+  {:doc "arglists attributes - [ G__2853 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_3"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-preserve-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_preserve_newline"}
+  {:doc "arglists attributes - [ zloc value ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_replace_2"}
+  {:doc "arglists attributes - [ G__2829 G__2830 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -replace*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_replace_3"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_right_2"}
+  {:doc "arglists attributes - [ G__2797 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -right*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_right_3"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠rightmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rightmost_2"}
+  {:doc "arglists attributes - [ G__2804 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -rightmost*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rightmost_3"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠rightmost?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rightmost_4"}
+  {:doc "arglists attributes - [ G__2794 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_root_2"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠root-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_root_string_2"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠seq?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_seq"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠set?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_set"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_sexpr_2"}
+  {:doc "arglists attributes - [ f p? zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -skip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_skip"}
+  {:doc "arglists attributes - [ zloc ] - [ f zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -skip-whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_skip_whitespace"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -skip-whitespace-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_skip_whitespace_left"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice_2"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_3"}
+  {:doc "arglists attributes - [ zloc & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -subedit->",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_subedit"}
+  {:doc "arglists attributes - [ zloc & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -subedit->>",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_subedit_2"}
+  {:doc "arglists attributes - [ zloc f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -subedit-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_subedit_node"}
+  {:doc "arglists attributes - [ zloc s ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠suffix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_suffix"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_tag_2"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_up_2"}
+  {:doc "arglists attributes - [ G__2791 ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -up*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_up_3"}
+  {:doc
+   "arglists attributes - [ zloc ] :type - :var :deprecated - 0.4.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_value_2"}
+  {:doc "arglists attributes - [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠vector?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_vector"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -whitespace-or-comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_or_comment"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_5"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.zip.base",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_base"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_child_sexprs_3"}
+  {:doc "arglists attributes = [ node ] - [ node {} ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠edn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edn_3"}
+  {:doc "arglists attributes = [ node ] - [ node {} ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠edn*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edn_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =length",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_length_3"}
+  {:doc "arglists attributes - [ f ] - [ f options ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -of-file",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_of_file_2"}
+  {:doc "arglists attributes = [ s ] - [ s options ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠of-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_of_string_2"}
+  {:doc "arglists attributes - [ zloc & [writer] ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -print",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_print_2"}
+  {:doc "arglists attributes - [ zloc & [writer] ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -print-root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_print_root_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =root-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_root_string_3"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_sexpr_3"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_tag_3"}
+  {:doc
+   "arglists attributes - [ zloc ] :type - :var :deprecated - 0.4.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - -value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_value_3"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.zip.edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_edit"}
+  {:doc "arglists attributes - [ zloc f & args ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_6"}
+  {:doc "arglists attributes - [ zloc s ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -prefix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prefix_2"}
+  {:doc "arglists attributes - [ zloc value ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_replace_4"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice_3"}
+  {:doc "arglists attributes - [ zloc s ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -suffix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_suffix_2"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.editz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_editz"}
+  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_7"}
+  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +prefix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prefix_3"}
+  {:doc "arglists attributes + [ zloc value ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_replace_5"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice_4"}
+  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +suffix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_suffix_3"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.zip.find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_find"}
+  {:doc
+   "arglists attributes - [ zloc p? ] - [ zloc f p? ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_2"}
+  {:doc "arglists attributes - [ zloc p? ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_depth_first_2"}
+  {:doc
+   "arglists attributes - [ zloc p? ] - [ zloc f p? ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_2"}
+  {:doc "arglists attributes - [ zloc p? ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-next-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_depth_first_2"}
+  {:doc
+   "arglists attributes - [ zloc t ] - [ zloc f t ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-next-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_tag_2"}
+  {:doc
+   "arglists attributes - [ zloc p? ] - [ zloc f p? ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-next-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_token_2"}
+  {:doc
+   "arglists attributes - [ zloc v ] - [ zloc f v ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-next-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_value_2"}
+  {:doc
+   "arglists attributes - [ zloc t ] - [ zloc f t ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag_2"}
+  {:doc
+   "arglists attributes - [ zloc p? ] - [ zloc f p? ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_token_2"}
+  {:doc
+   "arglists attributes - [ zloc v ] - [ zloc f v ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -find-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_value_2"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.findz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_findz"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_3"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_depth_first_3"}
+  {:doc
+   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-last-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_last_by_pos_2"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_3"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-next-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_depth_first_3"}
+  {:doc
+   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-next-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_tag_3"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-next-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_token_3"}
+  {:doc
+   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-next-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_value_3"}
+  {:doc
+   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag_3"}
+  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-tag-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag_by_pos_2"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_token_3"}
+  {:doc
+   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +find-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_value_3"}
+  {:doc "arglists attributes + [ {} {} ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +in-range?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_in_range"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.zip.move",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_move"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =down",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_down_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =end?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_end_3"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_left_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =leftmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_leftmost_5"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =leftmost?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_leftmost_6"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_next_5"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prev_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_right_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =rightmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rightmost_5"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =rightmost?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rightmost_6"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_up_4"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.zip.remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_remove"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_4"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.removez",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_removez"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_5"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-preserve-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_preserve_newline_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.zip.seq",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_seq"}
+  {:doc "arglists attributes - [ zloc k v ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -assoc",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_assoc_2"}
+  {:doc "arglists attributes - [ zloc k ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -get",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_get_2"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -list?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_list_2"}
+  {:doc "arglists attributes - [ f zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_3"}
+  {:doc "arglists attributes - [ f zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -map-keys",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_keys_2"}
+  {:doc "arglists attributes - [ f zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -map-vals",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_vals_2"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_4"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -seq?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_seq_2"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -set?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_set_2"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -vector?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_vector_2"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.seqz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_seqz"}
+  {:doc "arglists attributes + [ zloc k v ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +assoc",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_assoc_3"}
+  {:doc "arglists attributes + [ zloc k ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +get",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_get_3"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +list?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_list_3"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_5"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +map-keys",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_keys_3"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +map-vals",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_vals_3"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_6"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +seq?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_seq_3"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +set?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_set_3"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +vector?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_vector_3"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.zip.subedit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_subedit"}
+  {:doc "arglists attributes - [ zloc & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit->",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_8"}
+  {:doc "arglists attributes - [ zloc & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit->>",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_9"}
+  {:doc "arglists attributes - [ zloc f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -edit-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_node_2"}
+  {:doc "arglists attributes - [ zloc & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -subedit->",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_subedit_3"}
+  {:doc "arglists attributes - [ zloc & body ] :type - :macro ",
+   :name "rwt-clj v0 vs rwt-cljs - -subedit->>",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_subedit_4"}
+  {:doc "arglists attributes - [ zloc f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -subedit-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_subedit_node_2"}
+  {:doc "arglists attributes - [ zloc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -subzip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_subzip"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.utils",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_utils"}
+  {:doc "arglists attributes + [ [_ {} :as loc] ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-and-move-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_and_move_left_2"}
+  {:doc "arglists attributes + [ [_ {} :as loc] ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-and-move-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_and_move_right_2"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-and-move-up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_and_move_up"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_left_2"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-left-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_left_while_2"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_right_2"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-right-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_right_while_2"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +remove-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_while"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-cljs - - rewrite-clj.zip.walk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_walk"}
+  {:doc
+   "arglists attributes - [ zloc f ] - [ zloc p? f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -postwalk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_postwalk_2"}
+  {:doc "arglists attributes - [ p? f loc ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -postwalk-subtree",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_postwalk_subtree"}
+  {:doc
+   "arglists attributes - [ zloc f ] - [ zloc p? f ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -prewalk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prewalk_2"}
+  {:doc ":no-doc - true ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠ rewrite-clj.zip.whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_whitespace"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠append-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_append_newline_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠append-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_append_space_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comment_3"}
+  {:doc "arglists attributes - [ zloc ] - [ zloc n ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-newline-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_newline_left"}
+  {:doc "arglists attributes - [ zloc ] - [ zloc n ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-newline-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_newline_right"}
+  {:doc "arglists attributes - [ zloc ] - [ zloc n ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-space-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_space_left"}
+  {:doc "arglists attributes - [ zloc ] - [ zloc n ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-cljs - -insert-space-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_insert_space_right"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_linebreak_6"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠prepend-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prepend_newline_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-cljs - ≠prepend-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prepend_space_2"}
+  {:doc "arglists attributes = [ f p? zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =skip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_skip_2"}
+  {:doc "arglists attributes = [ zloc ] = [ f zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =skip-whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_skip_whitespace_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =skip-whitespace-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_skip_whitespace_left_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-cljs - +whitespace-not-linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_not_linebreak"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =whitespace-or-comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_or_comment_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-cljs - =whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_6"}
+  {:doc
+   "Diff of rewrite-clj 0.6.1 & 1.0.0-alpha Diff of apis in: rewrite-clj 0.6.1 clj rewrite-clj 1.0.0-alpha clj Options: Option Value :arglists-by :arity-only :exclude-namespaces [\"rewrite-clj\"\n \"rewrite-clj.potemkin\"\n \"rewrite-clj.custom-zipper.switchable\"\n \"rewrite-clj.interop\"] :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 16 3 11 publics 37 14 110 arglists 0 29 163 Notes: The api of the last released version of rewrite-clj v0 was used as a reference for rewrite-clj v1. As such, you’ll notice the apis are almost the same. I assume that rewrite-clj.custom-zipper.core is internal and marked it as such with :no-doc. There were some features unique to rewrite-cljs (such as paredit and some positional searching) which were brought over to rewrite-clj v1. The internal rewrite-cljs namespaces that were renamed to avoid cljs namespace collisions also occur in the clj side of rewrite-clj v1. All other differences are considered internal refactorings. Table of diffs: ≠ rewrite-clj.custom-zipper.core =append-child =branch? =children ≠custom-zipper ≠custom-zipper? =down =edit =end? =insert-child =insert-left =insert-right =left =leftmost =lefts ≠make-node =next =node =position +position-span =prev =remove =replace =right =rightmost =root =up ≠zipper ≠ rewrite-clj.custom-zipper.utils +remove-and-move-up ≠ rewrite-clj.node ≠child-sexprs -concat-strings ≠keyword-node +keyword-node? +map-context-apply +map-context-clear +map-qualifier-node +node? ≠sexpr +sexpr-able? ≠sexprs +symbol-node? ≠token-node - rewrite-clj.node.coerce + rewrite-clj.node.coercer +node-with-meta + rewrite-clj.node.extras +whitespace-or-comment? - rewrite-clj.node.indent -indent-spaces -indent-tabs -LinePrefixedNode -prefix-lines ≠ rewrite-clj.node.keyword ≠keyword-node +keyword-node? +keyword-sexpr +kw-qualifier + rewrite-clj.node.namespaced-map +map-qualifier-node +MapQualifierNode +namespaced-map-node +NamespacedMapNode +reapply-namespaced-map-context ≠ rewrite-clj.node.protocols ≠+extent ≠assert-sexpr-count ≠assert-single-sexpr ≠child-sexprs ≠concat-strings +default-auto-resolve ≠extent =InnerNode ≠make-printable! +make-printable-clj! +MapQualifiable +meta-elided ≠Node +node? =NodeCoerceable +sexpr +sexpr-able? ≠sexprs ≠sum-lengths +value +without-whitespace ≠write-node ≠ rewrite-clj.node.regex +pattern-string-for-regex ≠ rewrite-clj.node.seq -namespaced-map-node -NamespacedMapNode ≠ rewrite-clj.node.string -StringNode + rewrite-clj.node.stringz +string-node +StringNode ≠ rewrite-clj.node.token +symbol-node? +SymbolNode ≠token-node + rewrite-clj.paredit +barf-backward +barf-forward +join +kill +kill-at-pos +kill-one-at-pos +move-to-prev +raise +slurp-backward +slurp-backward-fully +slurp-forward +slurp-forward-fully +splice +splice-killing-backward +splice-killing-forward +split +split-at-pos +wrap-around +wrap-fully-forward-slurp ≠ rewrite-clj.parser ≠parse ≠parse-all + rewrite-clj.parser.namespaced-map +parse-namespaced-map - rewrite-clj.parser.utils -ignore -linebreak? -read-eol -space? -throw-reader -whitespace? ≠ rewrite-clj.reader +newline-normalizing-reader +read-keyword ≠read-while ≠ rewrite-clj.zip +append-child* ≠append-newline ≠append-space +find-last-by-pos +find-tag-by-pos +insert-child* +insert-newline-left +insert-newline-right +insert-space-left +insert-space-right +namespaced-map? +position-span ≠prepend-newline ≠prepend-space ≠print ≠print-root +reapply-context +remove-preserve-newline +sexpr-able? +subzip ≠ rewrite-clj.zip.base +->root-string +->string +get-opts ≠print ≠print-root +set-opts +sexpr-able? + rewrite-clj.zip.context +reapply-context + rewrite-clj.zip.editz +edit +prefix +replace +splice +suffix ≠ rewrite-clj.zip.find +find-last-by-pos +find-tag-by-pos + rewrite-clj.zip.findz +find +find-depth-first +find-last-by-pos +find-next +find-next-depth-first +find-next-tag +find-next-token +find-next-value +find-tag +find-tag-by-pos +find-token +find-value ≠ rewrite-clj.zip.remove +remove-preserve-newline + rewrite-clj.zip.removez +remove +remove-preserve-newline + rewrite-clj.zip.seqz +assoc +get +list? +map +map-keys +map-vals +map? +namespaced-map? +seq? +set? +vector? ≠ rewrite-clj.zip.whitespace ≠append-newline ≠append-space +comment? ≠prepend-newline ≠prepend-space +whitespace-not-linebreak? ",
    :name "rwt-clj v0 vs rwt-clj v1",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1"}
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#"}
+  {:doc ":no-doc + true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.custom-zipper.core",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_custom_zipper_core"}
+  {:doc "arglists attributes = [ G__2836 G__2837 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =append-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_child"}
+  {:doc "arglists attributes = [ G__2769 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =branch?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_branch"}
+  {:doc "arglists attributes = [ G__2772 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =children",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_children"}
+  {:doc "arglists attributes = [ root ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠custom-zipper",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_custom_zipper"}
+  {:doc "arglists attributes = [ value ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠custom-zipper?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_custom_zipper_2"}
+  {:doc "arglists attributes = [ G__2782 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =down",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_down"}
+  {:doc "arglists attributes = [ loc f & args ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_edit"}
+  {:doc "arglists attributes = [ G__2851 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =end?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_end"}
+  {:doc "arglists attributes = [ G__2833 G__2834 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =insert-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_child"}
+  {:doc "arglists attributes = [ G__2821 G__2822 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =insert-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_left"}
+  {:doc "arglists attributes = [ G__2825 G__2826 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =insert-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_right"}
+  {:doc "arglists attributes = [ G__2807 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_left"}
+  {:doc "arglists attributes = [ G__2814 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =leftmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_leftmost"}
+  {:doc "arglists attributes = [ G__2780 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =lefts",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_lefts"}
   {:doc
-   "Diff of rewrite-cljs 0.4.5 & rewrite-clj 1.0.0-alpha Diff of apis in: rewrite-cljs 0.4.5 cljs rewrite-clj 1.0.0-alpha cljs Options: Option Value :arglists-by :arity-only :exclude-namespaces [\"rewrite-clj\"\n \"rewrite-clj.potemkin\"\n \"rewrite-clj.custom-zipper.switchable\"\n \"rewrite-clj.interop\"] :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 27 1 10 publics 104 22 166 arglists 0 18 305 Notes: You’ll notice that the API of the last released version of rewrite-cljs as compared to the cljs api of rewrite-clj v1 has many differences. Rewrite-cljs lagged far behind rewrite-clj v0. The cljs side of rewrite-clj v1 adds in, where possible, rewrite-clj features. Table of diffs: + rewrite-clj.custom-zipper.core +append-child +branch? +children +custom-zipper +custom-zipper? +down +edit +end? +insert-child +insert-left +insert-right +left +leftmost +lefts +make-node +next +node +position +position-span +prev +remove +replace +right +rightmost +root +up +zipper + rewrite-clj.custom-zipper.utils +remove-and-move-left +remove-and-move-right +remove-and-move-up +remove-left +remove-left-while +remove-right +remove-right-while ≠ rewrite-clj.node ≠child-sexprs ≠children ≠coerce +comma-node +comma-separated +comma? ≠comment-node ≠comment? ≠deref-node ≠eval-node ≠fn-node ≠forms-node ≠inner? +integer-node ≠keyword-node +keyword-node? +leader-length ≠length +line-separated ≠linebreak? ≠list-node +map-context-apply +map-context-clear ≠map-node +map-qualifier-node ≠meta-node +namespaced-map-node ≠newline-node ≠newlines +node? ≠printable-only? ≠quote-node +raw-meta-node ≠reader-macro-node +regex-node ≠replace-children ≠set-node ≠sexpr +sexpr-able? +sexprs ≠spaces ≠string ≠string-node +symbol-node? ≠syntax-quote-node ≠tag ≠token-node ≠uneval-node ≠unquote-node ≠unquote-splicing-node +value ≠var-node ≠vector-node ≠whitespace-node +whitespace-nodes ≠whitespace? ≠ rewrite-clj.node.coercer =node-with-meta -seq-node ≠ rewrite-clj.node.comment =comment-node =comment? =CommentNode + rewrite-clj.node.extras +whitespace-or-comment? ≠ rewrite-clj.node.forms =forms-node =FormsNode + rewrite-clj.node.integer +integer-node +IntNode ≠ rewrite-clj.node.keyword ≠keyword-node +keyword-node? +keyword-sexpr =KeywordNode +kw-qualifier ≠ rewrite-clj.node.meta =meta-node =MetaNode =raw-meta-node + rewrite-clj.node.namespaced-map +map-qualifier-node +MapQualifierNode +namespaced-map-node +NamespacedMapNode +reapply-namespaced-map-context ≠ rewrite-clj.node.protocols ++extent =assert-sexpr-count =assert-single-sexpr ≠child-sexprs =concat-strings +default-auto-resolve +extent ≠InnerNode +make-printable! +make-printable-cljs! +MapQualifiable +meta-elided ≠Node +node? =NodeCoerceable +sexpr +sexpr-able? ≠sexprs =sum-lengths +value +without-whitespace + rewrite-clj.node.regex +pattern-string-for-regex +regex-node +RegexNode ≠ rewrite-clj.node.seq =list-node =map-node =SeqNode =set-node =vector-node -wrap-list -wrap-map -wrap-set -wrap-vec ≠ rewrite-clj.node.stringz =string-node =StringNode ≠ rewrite-clj.node.token +symbol-node? +SymbolNode =token-node =TokenNode ≠ rewrite-clj.node.whitespace =*count-fn* =*newline-fn* +comma-node =comma-separated +comma? +CommaNode =line-separated =linebreak? =newline-node =NewlineNode =newlines =space-separated =spaces =whitespace-node =whitespace-nodes =whitespace? =WhitespaceNode +with-count-fn +with-newline-fn ≠ rewrite-clj.paredit -move-n ≠ rewrite-clj.parser ≠parse ≠parse-all ≠ rewrite-clj.parser.core =parse-next ≠ rewrite-clj.parser.keyword =parse-keyword + rewrite-clj.parser.namespaced-map +parse-namespaced-map ≠ rewrite-clj.parser.string =parse-regex =parse-string ≠ rewrite-clj.parser.token =parse-token ≠ rewrite-clj.parser.whitespace =parse-whitespace ≠ rewrite-clj.reader =boundary? -buf +comma? -get-column-number -get-line-number =ignore -indexing-push-back-reader =linebreak? =next =peek -peek-char +position -read-char =read-include-linebreak ≠read-keyword =read-n =read-repeatedly -read-string =read-until =read-while =read-with-meta =space? =string->edn +string-reader =throw-reader ≠unread =whitespace-or-boundary? =whitespace? ≠ rewrite-clj.zip +->root-string +->string ≠append-child +append-child* +append-newline +append-space ≠assoc +child-sexprs ≠down +down* ≠edit +edit* +edit-> +edit->> +edit-node +edn +edn* ≠end? ≠find ≠find-depth-first ≠find-last-by-pos ≠find-next ≠find-next-depth-first ≠find-next-tag ≠find-next-token ≠find-next-value ≠find-tag ≠find-tag-by-pos ≠find-token ≠find-value ≠get ≠insert-child +insert-child* ≠insert-left +insert-left* +insert-newline-left +insert-newline-right ≠insert-right +insert-right* +insert-space-left +insert-space-right ≠left +left* ≠leftmost +leftmost* ≠leftmost? +length +linebreak? ≠list? ≠map ≠map-keys ≠map-vals ≠map? +namespaced-map? ≠next +next* ≠node ≠of-string +position +position-span +postwalk ≠prefix +prepend-newline +prepend-space ≠prev +prev* +prewalk +print +print-root +reapply-context ≠remove +remove* ≠remove-preserve-newline ≠replace +replace* ≠right +right* ≠rightmost +rightmost* ≠rightmost? ≠root ≠root-string ≠seq? ≠set? ≠sexpr +sexpr-able? +skip +skip-whitespace +skip-whitespace-left ≠splice ≠string +subedit-> +subedit->> +subedit-node +subzip ≠suffix ≠tag ≠up +up* +value ≠vector? +whitespace-or-comment? +whitespace? ≠ rewrite-clj.zip.base +->root-string +->string =child-sexprs ≠edn ≠edn* +get-opts =length ≠of-string +print +print-root =root-string +set-opts =sexpr +sexpr-able? =string =tag +value + rewrite-clj.zip.context +reapply-context ≠ rewrite-clj.zip.editz =edit =prefix =replace =splice =suffix ≠ rewrite-clj.zip.findz =find =find-depth-first =find-last-by-pos =find-next =find-next-depth-first =find-next-tag =find-next-token =find-next-value =find-tag =find-tag-by-pos =find-token =find-value -in-range? ≠ rewrite-clj.zip.move =down =end? =left =leftmost =leftmost? =next =prev =right =rightmost =rightmost? =up ≠ rewrite-clj.zip.removez =remove =remove-preserve-newline ≠ rewrite-clj.zip.seqz =assoc =get =list? =map =map-keys =map-vals =map? +namespaced-map? =seq? =set? =vector? + rewrite-clj.zip.subedit +edit-> +edit->> +edit-node +subedit-> +subedit->> +subedit-node +subzip - rewrite-clj.zip.utils -remove-and-move-left -remove-and-move-right -remove-and-move-up -remove-left -remove-left-while -remove-right -remove-right-while -remove-while + rewrite-clj.zip.walk +postwalk +postwalk-subtree +prewalk ≠ rewrite-clj.zip.whitespace ≠append-newline ≠append-space =comment? +insert-newline-left +insert-newline-right +insert-space-left +insert-space-right =linebreak? ≠prepend-newline ≠prepend-space =skip =skip-whitespace =skip-whitespace-left =whitespace-not-linebreak? =whitespace-or-comment? =whitespace? + rewrite-clj.custom-zipper.core :no-doc = true +append-child arglists attributes + [ zloc item ] :type + :var +branch? arglists attributes + [ zloc ] :type + :var +children arglists attributes + [ {} ] :type + :var +custom-zipper arglists attributes + [ root ] :type + :var +custom-zipper? arglists attributes + [ value ] :type + :var +down arglists attributes + [ zloc ] :type + :var +edit arglists attributes + [ zloc f & args ] :type + :var +end? arglists attributes + [ zloc ] :type + :var +insert-child arglists attributes + [ zloc item ] :type + :var +insert-left arglists attributes + [ zloc item ] :type + :var +insert-right arglists attributes + [ zloc item ] :type + :var +left arglists attributes + [ zloc ] :type + :var +leftmost arglists attributes + [ zloc ] :type + :var +lefts arglists attributes + [ zloc ] :type + :var +make-node arglists attributes + [ _zloc node children ] :type + :var +next arglists attributes + [ zloc ] :type + :var +node arglists attributes + [ zloc ] :type + :var +position arglists attributes + [ zloc ] :type + :var +position-span arglists attributes + [ zloc ] :type + :var +prev arglists attributes + [ zloc ] :type + :var +remove arglists attributes + [ zloc ] :type + :var +replace arglists attributes + [ zloc node ] :type + :var +right arglists attributes + [ zloc ] :type + :var +rightmost arglists attributes + [ zloc ] :type + :var +root arglists attributes + [ zloc ] :type + :var +up arglists attributes + [ zloc ] :type + :var +zipper arglists attributes + [ root ] :type + :var + rewrite-clj.custom-zipper.utils :no-doc = true +remove-and-move-left arglists attributes + [ loc ] :type + :var +remove-and-move-right arglists attributes + [ loc ] :type + :var +remove-and-move-up arglists attributes + [ loc ] :type + :var +remove-left arglists attributes + [ loc ] :type + :var +remove-left-while arglists attributes + [ zloc p? ] :type + :var +remove-right arglists attributes + [ loc ] :type + :var +remove-right-while arglists attributes + [ zloc p? ] :type + :var ≠ rewrite-clj.node ≠child-sexprs arglists attributes + [ node ] + [ node opts ] :type = :var ≠children arglists attributes + [ node ] :type = :var ≠coerce arglists attributes + [ form ] :type = :var +comma-node arglists attributes + [ s ] :type + :var +comma-separated arglists attributes + [ nodes ] :type + :var +comma? arglists attributes + [ node ] :type + :var ≠comment-node arglists attributes + [ s ] :type = :var ≠comment? arglists attributes + [ node ] :type = :var ≠deref-node arglists attributes + [ children ] :type = :var ≠eval-node arglists attributes + [ children ] :type = :var ≠fn-node arglists attributes + [ children ] :type = :var ≠forms-node arglists attributes + [ children ] :type = :var ≠inner? arglists attributes + [ node ] :type = :var +integer-node arglists attributes + [ value ] + [ value base ] :type + :var ≠keyword-node arglists attributes + [ k ] + [ k auto-resolved? ] :type = :var +keyword-node? arglists attributes + [ n ] :type + :var +leader-length arglists attributes + [ node ] :type + :var ≠length arglists attributes + [ node ] :type = :var +line-separated arglists attributes + [ nodes ] :type + :var ≠linebreak? arglists attributes + [ node ] :type = :var ≠list-node arglists attributes + [ children ] :type = :var +map-context-apply arglists attributes + [ node map-qualifier ] :type + :var +map-context-clear arglists attributes + [ node ] :type + :var ≠map-node arglists attributes + [ children ] :type = :var +map-qualifier-node arglists attributes + [ auto-resolved? prefix ] :type + :var ≠meta-node arglists attributes + [ children ] + [ metadata data ] :type = :var +namespaced-map-node arglists attributes + [ children ] :type + :var ≠newline-node arglists attributes + [ s ] :type = :var ≠newlines arglists attributes + [ n ] :type = :var +node? arglists attributes + [ x ] :type + :var ≠printable-only? arglists attributes + [ node ] :type = :var ≠quote-node arglists attributes + [ children ] :type = :var +raw-meta-node arglists attributes + [ children ] + [ metadata data ] :type + :var ≠reader-macro-node arglists attributes + [ children ] + [ macro-node form-node ] :type = :var +regex-node arglists attributes + [ pattern-string ] :type + :var ≠replace-children arglists attributes + [ node children ] :type = :var ≠set-node arglists attributes + [ children ] :type = :var ≠sexpr arglists attributes + [ node ] + [ node opts ] :type = :var +sexpr-able? arglists attributes + [ node ] :type + :var +sexprs arglists attributes + [ nodes ] + [ nodes opts ] :type + :var ≠spaces arglists attributes + [ n ] :type = :var ≠string arglists attributes + [ node ] :type = :var ≠string-node arglists attributes + [ lines ] :type = :var +symbol-node? arglists attributes + [ n ] :type + :var ≠syntax-quote-node arglists attributes + [ children ] :type = :var ≠tag arglists attributes + [ node ] :type = :var ≠token-node arglists attributes + [ value ] + [ value string-value ] :type = :var ≠uneval-node arglists attributes + [ children ] :type = :var ≠unquote-node arglists attributes + [ children ] :type = :var ≠unquote-splicing-node arglists attributes + [ children ] :type = :var +value arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 ≠var-node arglists attributes + [ children ] :type = :var ≠vector-node arglists attributes + [ children ] :type = :var ≠whitespace-node arglists attributes + [ s ] :type = :var +whitespace-nodes arglists attributes + [ s ] :type + :var ≠whitespace? arglists attributes + [ node ] :type = :var ≠ rewrite-clj.node.coercer :no-doc + true =node-with-meta arglists attributes = [ n value ] :type = :var -seq-node arglists attributes - [ f sq ] :type - :var ≠ rewrite-clj.node.comment :no-doc + true =comment-node arglists attributes = [ s ] :type = :var =comment? arglists attributes = [ node ] :type = :var =CommentNode attributes :type = :var + rewrite-clj.node.extras :no-doc = true +whitespace-or-comment? arglists attributes + [ node ] :type + :var ≠ rewrite-clj.node.forms :no-doc + true =forms-node arglists attributes = [ children ] :type = :var =FormsNode attributes :type = :var + rewrite-clj.node.integer :no-doc = true +integer-node arglists attributes + [ value ] + [ value base ] :type + :var +IntNode attributes :type + :var ≠ rewrite-clj.node.keyword :no-doc + true ≠keyword-node arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var +keyword-node? arglists attributes + [ n ] :type + :var +keyword-sexpr arglists attributes + [ kw kw-auto-resolved? map-qualifier {} ] :type + :var =KeywordNode attributes :type = :var +kw-qualifier arglists attributes + [ k auto-resolved? ] :type + :var ≠ rewrite-clj.node.meta :no-doc + true =meta-node arglists attributes = [ children ] = [ metadata data ] :type = :var =MetaNode attributes :type = :var =raw-meta-node arglists attributes = [ children ] = [ metadata data ] :type = :var + rewrite-clj.node.namespaced-map :no-doc = true +map-qualifier-node arglists attributes + [ auto-resolved? prefix ] :type + :var +MapQualifierNode attributes :type + :var +namespaced-map-node arglists attributes + [ children ] :type + :var +NamespacedMapNode attributes :type + :var +reapply-namespaced-map-context arglists attributes + [ n ] :type + :var ≠ rewrite-clj.node.protocols :no-doc + true ++extent arglists attributes + [ [row col] [row-extent col-extent] ] :type + :var =assert-sexpr-count arglists attributes = [ nodes c ] :type = :var =assert-single-sexpr arglists attributes = [ nodes ] :type = :var ≠child-sexprs arglists attributes = [ node ] + [ node opts ] :type = :var =concat-strings arglists attributes = [ nodes ] :type = :var +default-auto-resolve arglists attributes + [ alias ] :type + :var +extent arglists attributes + [ node ] :type + :var ≠InnerNode attributes members name arglists attributes :type = :protocol = children = [ _ ] :type = :var = inner? = [ _ ] :type = :var + leader-length + [ node ] :type + :var = replace-children = [ _ children ] :type = :var +make-printable! arglists attributes + [ obj ] :type + :var +make-printable-cljs! arglists attributes + [ obj ] :type + :var :no-doc + true +MapQualifiable attributes members name arglists attributes :type + :protocol + map-context-apply + [ node map-qualifier ] :type + :var + map-context-clear + [ node ] :type + :var +meta-elided arglists attributes + [ form ] :type + :var ≠Node attributes members name arglists attributes :type = :protocol = length = [ _ ] :type = :var + node-type + [ node ] :type + :var = printable-only? = [ _ ] :type = :var - sexpr - [ _ ] :type - :var + sexpr* + [ node opts ] :type + :var = string = [ _ ] :type = :var = tag = [ _ ] :type = :var +node? arglists attributes + [ x ] :type + :var =NodeCoerceable attributes members name arglists attributes :type = :protocol = coerce = [ _ ] :type = :var +sexpr arglists attributes + [ node ] + [ node opts ] :type + :var +sexpr-able? arglists attributes + [ node ] :type + :var ≠sexprs arglists attributes = [ nodes ] + [ nodes opts ] :type = :var =sum-lengths arglists attributes = [ nodes ] :type = :var +value arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 +without-whitespace arglists attributes + [ nodes ] :type + :var + rewrite-clj.node.regex :no-doc = true +pattern-string-for-regex arglists attributes + [ regex ] :type + :var +regex-node arglists attributes + [ pattern-string ] :type + :var +RegexNode attributes :type + :var ≠ rewrite-clj.node.seq :no-doc + true =list-node arglists attributes = [ children ] :type = :var =map-node arglists attributes = [ children ] :type = :var =SeqNode attributes :type = :var =set-node arglists attributes = [ children ] :type = :var =vector-node arglists attributes = [ children ] :type = :var -wrap-list arglists attributes - [ s ] :type - :var -wrap-map arglists attributes - [ s ] :type - :var -wrap-set arglists attributes - [ s ] :type - :var -wrap-vec arglists attributes - [ s ] :type - :var ≠ rewrite-clj.node.stringz :no-doc + true =string-node arglists attributes = [ lines ] :type = :var =StringNode attributes :type = :var ≠ rewrite-clj.node.token :no-doc + true +symbol-node? arglists attributes + [ n ] :type + :var +SymbolNode attributes :type + :var =token-node arglists attributes = [ value ] = [ value string-value ] :type = :var =TokenNode attributes :type = :var ≠ rewrite-clj.node.whitespace :no-doc + true =*count-fn* attributes :type = :var :dynamic = true =*newline-fn* attributes :type = :var :dynamic = true +comma-node arglists attributes + [ s ] :type + :var =comma-separated arglists attributes = [ nodes ] :type = :var +comma? arglists attributes + [ node ] :type + :var +CommaNode attributes :type + :var =line-separated arglists attributes = [ nodes ] :type = :var =linebreak? arglists attributes = [ node ] :type = :var =newline-node arglists attributes = [ s ] :type = :var =NewlineNode attributes :type = :var =newlines arglists attributes = [ n ] :type = :var =space-separated arglists attributes = [ nodes ] :type = :var =spaces arglists attributes = [ n ] :type = :var =whitespace-node arglists attributes = [ s ] :type = :var =whitespace-nodes arglists attributes = [ s ] :type = :var =whitespace? arglists attributes = [ node ] :type = :var =WhitespaceNode attributes :type = :var +with-count-fn arglists attributes + [ f & body ] :type + :macro +with-newline-fn arglists attributes + [ f & body ] :type + :macro ≠ rewrite-clj.paredit -move-n arglists attributes - [ loc f n ] :type - :var :no-doc - true ≠ rewrite-clj.parser ≠parse arglists attributes = [ reader ] :type = :var :no-doc + true ≠parse-all arglists attributes = [ reader ] :type = :var :no-doc + true ≠ rewrite-clj.parser.core :no-doc + true =parse-next arglists attributes = [ rdr ] :type = :var ≠ rewrite-clj.parser.keyword :no-doc + true =parse-keyword arglists attributes = [ reader ] :type = :var + rewrite-clj.parser.namespaced-map :no-doc = true +parse-namespaced-map arglists attributes + [ reader read-next ] :type + :var ≠ rewrite-clj.parser.string :no-doc + true =parse-regex arglists attributes = [ reader ] :type = :var =parse-string arglists attributes = [ reader ] :type = :var ≠ rewrite-clj.parser.token :no-doc + true =parse-token arglists attributes = [ reader ] :type = :var ≠ rewrite-clj.parser.whitespace :no-doc + true =parse-whitespace arglists attributes = [ reader ] :type = :var ≠ rewrite-clj.reader :no-doc + true =boundary? arglists attributes = [ c ] :type = :var -buf attributes :type - :var +comma? arglists attributes + [ c ] :type + :var -get-column-number attributes :type - :var -get-line-number attributes :type - :var =ignore arglists attributes = [ reader ] :type = :var -indexing-push-back-reader attributes :type - :var =linebreak? arglists attributes = [ c ] :type = :var =next arglists attributes = [ reader ] :type = :var =peek arglists attributes = [ reader ] :type = :var -peek-char attributes :type - :var +position arglists attributes + [ reader row-k col-k ] :type + :var -read-char attributes :type - :var =read-include-linebreak arglists attributes = [ reader ] :type = :var ≠read-keyword arglists attributes + [ reader ] - [ reader initch ] :type = :var =read-n arglists attributes = [ reader node-tag read-fn p? n ] :type = :var =read-repeatedly arglists attributes = [ reader read-fn ] :type = :var -read-string attributes :type - :var =read-until arglists attributes = [ reader p? ] :type = :var =read-while arglists attributes = [ reader p? ] = [ reader p? eof? ] :type = :var =read-with-meta arglists attributes = [ reader read-fn ] :type = :var =space? arglists attributes = [ c ] :type = :var =string->edn arglists attributes = [ s ] :type = :var +string-reader arglists attributes + [ s ] :type + :var =throw-reader arglists attributes = [ reader fmt & data ] :type = :var ≠unread arglists attributes + [ reader ch ] :type = :var =whitespace-or-boundary? arglists attributes = [ c ] :type = :var =whitespace? arglists attributes = [ ch ] :type = :var ≠ rewrite-clj.zip +->root-string arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 +->string arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ≠append-child arglists attributes + [ zloc item ] :type = :var +append-child* arglists attributes + [ zloc item ] :type + :var +append-newline arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 +append-space arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ≠assoc arglists attributes + [ zloc k v ] :type = :var +child-sexprs arglists attributes + [ zloc ] :type + :var ≠down arglists attributes + [ zloc ] :type = :var +down* arglists attributes + [ zloc ] :type + :var ≠edit arglists attributes + [ zloc f & args ] :type = :var +edit* arglists attributes + [ zloc f & args ] :type + :var +edit-> arglists attributes + [ zloc & body ] :type + :macro +edit->> arglists attributes + [ zloc & body ] :type + :macro +edit-node arglists attributes + [ zloc f ] :type + :var +edn arglists attributes + [ node ] + [ node opts ] :type + :var +edn* arglists attributes + [ node ] + [ node opts ] :type + :var ≠end? arglists attributes + [ zloc ] :type = :var ≠find arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ≠find-depth-first arglists attributes + [ zloc p? ] :type = :var ≠find-last-by-pos arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type = :var ≠find-next arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ≠find-next-depth-first arglists attributes + [ zloc p? ] :type = :var ≠find-next-tag arglists attributes + [ zloc t ] + [ zloc f t ] :type = :var ≠find-next-token arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ≠find-next-value arglists attributes + [ zloc v ] + [ zloc f v ] :type = :var ≠find-tag arglists attributes + [ zloc t ] + [ zloc f t ] :type = :var ≠find-tag-by-pos arglists attributes + [ zloc pos t ] :type = :var ≠find-token arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ≠find-value arglists attributes + [ zloc v ] + [ zloc f v ] :type = :var ≠get arglists attributes + [ zloc k ] :type = :var ≠insert-child arglists attributes + [ zloc item ] :type = :var +insert-child* arglists attributes + [ zloc item ] :type + :var ≠insert-left arglists attributes + [ zloc item ] :type = :var +insert-left* arglists attributes + [ zloc item ] :type + :var +insert-newline-left arglists attributes + [ zloc ] + [ zloc n ] :type + :var +insert-newline-right arglists attributes + [ zloc ] + [ zloc n ] :type + :var ≠insert-right arglists attributes + [ zloc item ] :type = :var +insert-right* arglists attributes + [ zloc item ] :type + :var +insert-space-left arglists attributes + [ zloc ] + [ zloc n ] :type + :var +insert-space-right arglists attributes + [ zloc ] + [ zloc n ] :type + :var ≠left arglists attributes + [ zloc ] :type = :var +left* arglists attributes + [ zloc ] :type + :var ≠leftmost arglists attributes + [ zloc ] :type = :var +leftmost* arglists attributes + [ zloc ] :type + :var ≠leftmost? arglists attributes + [ zloc ] :type = :var +length arglists attributes + [ zloc ] :type + :var +linebreak? arglists attributes + [ zloc ] :type + :var ≠list? arglists attributes + [ zloc ] :type = :var ≠map arglists attributes + [ f zloc ] :type = :var ≠map-keys arglists attributes + [ f zloc ] :type = :var ≠map-vals arglists attributes + [ f zloc ] :type = :var ≠map? arglists attributes + [ zloc ] :type = :var +namespaced-map? arglists attributes + [ zloc ] :type + :var ≠next arglists attributes + [ zloc ] :type = :var +next* arglists attributes + [ zloc ] :type + :var ≠node arglists attributes + [ zloc ] :type = :var ≠of-string arglists attributes + [ s ] + [ s opts ] :type = :var +position arglists attributes + [ zloc ] :type + :var +position-span arglists attributes + [ zloc ] :type + :var +postwalk arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ≠prefix arglists attributes + [ zloc s ] :type = :var +prepend-newline arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 +prepend-space arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ≠prev arglists attributes + [ zloc ] :type = :var +prev* arglists attributes + [ zloc ] :type + :var +prewalk arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var +print arglists attributes + [ zloc ] + [ zloc writer ] :type + :var +print-root arglists attributes + [ zloc ] + [ zloc writer ] :type + :var +reapply-context arglists attributes + [ zloc ] :type + :var ≠remove arglists attributes + [ zloc ] :type = :var +remove* arglists attributes + [ zloc ] :type + :var ≠remove-preserve-newline arglists attributes + [ zloc ] :type = :var ≠replace arglists attributes + [ zloc value ] :type = :var +replace* arglists attributes + [ zloc node ] :type + :var ≠right arglists attributes + [ zloc ] :type = :var +right* arglists attributes + [ zloc ] :type + :var ≠rightmost arglists attributes + [ zloc ] :type = :var +rightmost* arglists attributes + [ zloc ] :type + :var ≠rightmost? arglists attributes + [ zloc ] :type = :var ≠root arglists attributes + [ zloc ] :type = :var ≠root-string arglists attributes + [ zloc ] :type = :var ≠seq? arglists attributes + [ zloc ] :type = :var ≠set? arglists attributes + [ zloc ] :type = :var ≠sexpr arglists attributes + [ zloc ] :type = :var +sexpr-able? arglists attributes + [ zloc ] :type + :var +skip arglists attributes + [ f p? zloc ] :type + :var +skip-whitespace arglists attributes + [ zloc ] + [ f zloc ] :type + :var +skip-whitespace-left arglists attributes + [ zloc ] :type + :var ≠splice arglists attributes + [ zloc ] :type = :var ≠string arglists attributes + [ zloc ] :type = :var +subedit-> arglists attributes + [ zloc & body ] :type + :macro +subedit->> arglists attributes + [ zloc & body ] :type + :macro +subedit-node arglists attributes + [ zloc f ] :type + :var +subzip arglists attributes + [ zloc ] :type + :var ≠suffix arglists attributes + [ zloc s ] :type = :var ≠tag arglists attributes + [ zloc ] :type = :var ≠up arglists attributes + [ zloc ] :type = :var +up* arglists attributes + [ zloc ] :type + :var +value arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ≠vector? arglists attributes + [ zloc ] :type = :var +whitespace-or-comment? arglists attributes + [ zloc ] :type + :var +whitespace? arglists attributes + [ zloc ] :type + :var ≠ rewrite-clj.zip.base :no-doc + true +->root-string arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 +->string arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 =child-sexprs arglists attributes = [ zloc ] :type = :var ≠edn arglists attributes = [ node ] + [ node opts ] :type = :var ≠edn* arglists attributes = [ node ] + [ node opts ] :type = :var +get-opts arglists attributes + [ zloc ] :type + :var =length arglists attributes = [ zloc ] :type = :var ≠of-string arglists attributes = [ s ] + [ s opts ] :type = :var +print arglists attributes + [ zloc ] + [ zloc writer ] :type + :var +print-root arglists attributes + [ zloc ] + [ zloc writer ] :type + :var =root-string arglists attributes = [ zloc ] :type = :var +set-opts arglists attributes + [ zloc opts ] :type + :var =sexpr arglists attributes = [ zloc ] :type = :var +sexpr-able? arglists attributes + [ zloc ] :type + :var =string arglists attributes = [ zloc ] :type = :var =tag arglists attributes = [ zloc ] :type = :var +value arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 + rewrite-clj.zip.context :no-doc = true +reapply-context arglists attributes + [ zloc ] :type + :var ≠ rewrite-clj.zip.editz :no-doc + true =edit arglists attributes = [ zloc f & args ] :type = :var =prefix arglists attributes = [ zloc s ] :type = :var =replace arglists attributes = [ zloc value ] :type = :var =splice arglists attributes = [ zloc ] :type = :var =suffix arglists attributes = [ zloc s ] :type = :var ≠ rewrite-clj.zip.findz :no-doc + true =find arglists attributes = [ zloc p? ] = [ zloc f p? ] :type = :var =find-depth-first arglists attributes = [ zloc p? ] :type = :var =find-last-by-pos arglists attributes = [ zloc pos ] = [ zloc pos p? ] :type = :var =find-next arglists attributes = [ zloc p? ] = [ zloc f p? ] :type = :var =find-next-depth-first arglists attributes = [ zloc p? ] :type = :var =find-next-tag arglists attributes = [ zloc t ] = [ zloc f t ] :type = :var =find-next-token arglists attributes = [ zloc p? ] = [ zloc f p? ] :type = :var =find-next-value arglists attributes = [ zloc v ] = [ zloc f v ] :type = :var =find-tag arglists attributes = [ zloc t ] = [ zloc f t ] :type = :var =find-tag-by-pos arglists attributes = [ zloc pos t ] :type = :var =find-token arglists attributes = [ zloc p? ] = [ zloc f p? ] :type = :var =find-value arglists attributes = [ zloc v ] = [ zloc f v ] :type = :var -in-range? arglists attributes - [ {} {} ] :type - :var ≠ rewrite-clj.zip.move :no-doc + true =down arglists attributes = [ zloc ] :type = :var =end? arglists attributes = [ zloc ] :type = :var =left arglists attributes = [ zloc ] :type = :var =leftmost arglists attributes = [ zloc ] :type = :var =leftmost? arglists attributes = [ zloc ] :type = :var =next arglists attributes = [ zloc ] :type = :var =prev arglists attributes = [ zloc ] :type = :var =right arglists attributes = [ zloc ] :type = :var =rightmost arglists attributes = [ zloc ] :type = :var =rightmost? arglists attributes = [ zloc ] :type = :var =up arglists attributes = [ zloc ] :type = :var ≠ rewrite-clj.zip.removez :no-doc + true =remove arglists attributes = [ zloc ] :type = :var =remove-preserve-newline arglists attributes = [ zloc ] :type = :var ≠ rewrite-clj.zip.seqz :no-doc + true =assoc arglists attributes = [ zloc k v ] :type = :var =get arglists attributes = [ zloc k ] :type = :var =list? arglists attributes = [ zloc ] :type = :var =map arglists attributes = [ f zloc ] :type = :var =map-keys arglists attributes = [ f zloc ] :type = :var =map-vals arglists attributes = [ f zloc ] :type = :var =map? arglists attributes = [ zloc ] :type = :var +namespaced-map? arglists attributes + [ zloc ] :type + :var =seq? arglists attributes = [ zloc ] :type = :var =set? arglists attributes = [ zloc ] :type = :var =vector? arglists attributes = [ zloc ] :type = :var + rewrite-clj.zip.subedit :no-doc = true +edit-> arglists attributes + [ zloc & body ] :type + :macro +edit->> arglists attributes + [ zloc & body ] :type + :macro +edit-node arglists attributes + [ zloc f ] :type + :var +subedit-> arglists attributes + [ zloc & body ] :type + :macro +subedit->> arglists attributes + [ zloc & body ] :type + :macro +subedit-node arglists attributes + [ zloc f ] :type + :var +subzip arglists attributes + [ zloc ] :type + :var - rewrite-clj.zip.utils :no-doc = true -remove-and-move-left arglists attributes - [ [_ {} :as loc] ] :type - :var -remove-and-move-right arglists attributes - [ [_ {} :as loc] ] :type - :var -remove-and-move-up arglists attributes - [ loc ] :type - :var -remove-left arglists attributes - [ loc ] :type - :var -remove-left-while arglists attributes - [ zloc p? ] :type - :var -remove-right arglists attributes - [ loc ] :type - :var -remove-right-while arglists attributes - [ zloc p? ] :type - :var -remove-while arglists attributes - [ zloc p? ] :type - :var + rewrite-clj.zip.walk :no-doc = true +postwalk arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var +postwalk-subtree arglists attributes + [ p? f zloc ] :type + :var +prewalk arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ≠ rewrite-clj.zip.whitespace :no-doc + true ≠append-newline arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ≠append-space arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 =comment? arglists attributes = [ zloc ] :type = :var +insert-newline-left arglists attributes + [ zloc ] + [ zloc n ] :type + :var +insert-newline-right arglists attributes + [ zloc ] + [ zloc n ] :type + :var +insert-space-left arglists attributes + [ zloc ] + [ zloc n ] :type + :var +insert-space-right arglists attributes + [ zloc ] + [ zloc n ] :type + :var =linebreak? arglists attributes = [ zloc ] :type = :var ≠prepend-newline arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ≠prepend-space arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 =skip arglists attributes = [ f p? zloc ] :type = :var =skip-whitespace arglists attributes = [ zloc ] = [ f zloc ] :type = :var =skip-whitespace-left arglists attributes = [ zloc ] :type = :var =whitespace-not-linebreak? arglists attributes = [ zloc ] :type = :var =whitespace-or-comment? arglists attributes = [ zloc ] :type = :var =whitespace? arglists attributes = [ zloc ] :type = :var",
+   "arglists attributes = [ G__2775 G__2776 G__2777 ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠make-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_make_node"}
+  {:doc "arglists attributes = [ G__2839 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_next"}
+  {:doc "arglists attributes = [ G__2766 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node"}
+  {:doc "arglists attributes = [ loc ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =position",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_position"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +position-span",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_position_span"}
+  {:doc "arglists attributes = [ G__2846 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prev"}
+  {:doc "arglists attributes = [ G__2853 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove"}
+  {:doc "arglists attributes = [ G__2829 G__2830 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_replace"}
+  {:doc "arglists attributes = [ G__2797 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_right"}
+  {:doc "arglists attributes = [ G__2804 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =rightmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rightmost"}
+  {:doc "arglists attributes = [ G__2794 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_root"}
+  {:doc "arglists attributes = [ G__2791 ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_up"}
+  {:doc "arglists attributes = [ root ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠zipper",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_zipper"}
+  {:doc ":no-doc = true ",
+   :name
+   "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.custom-zipper.utils",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_custom_zipper_utils"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +remove-and-move-up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_and_move_up"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node"}
+  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_child_sexprs"}
+  {:doc "arglists attributes - [ nodes ] :type - :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -concat-strings",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_concat_strings"}
+  {:doc
+   "arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠keyword-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_node"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +keyword-node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_node_2"}
+  {:doc "arglists attributes + [ node map-qualifier ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +map-context-apply",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_context_apply"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +map-context-clear",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_context_clear"}
+  {:doc
+   "arglists attributes + [ auto-resolved? prefix ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +map-qualifier-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_qualifier_node"}
+  {:doc "arglists attributes + [ x ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node_2"}
+  {:doc "arglists attributes = [ _ ] + [ node opts ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +sexpr-able?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_able"}
+  {:doc
+   "arglists attributes = [ nodes ] + [ nodes opts ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexprs"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +symbol-node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_symbol_node"}
+  {:doc
+   "arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠token-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_token_node"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - - rewrite-clj.node.coerce",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_coerce"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.node.coercer",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_coercer"}
+  {:doc "arglists attributes + [ n value ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +node-with-meta",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node_with_meta"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.node.extras",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_extras"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +whitespace-or-comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_whitespace_or_comment"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - - rewrite-clj.node.indent",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_indent"}
+  {:doc "arglists attributes - [ node n ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -indent-spaces",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_indent_spaces"}
+  {:doc "arglists attributes - [ node n ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -indent-tabs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_indent_tabs"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -LinePrefixedNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_lineprefixednode"}
+  {:doc "arglists attributes - [ node prefix ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -prefix-lines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prefix_lines"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_keyword"}
+  {:doc
+   "arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠keyword-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_node_3"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +keyword-node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_node_4"}
+  {:doc
+   "arglists attributes + [ kw kw-auto-resolved? map-qualifier {} ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +keyword-sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_sexpr"}
+  {:doc "arglists attributes + [ k auto-resolved? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +kw-qualifier",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_kw_qualifier"}
+  {:doc ":no-doc = true ",
+   :name
+   "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.node.namespaced-map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_namespaced_map"}
+  {:doc
+   "arglists attributes + [ auto-resolved? prefix ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +map-qualifier-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_qualifier_node_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +MapQualifierNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_mapqualifiernode"}
+  {:doc "arglists attributes + [ children ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +namespaced-map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespaced_map_node"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +NamespacedMapNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespacedmapnode"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +reapply-namespaced-map-context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_reapply_namespaced_map_context"}
+  {:doc ":no-doc + true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.protocols",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_protocols"}
+  {:doc
+   "arglists attributes = [ [row col] [row-extent col-extent] ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠+extent",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_extent"}
+  {:doc
+   "arglists attributes = [ nodes c ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠assert-sexpr-count",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_assert_sexpr_count"}
+  {:doc "arglists attributes = [ nodes ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠assert-single-sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_assert_single_sexpr"}
+  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_child_sexprs_2"}
+  {:doc "arglists attributes = [ nodes ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠concat-strings",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_concat_strings_2"}
+  {:doc "arglists attributes + [ alias ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +default-auto-resolve",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_default_auto_resolve"}
+  {:doc "arglists attributes = [ node ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠extent",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_extent_2"}
+  {:doc
+   "attributes members name arglists attributes :type = :protocol = children = [ _ ] :type = :var = inner? = [ _ ] :type = :var = leader-length = [ _ ] :type = :var = replace-children = [ _ children ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =InnerNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_innernode"}
+  {:doc
+   "arglists attributes = [ class ] :type = :macro :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠make-printable!",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_make_printable"}
+  {:doc "arglists attributes + [ class ] :type + :macro ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +make-printable-clj!",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_make_printable_clj"}
+  {:doc
+   "attributes members name arglists attributes :type + :protocol + map-context-apply + [ node map-qualifier ] :type + :var + map-context-clear + [ node ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +MapQualifiable",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_mapqualifiable"}
+  {:doc "arglists attributes + [ form ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +meta-elided",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_meta_elided"}
+  {:doc
+   "attributes members name arglists attributes :type = :protocol = length = [ _ ] :type = :var + node-type + [ node ] :type + :var = printable-only? = [ _ ] :type = :var - sexpr - [ _ ] :type - :var + sexpr* + [ node opts ] :type + :var = string = [ _ ] :type = :var = tag = [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠Node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node_3"}
+  {:doc "arglists attributes + [ x ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node_4"}
+  {:doc
+   "attributes members name arglists attributes :type = :protocol = coerce = [ _ ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - =NodeCoerceable",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_nodecoerceable"}
+  {:doc "arglists attributes + [ node ] + [ node opts ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_2"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +sexpr-able?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_able_2"}
+  {:doc
+   "arglists attributes = [ nodes ] + [ nodes opts ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexprs_2"}
+  {:doc "arglists attributes = [ nodes ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠sum-lengths",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sum_lengths"}
+  {:doc
+   "arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_value"}
+  {:doc "arglists attributes + [ nodes ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +without-whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_without_whitespace"}
+  {:doc
+   "arglists attributes = [ writer node ] :type = :var :no-doc - true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠write-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_write_node"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.regex",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_regex"}
+  {:doc "arglists attributes + [ regex ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +pattern-string-for-regex",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_pattern_string_for_regex"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.seq",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_seq"}
+  {:doc "arglists attributes - [ children ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -namespaced-map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespaced_map_node_2"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -NamespacedMapNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespacedmapnode_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_string"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -StringNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_stringnode"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.node.stringz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_stringz"}
+  {:doc "arglists attributes + [ lines ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +string-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_string_node"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +StringNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_stringnode_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_token"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +symbol-node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_symbol_node_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +SymbolNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_symbolnode"}
+  {:doc
+   "arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠token-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_token_node_2"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.paredit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_paredit"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +barf-backward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_barf_backward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +barf-forward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_barf_forward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +join",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_join"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +kill",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_kill"}
+  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +kill-at-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_kill_at_pos"}
+  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +kill-one-at-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_kill_one_at_pos"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +move-to-prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_move_to_prev"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +raise",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_raise"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +slurp-backward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_slurp_backward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +slurp-backward-fully",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_slurp_backward_fully"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +slurp-forward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_slurp_forward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +slurp-forward-fully",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_slurp_forward_fully"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_splice"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +splice-killing-backward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_splice_killing_backward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +splice-killing-forward",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_splice_killing_forward"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +split",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_split"}
+  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +split-at-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_split_at_pos"}
+  {:doc "arglists attributes + [ zloc t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +wrap-around",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_wrap_around"}
+  {:doc "arglists attributes + [ zloc t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +wrap-fully-forward-slurp",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_wrap_fully_forward_slurp"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.parser",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_parser"}
+  {:doc
+   "arglists attributes = [ reader ] :type = :var :no-doc + true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠parse",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_parse"}
+  {:doc
+   "arglists attributes = [ reader ] :type = :var :no-doc + true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠parse-all",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_parse_all"}
+  {:doc ":no-doc = true ",
+   :name
+   "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.parser.namespaced-map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_parser_namespaced_map"}
+  {:doc "arglists attributes + [ reader read-next ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +parse-namespaced-map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_parse_namespaced_map"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - - rewrite-clj.parser.utils",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_parser_utils"}
+  {:doc "arglists attributes - [ reader ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -ignore",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_ignore"}
+  {:doc "arglists attributes - [ c ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_linebreak"}
+  {:doc "arglists attributes - [ reader ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -read-eol",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_read_eol"}
+  {:doc "arglists attributes - [ c ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -space?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_space"}
+  {:doc "arglists attributes - [ reader & msg ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -throw-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_throw_reader"}
+  {:doc "arglists attributes - [ c ] :type - :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - -whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_whitespace"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_reader"}
+  {:doc "arglists attributes + [ rdr ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +newline-normalizing-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_newline_normalizing_reader"}
+  {:doc "arglists attributes + [ reader ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +read-keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_read_keyword"}
+  {:doc
+   "arglists attributes + [ reader p? ] + [ reader p? eof? ] - [ reader p? & [eof?] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠read-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_read_while"}
+  {:doc "",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.zip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +append-child*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_child_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠append-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_newline"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠append-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_space"}
+  {:doc
+   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-last-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_last_by_pos"}
+  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-tag-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_tag_by_pos"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +insert-child*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_child_2"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +insert-newline-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_newline_left"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +insert-newline-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_newline_right"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +insert-space-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_space_left"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +insert-space-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_space_right"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +namespaced-map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespaced_map"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +position-span",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_position_span_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠prepend-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prepend_newline"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠prepend-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prepend_space"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠print",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_print"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠print-root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_print_root"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +reapply-context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_reapply_context"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +remove-preserve-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_preserve_newline"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +sexpr-able?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_able_3"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +subzip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_subzip"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.zip.base",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_base"}
+  {:doc
+   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +->root-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_root_string"}
+  {:doc
+   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +->string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_string"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +get-opts",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_get_opts"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠print",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_print_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠print-root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_print_root_2"}
+  {:doc "arglists attributes + [ zloc opts ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +set-opts",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_set_opts"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +sexpr-able?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_able_4"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_context"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +reapply-context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_reapply_context_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.editz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_editz"}
+  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_edit_2"}
+  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +prefix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prefix"}
+  {:doc "arglists attributes + [ zloc value ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_replace_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_splice_2"}
+  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +suffix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_suffix"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.zip.find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_find"}
+  {:doc
+   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-last-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_last_by_pos_2"}
+  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-tag-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_tag_by_pos_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.findz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_findz"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_depth_first"}
+  {:doc
+   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-last-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_last_by_pos_3"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-next-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next_depth_first"}
+  {:doc
+   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-next-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next_tag"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-next-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next_token"}
+  {:doc
+   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-next-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next_value"}
+  {:doc
+   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_tag"}
+  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-tag-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_tag_by_pos_3"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_token"}
+  {:doc
+   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +find-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_value"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.zip.remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_remove"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +remove-preserve-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_preserve_newline_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.removez",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_removez"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +remove-preserve-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_preserve_newline_3"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.seqz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_seqz"}
+  {:doc "arglists attributes + [ zloc k v ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +assoc",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_assoc"}
+  {:doc "arglists attributes + [ zloc k ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +get",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_get"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +list?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_list"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +map-keys",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_keys"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +map-vals",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_vals"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +namespaced-map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespaced_map_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +seq?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_seq"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +set?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_set"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +vector?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_vector"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.zip.whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_whitespace"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠append-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_newline_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠append-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_space_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_comment"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠prepend-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prepend_newline_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   :name "rwt-clj v0 vs rwt-clj v1 - ≠prepend-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prepend_space_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v0 vs rwt-clj v1 - +whitespace-not-linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_whitespace_not_linebreak"}
+  {:doc
+   "Diff of rewrite-cljs 0.4.5 & rewrite-clj 1.0.0-alpha Diff of apis in: rewrite-cljs 0.4.5 cljs rewrite-clj 1.0.0-alpha cljs Options: Option Value :arglists-by :arity-only :exclude-namespaces [\"rewrite-clj\"\n \"rewrite-clj.potemkin\"\n \"rewrite-clj.custom-zipper.switchable\"\n \"rewrite-clj.interop\"] :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 27 1 10 publics 104 22 166 arglists 0 18 305 Notes: You’ll notice that the API of the last released version of rewrite-cljs as compared to the cljs api of rewrite-clj v1 has many differences. Rewrite-cljs lagged far behind rewrite-clj v0. The cljs side of rewrite-clj v1 adds in, where possible, rewrite-clj features. Table of diffs: + rewrite-clj.custom-zipper.core +append-child +branch? +children +custom-zipper +custom-zipper? +down +edit +end? +insert-child +insert-left +insert-right +left +leftmost +lefts +make-node +next +node +position +position-span +prev +remove +replace +right +rightmost +root +up +zipper + rewrite-clj.custom-zipper.utils +remove-and-move-left +remove-and-move-right +remove-and-move-up +remove-left +remove-left-while +remove-right +remove-right-while ≠ rewrite-clj.node ≠child-sexprs ≠children ≠coerce +comma-node +comma-separated +comma? ≠comment-node ≠comment? ≠deref-node ≠eval-node ≠fn-node ≠forms-node ≠inner? +integer-node ≠keyword-node +keyword-node? +leader-length ≠length +line-separated ≠linebreak? ≠list-node +map-context-apply +map-context-clear ≠map-node +map-qualifier-node ≠meta-node +namespaced-map-node ≠newline-node ≠newlines +node? ≠printable-only? ≠quote-node +raw-meta-node ≠reader-macro-node +regex-node ≠replace-children ≠set-node ≠sexpr +sexpr-able? +sexprs ≠spaces ≠string ≠string-node +symbol-node? ≠syntax-quote-node ≠tag ≠token-node ≠uneval-node ≠unquote-node ≠unquote-splicing-node +value ≠var-node ≠vector-node ≠whitespace-node +whitespace-nodes ≠whitespace? ≠ rewrite-clj.node.coercer =node-with-meta -seq-node ≠ rewrite-clj.node.comment =comment-node =comment? =CommentNode + rewrite-clj.node.extras +whitespace-or-comment? ≠ rewrite-clj.node.forms =forms-node =FormsNode + rewrite-clj.node.integer +integer-node +IntNode ≠ rewrite-clj.node.keyword ≠keyword-node +keyword-node? +keyword-sexpr =KeywordNode +kw-qualifier ≠ rewrite-clj.node.meta =meta-node =MetaNode =raw-meta-node + rewrite-clj.node.namespaced-map +map-qualifier-node +MapQualifierNode +namespaced-map-node +NamespacedMapNode +reapply-namespaced-map-context ≠ rewrite-clj.node.protocols ++extent =assert-sexpr-count =assert-single-sexpr ≠child-sexprs =concat-strings +default-auto-resolve +extent ≠InnerNode +make-printable! +make-printable-cljs! +MapQualifiable +meta-elided ≠Node +node? =NodeCoerceable +sexpr +sexpr-able? ≠sexprs =sum-lengths +value +without-whitespace + rewrite-clj.node.regex +pattern-string-for-regex +regex-node +RegexNode ≠ rewrite-clj.node.seq =list-node =map-node =SeqNode =set-node =vector-node -wrap-list -wrap-map -wrap-set -wrap-vec ≠ rewrite-clj.node.stringz =string-node =StringNode ≠ rewrite-clj.node.token +symbol-node? +SymbolNode =token-node =TokenNode ≠ rewrite-clj.node.whitespace =*count-fn* =*newline-fn* +comma-node =comma-separated +comma? +CommaNode =line-separated =linebreak? =newline-node =NewlineNode =newlines =space-separated =spaces =whitespace-node =whitespace-nodes =whitespace? =WhitespaceNode +with-count-fn +with-newline-fn ≠ rewrite-clj.paredit -move-n ≠ rewrite-clj.parser ≠parse ≠parse-all ≠ rewrite-clj.parser.core =parse-next ≠ rewrite-clj.parser.keyword =parse-keyword + rewrite-clj.parser.namespaced-map +parse-namespaced-map ≠ rewrite-clj.parser.string =parse-regex =parse-string ≠ rewrite-clj.parser.token =parse-token ≠ rewrite-clj.parser.whitespace =parse-whitespace ≠ rewrite-clj.reader =boundary? -buf +comma? -get-column-number -get-line-number =ignore -indexing-push-back-reader =linebreak? =next =peek -peek-char +position -read-char =read-include-linebreak ≠read-keyword =read-n =read-repeatedly -read-string =read-until =read-while =read-with-meta =space? =string->edn +string-reader =throw-reader ≠unread =whitespace-or-boundary? =whitespace? ≠ rewrite-clj.zip +->root-string +->string ≠append-child +append-child* +append-newline +append-space ≠assoc +child-sexprs ≠down +down* ≠edit +edit* +edit-> +edit->> +edit-node +edn +edn* ≠end? ≠find ≠find-depth-first ≠find-last-by-pos ≠find-next ≠find-next-depth-first ≠find-next-tag ≠find-next-token ≠find-next-value ≠find-tag ≠find-tag-by-pos ≠find-token ≠find-value ≠get ≠insert-child +insert-child* ≠insert-left +insert-left* +insert-newline-left +insert-newline-right ≠insert-right +insert-right* +insert-space-left +insert-space-right ≠left +left* ≠leftmost +leftmost* ≠leftmost? +length +linebreak? ≠list? ≠map ≠map-keys ≠map-vals ≠map? +namespaced-map? ≠next +next* ≠node ≠of-string +position +position-span +postwalk ≠prefix +prepend-newline +prepend-space ≠prev +prev* +prewalk +print +print-root +reapply-context ≠remove +remove* ≠remove-preserve-newline ≠replace +replace* ≠right +right* ≠rightmost +rightmost* ≠rightmost? ≠root ≠root-string ≠seq? ≠set? ≠sexpr +sexpr-able? +skip +skip-whitespace +skip-whitespace-left ≠splice ≠string +subedit-> +subedit->> +subedit-node +subzip ≠suffix ≠tag ≠up +up* +value ≠vector? +whitespace-or-comment? +whitespace? ≠ rewrite-clj.zip.base +->root-string +->string =child-sexprs ≠edn ≠edn* +get-opts =length ≠of-string +print +print-root =root-string +set-opts =sexpr +sexpr-able? =string =tag +value + rewrite-clj.zip.context +reapply-context ≠ rewrite-clj.zip.editz =edit =prefix =replace =splice =suffix ≠ rewrite-clj.zip.findz =find =find-depth-first =find-last-by-pos =find-next =find-next-depth-first =find-next-tag =find-next-token =find-next-value =find-tag =find-tag-by-pos =find-token =find-value -in-range? ≠ rewrite-clj.zip.move =down =end? =left =leftmost =leftmost? =next =prev =right =rightmost =rightmost? =up ≠ rewrite-clj.zip.removez =remove =remove-preserve-newline ≠ rewrite-clj.zip.seqz =assoc =get =list? =map =map-keys =map-vals =map? +namespaced-map? =seq? =set? =vector? + rewrite-clj.zip.subedit +edit-> +edit->> +edit-node +subedit-> +subedit->> +subedit-node +subzip - rewrite-clj.zip.utils -remove-and-move-left -remove-and-move-right -remove-and-move-up -remove-left -remove-left-while -remove-right -remove-right-while -remove-while + rewrite-clj.zip.walk +postwalk +postwalk-subtree +prewalk ≠ rewrite-clj.zip.whitespace ≠append-newline ≠append-space =comment? +insert-newline-left +insert-newline-right +insert-space-left +insert-space-right =linebreak? ≠prepend-newline ≠prepend-space =skip =skip-whitespace =skip-whitespace-left =whitespace-not-linebreak? =whitespace-or-comment? =whitespace? ",
    :name "rwt-cljs vs rwt-clj v1",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1"}
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.custom-zipper.core",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_custom_zipper_core"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +append-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_child"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +branch?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_branch"}
+  {:doc "arglists attributes + [ {} ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +children",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_children"}
+  {:doc "arglists attributes + [ root ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +custom-zipper",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_custom_zipper"}
+  {:doc "arglists attributes + [ value ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +custom-zipper?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_custom_zipper_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +down",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_down"}
+  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +end?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_end"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_child"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_left"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_right"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_left"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +leftmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +lefts",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_lefts"}
+  {:doc "arglists attributes + [ _zloc node children ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +make-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_make_node"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_next"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +position",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +position-span",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position_span"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prev"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove"}
+  {:doc "arglists attributes + [ zloc node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_right"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +rightmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_up"}
+  {:doc "arglists attributes + [ root ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +zipper",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_zipper"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.custom-zipper.utils",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_custom_zipper_utils"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove-and-move-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_left"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove-and-move-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_right"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove-and-move-up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_up"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_left"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove-left-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_left_while"}
+  {:doc "arglists attributes + [ loc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_right"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove-right-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_right_while"}
+  {:doc "",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node"}
+  {:doc "arglists attributes + [ node ] + [ node opts ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_child_sexprs"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠children",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_children_2"}
+  {:doc "arglists attributes + [ form ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠coerce",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_coerce"}
+  {:doc "arglists attributes + [ s ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +comma-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_node"}
+  {:doc "arglists attributes + [ nodes ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +comma-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_separated"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +comma?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma"}
+  {:doc "arglists attributes + [ s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠comment-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comment_node"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comment"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠deref-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_deref_node"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠eval-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_eval_node"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠fn-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_fn_node"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠forms-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_forms_node"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠inner?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_inner"}
   {:doc
-   "Diff of rewrite-clj 1.0.0-alpha cljs & clj Diff of apis in: rewrite-clj 1.0.0-alpha cljs rewrite-clj 1.0.0-alpha clj Options: Option Value :arglists-by :arity-only :exclude-namespaces [\"rewrite-clj.potemkin.clojure\"] :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 5 0 5 publics 0 1 38 arglists 0 1 49 Notes: The cljs and clj sides of rewrite-clj v1 have the following differences of note: You’ll notice that the Clojure API has the ability to deal with files, the ClojureScript API does not. If we were to exclude api namespaces and functions marked with no-doc we would see only item 1 as differences. We include them because it seems that historically, internal undocumented features have been used in rewrite-cljs and rewrite-clj. The ClojureScript API is missing the Clojure API namespaces that cause namespace clashes on the clojurescript side. Table of diffs: ≠ rewrite-clj.node.protocols +make-printable-clj! -make-printable-cljs! +write-node + rewrite-clj.node.string +string-node ≠ rewrite-clj.parser +parse-file +parse-file-all ≠ rewrite-clj.reader +file-reader +newline-normalizing-reader ≠ rewrite-clj.zip +of-file ≠ rewrite-clj.zip.base +of-file + rewrite-clj.zip.edit +edit +prefix +replace +splice +suffix + rewrite-clj.zip.find +find +find-depth-first +find-last-by-pos +find-next +find-next-depth-first +find-next-tag +find-next-token +find-next-value +find-tag +find-tag-by-pos +find-token +find-value + rewrite-clj.zip.remove +remove +remove-preserve-newline + rewrite-clj.zip.seq +assoc +get +list? +map +map-keys +map-vals +map? +seq? +set? +vector? ≠ rewrite-clj.node.protocols :no-doc = true +make-printable-clj! arglists attributes + [ class ] :type + :macro -make-printable-cljs! arglists attributes - [ obj ] :type - :var :no-doc - true +write-node arglists attributes + [ writer node ] :type + :var + rewrite-clj.node.string :no-doc = true +string-node arglists attributes + [ lines ] :type + :var ≠ rewrite-clj.parser +parse-file arglists attributes + [ f ] :type + :var +parse-file-all arglists attributes + [ f ] :type + :var ≠ rewrite-clj.reader :no-doc = true +file-reader arglists attributes + [ f ] :type + :var +newline-normalizing-reader arglists attributes + [ rdr ] :type + :var ≠ rewrite-clj.zip +of-file arglists attributes + [ f ] + [ f opts ] :type + :var ≠ rewrite-clj.zip.base :no-doc = true +of-file arglists attributes + [ f ] + [ f opts ] :type + :var + rewrite-clj.zip.edit :no-doc = true +edit arglists attributes + [ zloc f & args ] :type + :var +prefix arglists attributes + [ zloc s ] :type + :var +replace arglists attributes + [ zloc value ] :type + :var +splice arglists attributes + [ zloc ] :type + :var +suffix arglists attributes + [ zloc s ] :type + :var + rewrite-clj.zip.find :no-doc = true +find arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-depth-first arglists attributes + [ zloc p? ] :type + :var +find-last-by-pos arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var +find-next arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-next-depth-first arglists attributes + [ zloc p? ] :type + :var +find-next-tag arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var +find-next-token arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-next-value arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var +find-tag arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var +find-tag-by-pos arglists attributes + [ zloc pos t ] :type + :var +find-token arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var +find-value arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var + rewrite-clj.zip.remove :no-doc = true +remove arglists attributes + [ zloc ] :type + :var +remove-preserve-newline arglists attributes + [ zloc ] :type + :var + rewrite-clj.zip.seq :no-doc = true +assoc arglists attributes + [ zloc k v ] :type + :var +get arglists attributes + [ zloc k ] :type + :var +list? arglists attributes + [ zloc ] :type + :var +map arglists attributes + [ f zloc ] :type + :var +map-keys arglists attributes + [ f zloc ] :type + :var +map-vals arglists attributes + [ f zloc ] :type + :var +map? arglists attributes + [ zloc ] :type + :var +seq? arglists attributes + [ zloc ] :type + :var +set? arglists attributes + [ zloc ] :type + :var +vector? arglists attributes + [ zloc ] :type + :var",
+   "arglists attributes + [ value ] + [ value base ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +integer-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_integer_node"}
+  {:doc
+   "arglists attributes + [ k ] + [ k auto-resolved? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠keyword-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_node"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +keyword-node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_node_2"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +leader-length",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leader_length"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠length",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_length"}
+  {:doc "arglists attributes + [ nodes ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +line-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_line_separated"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_linebreak"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠list-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_list_node"}
+  {:doc "arglists attributes + [ node map-qualifier ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +map-context-apply",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_context_apply"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +map-context-clear",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_context_clear"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_node"}
+  {:doc
+   "arglists attributes + [ auto-resolved? prefix ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +map-qualifier-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_qualifier_node"}
+  {:doc
+   "arglists attributes + [ children ] + [ metadata data ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠meta-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_meta_node"}
+  {:doc "arglists attributes + [ children ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +namespaced-map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespaced_map_node"}
+  {:doc "arglists attributes + [ s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠newline-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newline_node"}
+  {:doc "arglists attributes + [ n ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠newlines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newlines"}
+  {:doc "arglists attributes + [ x ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_2"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠printable-only?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_printable_only"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠quote-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_quote_node"}
+  {:doc
+   "arglists attributes + [ children ] + [ metadata data ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +raw-meta-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_raw_meta_node"}
+  {:doc
+   "arglists attributes + [ children ] + [ macro-node form-node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠reader-macro-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_reader_macro_node"}
+  {:doc "arglists attributes + [ pattern-string ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +regex-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_regex_node"}
+  {:doc "arglists attributes + [ node children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠replace-children",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace_children"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠set-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_set_node"}
+  {:doc "arglists attributes + [ node ] + [ node opts ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +sexpr-able?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_able"}
+  {:doc
+   "arglists attributes + [ nodes ] + [ nodes opts ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexprs"}
+  {:doc "arglists attributes + [ n ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠spaces",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_spaces"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string"}
+  {:doc "arglists attributes + [ lines ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠string-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_node"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +symbol-node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_symbol_node"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠syntax-quote-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_syntax_quote_node"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_tag"}
+  {:doc
+   "arglists attributes + [ value ] + [ value string-value ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠token-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_token_node"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠uneval-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_uneval_node"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠unquote-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_unquote_node"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠unquote-splicing-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_unquote_splicing_node"}
+  {:doc
+   "arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_value"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠var-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_var_node"}
+  {:doc "arglists attributes + [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠vector-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_vector_node"}
+  {:doc "arglists attributes + [ s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠whitespace-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_node"}
+  {:doc "arglists attributes + [ s ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +whitespace-nodes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_nodes"}
+  {:doc "arglists attributes + [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.coercer",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_coercer"}
+  {:doc "arglists attributes = [ n value ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =node-with-meta",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_with_meta"}
+  {:doc "arglists attributes - [ f sq ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -seq-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_seq_node"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.comment",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_comment"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =comment-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comment_node_2"}
+  {:doc "arglists attributes = [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comment_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =CommentNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_commentnode"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.node.extras",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_extras"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +whitespace-or-comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_or_comment"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.forms",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_forms"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =forms-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_forms_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =FormsNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_formsnode"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.node.integer",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_integer"}
+  {:doc
+   "arglists attributes + [ value ] + [ value base ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +integer-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_integer_node_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +IntNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_intnode"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_keyword"}
+  {:doc
+   "arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠keyword-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_node_3"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +keyword-node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_node_4"}
+  {:doc
+   "arglists attributes + [ kw kw-auto-resolved? map-qualifier {} ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +keyword-sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_sexpr"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =KeywordNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keywordnode"}
+  {:doc "arglists attributes + [ k auto-resolved? ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +kw-qualifier",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_kw_qualifier"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.meta",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_meta"}
+  {:doc
+   "arglists attributes = [ children ] = [ metadata data ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =meta-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_meta_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =MetaNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_metanode"}
+  {:doc
+   "arglists attributes = [ children ] = [ metadata data ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =raw-meta-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_raw_meta_node_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.node.namespaced-map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_namespaced_map"}
+  {:doc
+   "arglists attributes + [ auto-resolved? prefix ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +map-qualifier-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_qualifier_node_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +MapQualifierNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_mapqualifiernode"}
+  {:doc "arglists attributes + [ children ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +namespaced-map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespaced_map_node_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +NamespacedMapNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespacedmapnode"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +reapply-namespaced-map-context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_reapply_namespaced_map_context"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.protocols",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_protocols"}
+  {:doc
+   "arglists attributes + [ [row col] [row-extent col-extent] ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ++extent",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_extent"}
+  {:doc "arglists attributes = [ nodes c ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =assert-sexpr-count",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_assert_sexpr_count"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =assert-single-sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_assert_single_sexpr"}
+  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_child_sexprs_2"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =concat-strings",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_concat_strings"}
+  {:doc "arglists attributes + [ alias ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +default-auto-resolve",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_default_auto_resolve"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +extent",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_extent_2"}
+  {:doc
+   "attributes members name arglists attributes :type = :protocol = children = [ _ ] :type = :var = inner? = [ _ ] :type = :var + leader-length + [ node ] :type + :var = replace-children = [ _ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠InnerNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_innernode"}
+  {:doc "arglists attributes + [ obj ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +make-printable!",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_make_printable"}
+  {:doc "arglists attributes + [ obj ] :type + :var :no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - +make-printable-cljs!",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_make_printable_cljs"}
+  {:doc
+   "attributes members name arglists attributes :type + :protocol + map-context-apply + [ node map-qualifier ] :type + :var + map-context-clear + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +MapQualifiable",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_mapqualifiable"}
+  {:doc "arglists attributes + [ form ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +meta-elided",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_meta_elided"}
+  {:doc
+   "attributes members name arglists attributes :type = :protocol = length = [ _ ] :type = :var + node-type + [ node ] :type + :var = printable-only? = [ _ ] :type = :var - sexpr - [ _ ] :type - :var + sexpr* + [ node opts ] :type + :var = string = [ _ ] :type = :var = tag = [ _ ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠Node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_3"}
+  {:doc "arglists attributes + [ x ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_4"}
+  {:doc
+   "attributes members name arglists attributes :type = :protocol = coerce = [ _ ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =NodeCoerceable",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_nodecoerceable"}
+  {:doc "arglists attributes + [ node ] + [ node opts ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_2"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +sexpr-able?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_able_2"}
+  {:doc
+   "arglists attributes = [ nodes ] + [ nodes opts ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexprs_2"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =sum-lengths",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sum_lengths"}
+  {:doc
+   "arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_value_2"}
+  {:doc "arglists attributes + [ nodes ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +without-whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_without_whitespace"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.node.regex",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_regex"}
+  {:doc "arglists attributes + [ regex ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +pattern-string-for-regex",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_pattern_string_for_regex"}
+  {:doc "arglists attributes + [ pattern-string ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +regex-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_regex_node_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +RegexNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_regexnode"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.seq",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_seq"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =list-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_list_node_2"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =map-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =SeqNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_seqnode"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =set-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_set_node_2"}
+  {:doc "arglists attributes = [ children ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =vector-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_vector_node_2"}
+  {:doc "arglists attributes - [ s ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -wrap-list",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_wrap_list"}
+  {:doc "arglists attributes - [ s ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -wrap-map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_wrap_map"}
+  {:doc "arglists attributes - [ s ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -wrap-set",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_wrap_set"}
+  {:doc "arglists attributes - [ s ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -wrap-vec",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_wrap_vec"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.stringz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_stringz"}
+  {:doc "arglists attributes = [ lines ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =string-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =StringNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_stringnode"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_token"}
+  {:doc "arglists attributes + [ n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +symbol-node?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_symbol_node_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +SymbolNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_symbolnode"}
+  {:doc
+   "arglists attributes = [ value ] = [ value string-value ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =token-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_token_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =TokenNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_tokennode"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_whitespace"}
+  {:doc "attributes :type = :var :dynamic = true ",
+   :name "rwt-cljs vs rwt-clj v1 - =*count-fn*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_count_fn"}
+  {:doc "attributes :type = :var :dynamic = true ",
+   :name "rwt-cljs vs rwt-clj v1 - =*newline-fn*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newline_fn"}
+  {:doc "arglists attributes + [ s ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +comma-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_node_2"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =comma-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_separated_2"}
+  {:doc "arglists attributes + [ node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +comma?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_2"}
+  {:doc "attributes :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +CommaNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_commanode"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =line-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_line_separated_2"}
+  {:doc "arglists attributes = [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_linebreak_2"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =newline-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newline_node_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =NewlineNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newlinenode"}
+  {:doc "arglists attributes = [ n ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =newlines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newlines_2"}
+  {:doc "arglists attributes = [ nodes ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =space-separated",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_space_separated"}
+  {:doc "arglists attributes = [ n ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =spaces",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_spaces_2"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =whitespace-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_node_2"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =whitespace-nodes",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_nodes_2"}
+  {:doc "arglists attributes = [ node ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_2"}
+  {:doc "attributes :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =WhitespaceNode",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespacenode"}
+  {:doc "arglists attributes + [ f & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +with-count-fn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_with_count_fn"}
+  {:doc "arglists attributes + [ f & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +with-newline-fn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_with_newline_fn"}
+  {:doc "",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.paredit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_paredit"}
+  {:doc
+   "arglists attributes - [ loc f n ] :type - :var :no-doc - true ",
+   :name "rwt-cljs vs rwt-clj v1 - -move-n",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_move_n"}
+  {:doc "",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser"}
+  {:doc
+   "arglists attributes = [ reader ] :type = :var :no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠parse",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse"}
+  {:doc
+   "arglists attributes = [ reader ] :type = :var :no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠parse-all",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_all"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.core",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_core"}
+  {:doc "arglists attributes = [ rdr ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =parse-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_next"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_keyword"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =parse-keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_keyword"}
+  {:doc ":no-doc = true ",
+   :name
+   "rwt-cljs vs rwt-clj v1 - + rewrite-clj.parser.namespaced-map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_namespaced_map"}
+  {:doc "arglists attributes + [ reader read-next ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +parse-namespaced-map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_namespaced_map"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_string"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =parse-regex",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_regex"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =parse-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_string"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_token"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =parse-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_token"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_whitespace"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =parse-whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_whitespace"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_reader"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =boundary?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_boundary"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -buf",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_buf"}
+  {:doc "arglists attributes + [ c ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +comma?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_3"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -get-column-number",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_get_column_number"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -get-line-number",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_get_line_number"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =ignore",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_ignore"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -indexing-push-back-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_indexing_push_back_reader"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_linebreak_3"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_next_2"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =peek",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_peek"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -peek-char",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_peek_char"}
+  {:doc "arglists attributes + [ reader row-k col-k ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +position",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position_2"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -read-char",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_char"}
+  {:doc "arglists attributes = [ reader ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =read-include-linebreak",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_include_linebreak"}
+  {:doc
+   "arglists attributes + [ reader ] - [ reader initch ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠read-keyword",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_keyword"}
+  {:doc
+   "arglists attributes = [ reader node-tag read-fn p? n ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =read-n",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_n"}
+  {:doc "arglists attributes = [ reader read-fn ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =read-repeatedly",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_repeatedly"}
+  {:doc "attributes :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -read-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_string"}
+  {:doc "arglists attributes = [ reader p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =read-until",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_until"}
+  {:doc
+   "arglists attributes = [ reader p? ] = [ reader p? eof? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =read-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_while"}
+  {:doc "arglists attributes = [ reader read-fn ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =read-with-meta",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_with_meta"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =space?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_space"}
+  {:doc "arglists attributes = [ s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =string->edn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_edn"}
+  {:doc "arglists attributes + [ s ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +string-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_reader"}
+  {:doc "arglists attributes = [ reader fmt & data ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =throw-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_throw_reader"}
+  {:doc "arglists attributes + [ reader ch ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠unread",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_unread"}
+  {:doc "arglists attributes = [ c ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =whitespace-or-boundary?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_or_boundary"}
+  {:doc "arglists attributes = [ ch ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_3"}
+  {:doc "",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip"}
+  {:doc
+   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +->root-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_string"}
+  {:doc
+   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +->string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_2"}
+  {:doc "arglists attributes + [ zloc item ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠append-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_child_2"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +append-child*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_child_3"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +append-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_newline"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +append-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_space"}
+  {:doc "arglists attributes + [ zloc k v ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠assoc",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_assoc"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_child_sexprs_3"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠down",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_down_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +down*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_down_3"}
+  {:doc "arglists attributes + [ zloc f & args ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_2"}
+  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +edit*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_3"}
+  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +edit->",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_4"}
+  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +edit->>",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_5"}
+  {:doc "arglists attributes + [ zloc f ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +edit-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_node"}
+  {:doc "arglists attributes + [ node ] + [ node opts ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +edn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edn"}
+  {:doc "arglists attributes + [ node ] + [ node opts ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +edn*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edn_2"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠end?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_end_2"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find"}
+  {:doc "arglists attributes + [ zloc p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_depth_first"}
+  {:doc
+   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-last-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_last_by_pos"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next"}
+  {:doc "arglists attributes + [ zloc p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-next-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_depth_first"}
+  {:doc
+   "arglists attributes + [ zloc t ] + [ zloc f t ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-next-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_tag"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-next-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_token"}
+  {:doc
+   "arglists attributes + [ zloc v ] + [ zloc f v ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-next-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_value"}
+  {:doc
+   "arglists attributes + [ zloc t ] + [ zloc f t ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_tag"}
+  {:doc "arglists attributes + [ zloc pos t ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-tag-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_tag_by_pos"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_token"}
+  {:doc
+   "arglists attributes + [ zloc v ] + [ zloc f v ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠find-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_value"}
+  {:doc "arglists attributes + [ zloc k ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠get",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_get"}
+  {:doc "arglists attributes + [ zloc item ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠insert-child",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_child_2"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-child*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_child_3"}
+  {:doc "arglists attributes + [ zloc item ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠insert-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_left_2"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-left*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_left_3"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-newline-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_newline_left"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-newline-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_newline_right"}
+  {:doc "arglists attributes + [ zloc item ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠insert-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_right_2"}
+  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-right*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_right_3"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-space-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_space_left"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-space-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_space_right"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_left_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +left*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_left_3"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠leftmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +leftmost*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost_3"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠leftmost?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost_4"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +length",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_length_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_linebreak_4"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠list?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_list"}
+  {:doc "arglists attributes + [ f zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map"}
+  {:doc "arglists attributes + [ f zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠map-keys",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_keys"}
+  {:doc "arglists attributes + [ f zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠map-vals",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_vals"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +namespaced-map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespaced_map"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_next_3"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +next*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_next_4"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_5"}
+  {:doc "arglists attributes + [ s ] + [ s opts ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠of-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_of_string"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +position",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position_3"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +position-span",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position_span_2"}
+  {:doc
+   "arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +postwalk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_postwalk"}
+  {:doc "arglists attributes + [ zloc s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠prefix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prefix"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +prepend-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prepend_newline"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +prepend-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prepend_space"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prev_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +prev*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prev_3"}
+  {:doc
+   "arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +prewalk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prewalk"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc writer ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +print",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_print"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc writer ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +print-root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_print_root"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +reapply-context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_reapply_context"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +remove*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_3"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠remove-preserve-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_preserve_newline"}
+  {:doc "arglists attributes + [ zloc value ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace_2"}
+  {:doc "arglists attributes + [ zloc node ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +replace*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace_3"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_right_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +right*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_right_3"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠rightmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +rightmost*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost_3"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠rightmost?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost_4"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_2"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠root-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_string_2"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠seq?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_seq"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠set?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_set"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_3"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +sexpr-able?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_able_3"}
+  {:doc "arglists attributes + [ f p? zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +skip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip"}
+  {:doc "arglists attributes + [ zloc ] + [ f zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +skip-whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip_whitespace"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +skip-whitespace-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip_whitespace_left"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_splice"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_3"}
+  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +subedit->",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit"}
+  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +subedit->>",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_2"}
+  {:doc "arglists attributes + [ zloc f ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +subedit-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_node"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +subzip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subzip"}
+  {:doc "arglists attributes + [ zloc s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠suffix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_suffix"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_tag_2"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_up_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +up*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_up_3"}
+  {:doc
+   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_value_3"}
+  {:doc "arglists attributes + [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠vector?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_vector"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +whitespace-or-comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_or_comment_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_4"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.base",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_base"}
+  {:doc
+   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +->root-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_string_3"}
+  {:doc
+   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +->string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =child-sexprs",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_child_sexprs_4"}
+  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠edn",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edn_3"}
+  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠edn*",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edn_4"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +get-opts",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_get_opts"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =length",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_length_3"}
+  {:doc "arglists attributes = [ s ] + [ s opts ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠of-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_of_string_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc writer ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +print",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_print_2"}
+  {:doc
+   "arglists attributes + [ zloc ] + [ zloc writer ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +print-root",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_print_root_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =root-string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_string_4"}
+  {:doc "arglists attributes + [ zloc opts ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +set-opts",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_set_opts"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =sexpr",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_4"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +sexpr-able?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_able_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_5"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_tag_3"}
+  {:doc
+   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - +value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_value_4"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.zip.context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_context"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +reapply-context",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_reapply_context_2"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.editz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_editz"}
+  {:doc "arglists attributes = [ zloc f & args ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_6"}
+  {:doc "arglists attributes = [ zloc s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =prefix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prefix_2"}
+  {:doc "arglists attributes = [ zloc value ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_splice_2"}
+  {:doc "arglists attributes = [ zloc s ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =suffix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_suffix_2"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.findz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_findz"}
+  {:doc
+   "arglists attributes = [ zloc p? ] = [ zloc f p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_2"}
+  {:doc "arglists attributes = [ zloc p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_depth_first_2"}
+  {:doc
+   "arglists attributes = [ zloc pos ] = [ zloc pos p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-last-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_last_by_pos_2"}
+  {:doc
+   "arglists attributes = [ zloc p? ] = [ zloc f p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_2"}
+  {:doc "arglists attributes = [ zloc p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-next-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_depth_first_2"}
+  {:doc
+   "arglists attributes = [ zloc t ] = [ zloc f t ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-next-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_tag_2"}
+  {:doc
+   "arglists attributes = [ zloc p? ] = [ zloc f p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-next-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_token_2"}
+  {:doc
+   "arglists attributes = [ zloc v ] = [ zloc f v ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-next-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_value_2"}
+  {:doc
+   "arglists attributes = [ zloc t ] = [ zloc f t ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_tag_2"}
+  {:doc "arglists attributes = [ zloc pos t ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-tag-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_tag_by_pos_2"}
+  {:doc
+   "arglists attributes = [ zloc p? ] = [ zloc f p? ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_token_2"}
+  {:doc
+   "arglists attributes = [ zloc v ] = [ zloc f v ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =find-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_value_2"}
+  {:doc "arglists attributes - [ {} {} ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -in-range?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_in_range"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.move",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_move"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =down",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_down_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =end?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_end_3"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_left_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =leftmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost_5"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =leftmost?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost_6"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_next_5"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =prev",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prev_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_right_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =rightmost",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost_5"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =rightmost?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost_6"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_up_4"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.removez",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_removez"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_4"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =remove-preserve-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_preserve_newline_2"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.seqz",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_seqz"}
+  {:doc "arglists attributes = [ zloc k v ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =assoc",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_assoc_2"}
+  {:doc "arglists attributes = [ zloc k ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =get",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_get_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =list?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_list_2"}
+  {:doc "arglists attributes = [ f zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_3"}
+  {:doc "arglists attributes = [ f zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =map-keys",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_keys_2"}
+  {:doc "arglists attributes = [ f zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =map-vals",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_vals_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_4"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +namespaced-map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespaced_map_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =seq?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_seq_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =set?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_set_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =vector?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_vector_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.zip.subedit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_subedit"}
+  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +edit->",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_7"}
+  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +edit->>",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_8"}
+  {:doc "arglists attributes + [ zloc f ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +edit-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_node_2"}
+  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +subedit->",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_3"}
+  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+   :name "rwt-cljs vs rwt-clj v1 - +subedit->>",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_4"}
+  {:doc "arglists attributes + [ zloc f ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +subedit-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_node_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +subzip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subzip_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - - rewrite-clj.zip.utils",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_utils"}
+  {:doc "arglists attributes - [ [_ {} :as loc] ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -remove-and-move-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_left_2"}
+  {:doc "arglists attributes - [ [_ {} :as loc] ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -remove-and-move-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_right_2"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -remove-and-move-up",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_up_2"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -remove-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_left_2"}
+  {:doc "arglists attributes - [ zloc p? ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -remove-left-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_left_while_2"}
+  {:doc "arglists attributes - [ loc ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -remove-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_right_2"}
+  {:doc "arglists attributes - [ zloc p? ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -remove-right-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_right_while_2"}
+  {:doc "arglists attributes - [ zloc p? ] :type - :var ",
+   :name "rwt-cljs vs rwt-clj v1 - -remove-while",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_while"}
+  {:doc ":no-doc = true ",
+   :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.zip.walk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_walk"}
+  {:doc
+   "arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +postwalk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_postwalk_2"}
+  {:doc "arglists attributes + [ p? f zloc ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +postwalk-subtree",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_postwalk_subtree"}
+  {:doc
+   "arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +prewalk",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prewalk_2"}
+  {:doc ":no-doc + true ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_whitespace"}
+  {:doc
+   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠append-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_newline_2"}
+  {:doc
+   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠append-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_space_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comment_3"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-newline-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_newline_left_2"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-newline-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_newline_right_2"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-space-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_space_left_2"}
+  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+   :name "rwt-cljs vs rwt-clj v1 - +insert-space-right",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_space_right_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_linebreak_5"}
+  {:doc
+   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠prepend-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prepend_newline_2"}
+  {:doc
+   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ",
+   :name "rwt-cljs vs rwt-clj v1 - ≠prepend-space",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prepend_space_2"}
+  {:doc "arglists attributes = [ f p? zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =skip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip_2"}
+  {:doc "arglists attributes = [ zloc ] = [ f zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =skip-whitespace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip_whitespace_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =skip-whitespace-left",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip_whitespace_left_2"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =whitespace-not-linebreak?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_not_linebreak"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =whitespace-or-comment?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_or_comment_3"}
+  {:doc "arglists attributes = [ zloc ] :type = :var ",
+   :name "rwt-cljs vs rwt-clj v1 - =whitespace?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_5"}
+  {:doc
+   "Diff of rewrite-clj 1.0.0-alpha cljs & clj Diff of apis in: rewrite-clj 1.0.0-alpha cljs rewrite-clj 1.0.0-alpha clj Options: Option Value :arglists-by :arity-only :exclude-namespaces [\"rewrite-clj.potemkin.clojure\"] :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 5 0 5 publics 0 1 38 arglists 0 1 49 Notes: The cljs and clj sides of rewrite-clj v1 have the following differences of note: You’ll notice that the Clojure API has the ability to deal with files, the ClojureScript API does not. If we were to exclude api namespaces and functions marked with no-doc we would see only item 1 as differences. We include them because it seems that historically, internal undocumented features have been used in rewrite-cljs and rewrite-clj. The ClojureScript API is missing the Clojure API namespaces that cause namespace clashes on the clojurescript side. Table of diffs: ≠ rewrite-clj.node.protocols +make-printable-clj! -make-printable-cljs! +write-node + rewrite-clj.node.string +string-node ≠ rewrite-clj.parser +parse-file +parse-file-all ≠ rewrite-clj.reader +file-reader +newline-normalizing-reader ≠ rewrite-clj.zip +of-file ≠ rewrite-clj.zip.base +of-file + rewrite-clj.zip.edit +edit +prefix +replace +splice +suffix + rewrite-clj.zip.find +find +find-depth-first +find-last-by-pos +find-next +find-next-depth-first +find-next-tag +find-next-token +find-next-value +find-tag +find-tag-by-pos +find-token +find-value + rewrite-clj.zip.remove +remove +remove-preserve-newline + rewrite-clj.zip.seq +assoc +get +list? +map +map-keys +map-vals +map? +seq? +set? +vector? ",
    :name "rwt-clj v1 clj vs cljs all",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all"}
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.node.protocols",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_node_protocols"}
+  {:doc "arglists attributes + [ class ] :type + :macro ",
+   :name "rwt-clj v1 clj vs cljs all - +make-printable-clj!",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_make_printable_clj"}
+  {:doc "arglists attributes - [ obj ] :type - :var :no-doc - true ",
+   :name "rwt-clj v1 clj vs cljs all - -make-printable-cljs!",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_make_printable_cljs"}
+  {:doc "arglists attributes + [ writer node ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +write-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_write_node"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.node.string",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_node_string"}
+  {:doc "arglists attributes + [ lines ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +string-node",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_string_node"}
+  {:doc "",
+   :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.parser",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_parser"}
+  {:doc "arglists attributes + [ f ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +parse-file",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_parse_file"}
+  {:doc "arglists attributes + [ f ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +parse-file-all",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_parse_file_all"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_reader"}
+  {:doc "arglists attributes + [ f ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +file-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_file_reader"}
+  {:doc "arglists attributes + [ rdr ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +newline-normalizing-reader",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_newline_normalizing_reader"}
+  {:doc "",
+   :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.zip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip"}
+  {:doc "arglists attributes + [ f ] + [ f opts ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +of-file",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_of_file"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.zip.base",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_base"}
+  {:doc "arglists attributes + [ f ] + [ f opts ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +of-file",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_of_file_2"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.zip.edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_edit"}
+  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +edit",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_edit"}
+  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +prefix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_prefix"}
+  {:doc "arglists attributes + [ zloc value ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +replace",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_replace"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +splice",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_splice"}
+  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +suffix",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_suffix"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.zip.find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_find"}
   {:doc
-   "Diff of rewrite-clj 1.0.0-alpha cljs & clj Diff of apis in: rewrite-clj 1.0.0-alpha cljs rewrite-clj 1.0.0-alpha clj Options: Option Value :arglists-by :arity-only :exclude-namespaces [\"rewrite-clj.potemkin.clojure\"] :exclude-with [:no-doc :skip-wiki] :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 2 0 0 publics 0 0 3 arglists 0 0 4 Notes: When we exclude API elements that are considered internal, we are left with the expected feature differences between cljs and clj usages, namely: file support. Table of diffs: ≠ rewrite-clj.parser +parse-file +parse-file-all ≠ rewrite-clj.zip +of-file ≠ rewrite-clj.parser +parse-file arglists attributes + [ f ] :type + :var +parse-file-all arglists attributes + [ f ] :type + :var ≠ rewrite-clj.zip +of-file arglists attributes + [ f ] + [ f opts ] :type + :var",
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_depth_first"}
+  {:doc
+   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-last-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_last_by_pos"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-next",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next"}
+  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-next-depth-first",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next_depth_first"}
+  {:doc
+   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-next-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next_tag"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-next-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next_token"}
+  {:doc
+   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-next-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next_value"}
+  {:doc
+   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-tag",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_tag"}
+  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-tag-by-pos",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_tag_by_pos"}
+  {:doc
+   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-token",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_token"}
+  {:doc
+   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +find-value",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_value"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.zip.remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_remove"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +remove",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_remove"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +remove-preserve-newline",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_remove_preserve_newline"}
+  {:doc ":no-doc = true ",
+   :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.zip.seq",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_seq"}
+  {:doc "arglists attributes + [ zloc k v ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +assoc",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_assoc"}
+  {:doc "arglists attributes + [ zloc k ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +get",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_get"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +list?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_list"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +map",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_map"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +map-keys",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_map_keys"}
+  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +map-vals",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_map_vals"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +map?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_map_2"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +seq?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_seq"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +set?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_set"}
+  {:doc "arglists attributes + [ zloc ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs all - +vector?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_vector"}
+  {:doc
+   "Diff of rewrite-clj 1.0.0-alpha cljs & clj Diff of apis in: rewrite-clj 1.0.0-alpha cljs rewrite-clj 1.0.0-alpha clj Options: Option Value :arglists-by :arity-only :exclude-namespaces [\"rewrite-clj.potemkin.clojure\"] :exclude-with [:no-doc :skip-wiki] :include :changed-publics Legend: -A only +B only -A is+different from B ≠changes within A and B =equal Stats: Element Have changes within In A Only In B Only namespaces 2 0 0 publics 0 0 3 arglists 0 0 4 Notes: When we exclude API elements that are considered internal, we are left with the expected feature differences between cljs and clj usages, namely: file support. Table of diffs: ≠ rewrite-clj.parser +parse-file +parse-file-all ≠ rewrite-clj.zip +of-file ",
    :name "rwt-clj v1 clj vs cljs public",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public"}
-  {:doc
-   "Frequently Asked Questions Documentation What is the meaning of the ^:no-doc metadata? Our goal is to produce documentation for users of rewrite-clj. As such we only want to document public APIs. ^:no-doc is a signal to cljdoc that source code should not be included in generated documentation. This metadata convention was introduced by codox. What the markdown? Stand alone articles are written up in AsciiDoc. it is a richer markup language than GitHub markdown. is supported by cljdoc. Our docstrings sometimes take advantage of CommonMark which is supported by cljdoc for docstrings. GitHub uses CommonMark as part of of its markdown solution.",
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#"}
+  {:doc "",
+   :name "rwt-clj v1 clj vs cljs public - ≠ rewrite-clj.parser",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_rewrite_clj_parser"}
+  {:doc "arglists attributes + [ f ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs public - +parse-file",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_parse_file"}
+  {:doc "arglists attributes + [ f ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs public - +parse-file-all",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_parse_file_all"}
+  {:doc "",
+   :name "rwt-clj v1 clj vs cljs public - ≠ rewrite-clj.zip",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_rewrite_clj_zip"}
+  {:doc "arglists attributes + [ f ] + [ f opts ] :type + :var ",
+   :name "rwt-clj v1 clj vs cljs public - +of-file",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_of_file"}
+  {:doc "Frequently Asked Questions ",
    :name "Frequently Asked Questions",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/frequently-asked-questions"}
-  {:doc
-   "Contributing Guidelines Do remember that a gift, while appreciated, is also a burden. We value your input but start with an issue to propose your change before investing your valuable time in a PR. read the rewrite-clj Developer Guide. follow the seven rules of a great Git commit message. follow the Clojure Style Guide. include/update tests for your change. ensure that the Continuous Integration checks pass. feel free to pester the project maintainers about your PR if it hasn't been responded to. Sometimes notifications can be missed. Don't include more than one feature or fix in a single PR. include changes unrelated to the purpose of the PR. This includes changing the project version number, adding lines to the .gitignore file, or changing the indentation or formatting. open a new PR if changes are requested. Just push to the same branch and the PR will be updated. overuse vertical whitespace; avoid multiple sequential blank lines.",
-   :name "Contributing",
-   :path "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/contributing"}
-  {:doc
-   "Contributor Covenant Code of Conduct Our Pledge We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation. We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community. Our Standards Examples of behavior that contributes to a positive environment for our community include: Demonstrating empathy and kindness toward other people Being respectful of differing opinions, viewpoints, and experiences Giving and gracefully accepting constructive feedback Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience Focusing on what is best not just for us as individuals, but for the overall community Examples of unacceptable behavior include: The use of sexualized language or imagery, and sexual attention or advances of any kind Trolling, insulting or derogatory comments, and personal or political attacks Public or private harassment Publishing others' private information, such as a physical or email address, without their explicit permission Other conduct which could reasonably be considered inappropriate in a professional setting Enforcement Responsibilities Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate. Scope This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Enforcement Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly. All community leaders are obligated to respect the privacy and security of the reporter of any incident. Enforcement Guidelines Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct: 1. Correction Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community. Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested. 2. Warning Community Impact: A violation through a single incident or series of actions. Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban. 3. Temporary Ban Community Impact: A serious violation of community standards, including sustained inappropriate behavior. Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban. 4. Permanent Ban Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals. Consequence: A permanent ban from any sort of public interaction within the community. Attribution This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html. Community Impact Guidelines were inspired by Mozilla's code of conduct enforcement ladder. For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.",
-   :name "Code of Conduct",
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/frequently-asked-questions#"}
+  {:doc "",
+   :name "Frequently Asked Questions - Documentation",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct"}
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/frequently-asked-questions#_documentation"}
   {:doc
-   "Maintainer Guide Table of Contents Introduction Releasing Overview Updating the Version Special Setup Local Verification Invoking Introduction This doc covers notes for project maintainers. Releasing Overview The released workflow is handled by our Release GitHub Action. The release workflow: Create a thin jar using our version scheme Apply jar version to following docs: user guide docs deps.edn usage example change log \"unreleased\" and \"unreleased breaking changes\" headings Deploy the jar to clojars Commit and push updates made to CHANGELOG.adoc and 01-user-guide.adoc back to the project Create and push a release tag back to the project repo Inform cljdoc of the new release At this time, the release workflow does not run tests. The assumption is that you’ve waited for the last CI test run to complete and are happy with the results. The release workflow will fail if the change log is not ready for release. Updating the Version Edit version.edn in the project root. The release workflow consults this file when constructing the version. Special Setup GitHub has been configured with necessary secrets for GitHub Actions to deploy to clojars. Local Verification To run the change log validation locally: bb ci-release validate If you so wish, you can also locally run all steps up to, but not including, deploy via: bb ci-release prep Be aware though that you will NOT want to check in changes prep makes to CHANGELOG.adoc and 01-user-guide.adoc. Invoking As a maintainer you should have sufficient privileges to see a \"Run Workflow\" dropdown button on the Release action page. The dropdown will prompt for a branch. I did not see a way to disable this prompt, simply leave it at \"main\" and run the workflow. Don’t forget to pull after a release to get the changes made by the release workflow.",
+   "Our goal is to produce documentation for users of rewrite-clj. As such we only want to document public APIs. ^:no-doc is a signal to cljdoc that source code should not be included in generated documentation. This metadata convention was introduced by codox. ",
+   :name
+   "Frequently Asked Questions - What is the meaning of the ^:no-doc metadata?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/frequently-asked-questions#_what_is_the_meaning_of_the_no_doc_metadata"}
+  {:doc
+   "Stand alone articles are written up in AsciiDoc. it is a richer markup language than GitHub markdown. is supported by cljdoc. Our docstrings sometimes take advantage of CommonMark which is supported by cljdoc for docstrings. GitHub uses CommonMark as part of of its markdown solution. ",
+   :name "Frequently Asked Questions - What the markdown?",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/frequently-asked-questions#_what_the_markdown"}
+  {:doc
+   "Do remember that a gift, while appreciated, is also a burden. We value your input but start with an issue to propose your change before investing your valuable time in a PR. read the rewrite-clj Developer Guide. follow the seven rules of a great Git commit message. follow the Clojure Style Guide. include/update tests for your change. ensure that the Continuous Integration checks pass. feel free to pester the project maintainers about your PR if it hasn't been responded to. Sometimes notifications can be missed. Don't include more than one feature or fix in a single PR. include changes unrelated to the purpose of the PR. This includes changing the project version number, adding lines to the .gitignore file, or changing the indentation or formatting. open a new PR if changes are requested. Just push to the same branch and the PR will be updated. overuse vertical whitespace; avoid multiple sequential blank lines. ",
+   :name "Contributing - Contributing Guidelines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/contributing#contributing-guidelines"}
+  {:doc
+   "We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation. We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community. ",
+   :name "Code of Conduct - Our Pledge",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#our-pledge"}
+  {:doc
+   "Examples of behavior that contributes to a positive environment for our community include: Demonstrating empathy and kindness toward other people Being respectful of differing opinions, viewpoints, and experiences Giving and gracefully accepting constructive feedback Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience Focusing on what is best not just for us as individuals, but for the overall community Examples of unacceptable behavior include: The use of sexualized language or imagery, and sexual attention or advances of any kind Trolling, insulting or derogatory comments, and personal or political attacks Public or private harassment Publishing others' private information, such as a physical or email address, without their explicit permission Other conduct which could reasonably be considered inappropriate in a professional setting ",
+   :name "Code of Conduct - Our Standards",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#our-standards"}
+  {:doc
+   "Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate. ",
+   :name "Code of Conduct - Enforcement Responsibilities",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#enforcement-responsibilities"}
+  {:doc
+   "This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. ",
+   :name "Code of Conduct - Scope",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#scope"}
+  {:doc
+   "Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly. All community leaders are obligated to respect the privacy and security of the reporter of any incident. ",
+   :name "Code of Conduct - Enforcement",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#enforcement"}
+  {:doc
+   "Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct: ",
+   :name "Code of Conduct - Enforcement Guidelines",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#enforcement-guidelines"}
+  {:doc
+   "Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community. Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested. ",
+   :name "Code of Conduct - 1. Correction",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#1-correction"}
+  {:doc
+   "Community Impact: A violation through a single incident or series of actions. Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban. ",
+   :name "Code of Conduct - 2. Warning",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#2-warning"}
+  {:doc
+   "Community Impact: A serious violation of community standards, including sustained inappropriate behavior. Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban. ",
+   :name "Code of Conduct - 3. Temporary Ban",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#3-temporary-ban"}
+  {:doc
+   "Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals. Consequence: A permanent ban from any sort of public interaction within the community. ",
+   :name "Code of Conduct - 4. Permanent Ban",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#4-permanent-ban"}
+  {:doc
+   "This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html. Community Impact Guidelines were inspired by Mozilla's code of conduct enforcement ladder. For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations. ",
+   :name "Code of Conduct - Attribution",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/code-of-conduct#attribution"}
+  {:doc
+   "Maintainer Guide Table of Contents Introduction Releasing Overview Updating the Version Special Setup Local Verification Invoking ",
    :name "Maintainer Guide",
    :path
-   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide"}],
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide#"}
+  {:doc "This doc covers notes for project maintainers. ",
+   :name "Maintainer Guide - Introduction",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide#_introduction"}
+  {:doc "",
+   :name "Maintainer Guide - Releasing",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide#_releasing"}
+  {:doc
+   "The released workflow is handled by our Release GitHub Action. The release workflow: Create a thin jar using our version scheme Apply jar version to following docs: user guide docs deps.edn usage example change log \"unreleased\" and \"unreleased breaking changes\" headings Deploy the jar to clojars Commit and push updates made to CHANGELOG.adoc and 01-user-guide.adoc back to the project Create and push a release tag back to the project repo Inform cljdoc of the new release At this time, the release workflow does not run tests. The assumption is that you’ve waited for the last CI test run to complete and are happy with the results. The release workflow will fail if the change log is not ready for release. ",
+   :name "Maintainer Guide - Overview",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide#_overview"}
+  {:doc
+   "Edit version.edn in the project root. The release workflow consults this file when constructing the version. ",
+   :name "Maintainer Guide - Updating the Version",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide#_updating_the_version"}
+  {:doc
+   "GitHub has been configured with necessary secrets for GitHub Actions to deploy to clojars. ",
+   :name "Maintainer Guide - Special Setup",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide#_special_setup"}
+  {:doc
+   "To run the change log validation locally: bb ci-release validate If you so wish, you can also locally run all steps up to, but not including, deploy via: bb ci-release prep Be aware though that you will NOT want to check in changes prep makes to CHANGELOG.adoc and 01-user-guide.adoc. ",
+   :name "Maintainer Guide - Local Verification",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide#_local_verification"}
+  {:doc
+   "As a maintainer you should have sufficient privileges to see a \"Run Workflow\" dropdown button on the Release action page. The dropdown will prompt for a branch. I did not see a way to disable this prompt, simply leave it at \"main\" and run the workflow. Don’t forget to pull after a release to get the changes made by the release workflow. ",
+   :name "Maintainer Guide - Invoking",
+   :path
+   "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/maintainer-guide#_invoking"}],
  :namespaces
  [{:doc
    "APIs to navigate and update Clojure/ClojureScript/EDN source code.\n\nUse [[rewrite-clj.zip]] to ingest your source code into a zipper of nodes and then again to navigate and/or change it.\n\nOptionally use [[rewrite-clj.parser]] to instead work with raw nodes.\n\n[[rewrite-clj.node]] will help you to inspect and create nodes.\n\n[[rewrite-clj.paredit]] first appeared in the ClojureScript only version of rewrite-clj and supports structured editing of the zipper tree.",

--- a/src/cljdoc/render/api_searchset.clj
+++ b/src/cljdoc/render/api_searchset.clj
@@ -7,8 +7,6 @@
             [clojure.string :as str])
   (:import (org.jsoup Jsoup)))
 
-(def header-tag? #{"h1" "h2" "h3" "h4" "h5" "h6"})
-
 (defn path-for-doc
   [doc version-entity]
   (routes/url-for :artifact/doc
@@ -29,19 +27,111 @@
   [version-entity name-of-ns def-name]
   (str (path-for-namespace version-entity name-of-ns) "#" def-name))
 
-(defn- elements->doc-segments
-  "Does the tricky work of walking through the Jsoup node siblings and collecting
-  headers and their text. Important considerations:
+(defn- soup-elem?
+  "Returns true if Jsoup elem is an html element (as oppposed to a text node)"
+  [elem]
+  (instance? org.jsoup.nodes.Element elem))
 
-  1. Documents do not necessarily start with a header.
-  2. Headers do not necessarily have text between them and the next header or the
-     end of the document.
-  3. Flexmark makes sure that all markdown headers have anchors, meaning this only works for markdown and not asciidoc."
-  [elements doc-title]
+(defn heading-elem?
+  [elem]
+  (and
+   (soup-elem? elem)
+   (#{"h1" "h2" "h3" "h4" "h5" "h6"} (.tagName elem))
+   (= "a" (some-> elem .children first .tagName))))
+
+(defn- adoc-section? [elem]
+  (and (soup-elem? elem)
+       (= "div" (.tagName elem))
+       (.hasAttr elem "class")
+       (re-matches #"sect[1-9]" (.attr elem "class"))
+       (heading-elem? (first (.children elem)))))
+
+(defn- adoc-section-title [section-elem]
+  (-> section-elem .children .first .text))
+
+(defn- adoc-section-anchor [section-elem]
+  (-> section-elem .children .first .attributes (.get "id")))
+
+(defn- append-text [s elem]
+  (let [t (-> elem .text str/trim)]
+    (if (= "" t)
+      s
+      (str s t " "))))
+
+(defn adoc-section-text [section-elem]
+  (let [elems (if (= "sectionbody" (some-> section-elem
+                                           .children
+                                           first
+                                           .nextElementSibling
+                                           (.attr "class")))
+                (-> section-elem .children .first .nextElementSibling .childNodes)
+                (-> section-elem .childNodes))]
+    (reduce (fn [acc elem]
+              (if (or (adoc-section? elem) (heading-elem? elem))
+                acc
+                (append-text acc elem)))
+            ""
+            elems)))
+
+(defn adoc-soup->doc-segments
+  "Returns document segments for a JSoup parsed `body-elem` AsciiDoc with `doc-title`.
+
+  For adoc, the <a href> points to the header tag.
+  ```
+  <h2 id=x><a href=x>Formatting marks</a></h2>
+  ```
+
+  Adoc uses a nested structure.
+  The sect3 div is under the sect2 div which is under the sect1 div.
+
+  Adoc is a bit odd, in that sect1 plunks its content under a sectionbody div
+  But... does not seem to do this for deeper sections.
+
+  ```
+  <body>
+   blah
+   <div class=sect1>
+    <h2 id=x><a href=#x>Heading</a></h2>
+    <div class=sectionbody>
+     blah
+     blah
+     <div class=sect2>
+      <h3 id=y><a href=#y>Heading</a><h3>
+      blah
+      blah
+     </div>
+    </div>
+   </div>
+  </body>
+
+  Also: adoc documents can end with trailing non-header content like footers."
+  [body-elem doc-title]
+  (let [all-nodes (tree-seq #(.childNodes %) #(.childNodes %) body-elem)]
+    (reduce (fn [acc elem]
+              (if (adoc-section? elem)
+                (conj acc
+                      {:title (adoc-section-title elem)
+                       :anchor (adoc-section-anchor elem)
+                       :text (adoc-section-text elem)})
+                acc))
+            [{:title doc-title
+              :anchor nil
+              :text (adoc-section-text body-elem)}]
+            all-nodes)))
+
+(defn- md-soup->doc-segments
+  "Returns document segments for a JSoup parsed `body-elem` CommonMark doc with `doc-title`.
+
+  For md, links to `<a>` ref points to itself:
+  ```
+  <h2><a href=x id=x>Formatting marks</a></h2>
+  ```
+  The md structure is simple and flat."
+  [body-elem doc-title]
   (loop [doc-segment {:title doc-title
                       :anchor nil
                       :text nil}
-         [element & remaining-elements] elements
+         [element & remaining-elements] (.childNodes body-elem)
          doc-segments []]
     (cond
       (nil? element)
@@ -49,7 +139,7 @@
         (conj doc-segments doc-segment)
         doc-segments)
 
-      (header-tag? (.tagName element))
+      (heading-elem? element)
       (recur {:title (.text element)
               :anchor (-> element .children (.select ".md-anchor") .first .attributes (.get "id"))
               :text nil}
@@ -59,48 +149,56 @@
                doc-segments))
 
       :else
-      (recur (update doc-segment :text #(str % " " (.text element)))
+      (recur (update doc-segment :text #(append-text % element))
              remaining-elements
              doc-segments))))
 
-(defn- markdown-doc->docs
-  [doc version-entity]
-  (let [doc-title (:title doc)
-        type-and-contents (doctree/entry->type-and-content doc)
-        html (rt/render-text type-and-contents)
-        doc (Jsoup/parse html)
-        body-elements (-> doc (.getElementsByTag "body") first .children)
-        doc-segments (elements->doc-segments body-elements doc-title)]
-    (map #(let [title (if (:anchor %) (str doc-title " - " (:title %))
-                          doc-title)
-                url (str (path-for-doc doc version-entity) "#" (:anchor %))
-                text (:text %)]
-            {:name title
-             :path url
-             :doc text})
-         doc-segments)))
-
-(defn- generic-doc->docs
-  [doc version-entity]
-  (let [[type contents] (doctree/entry->type-and-content doc)]
+(defn doc->doc-segments [doc]
+  (let [doc-tuple (doctree/entry->type-and-content doc)
+        [doc-type contents] doc-tuple]
     (when contents
-      (let [html (rt/render-text [type contents])
-            text (-> html Jsoup/parse (.getElementsByTag "body") first .text)]
-        [{:name (:title doc)
-          :path (path-for-doc doc version-entity)
-          :doc text}]))))
+      (let [html (rt/render-text doc-tuple)
+            doc-elements (Jsoup/parse html)
+            body-elements (-> doc-elements (.getElementsByTag "body") .first)
+            doc-title (:title doc)]
+        (case doc-type
+          :cljdoc/markdown (md-soup->doc-segments body-elements doc-title)
+          :cljdoc/asciidoc (adoc-soup->doc-segments body-elements doc-title))))))
 
 (defn- doc->docs
-  "Performs one of two operations, depending on document type:
+  "Returns `doc` broken down into headings with any text belong to those headings.
+  Url paths are resolved from `version-entity`.
 
-  1. For markdown it takes a single cache-bundle doc and breaks it into multiple sections by header,
-  each with their own name, doc, and URL path.
-  2. For anything else it renders to HTML and then grabs all the text from the body as a single link."
+  The text for a heading should not include text for any of its sub-headings.
+
+  For a conceptual example:
+   heading1
+    contenta
+    heading2
+     contentb
+
+  The text for heading1 should only contain contenta.
+
+  The root heading is the doc title; any text not belonging to any heading will belong
+  to the root heading.
+
+  All headings should be included even if they have no text.
+
+  Important considerations:
+  1. Documents do not necessarily start with a header.
+  2. Headers do not necessarily have text between them and the next header or the
+     end of the document."
   [doc version-entity]
-  (case (:cljdoc.doc/type doc)
-    :cljdoc/markdown (markdown-doc->docs doc version-entity)
-    ;; TODO: asciidoc rendering
-    (generic-doc->docs doc version-entity)))
+  (when-let [doc-segments (doc->doc-segments doc)]
+    (let [doc-title (:title doc)]
+      (map #(let [title (if (:anchor %) (str doc-title " - " (:title %))
+                            doc-title)
+                  url (str (path-for-doc doc version-entity) "#" (:anchor %))
+                  text (:text %)]
+              {:name title
+               :path url
+               :doc text})
+           doc-segments))))
 
 (defn- ->namespaces
   "Renders cache-bundle `namespaces` into a format consumable by the API. This consists of:
@@ -160,3 +258,59 @@
   {:namespaces (->namespaces namespaces version-entity)
    :defs (->defs defs version-entity)
    :docs (->docs docs version-entity)})
+
+(comment
+  (require '[clojure.edn :as edn])
+
+  (def cb (-> "resources/test_data/cache_bundle.edn"
+              slurp
+              edn/read-string))
+
+  (-> cb :version :doc)
+  (def sr (cache-bundle->searchset cb))
+
+  ;; adoc play
+  (-> "<body>hello
+        pre content
+        <div class=\"sect1\">
+          <h2 id=\"a-id\"><a href=\"#a-id\">a-title</a></h2>
+          <div class=sectionbody>
+            a-content
+            <p>more a-content!</p>
+            <div class=\"sect2\">
+              <h3 id=\"b-id\"><a href=\"#b-id\">b-title</a></h3>
+              b-content
+            </div>
+            <div class=\"sect2\">
+              <h3 id=\"c-id\"><a href=\"#c-id\">c-title</a></h3>
+            </div>
+          </div>
+        </div>
+        post section content
+        <p>more-post!</p>
+        <h2>this aint no section header</h2>
+      </body>"
+      Jsoup/parse
+      (.getElementsByTag "body")
+      .first
+      (adoc-soup->doc-segments "My doc title"))
+
+  ;; md play
+  (-> "<body>
+        content before the first header
+        <h1><a id=\"a-id\" class=\"md-anchor\" href=\"#a-id\">a-title</a></h1>
+        a-content
+        <p>more a-content!</p>
+
+        <h2><a id=\"b-id\" class=\"md-anchor\" href=\"#b-id\">b-title</a></h2>
+        b-content
+
+        <h1><a id=\"c-id\" class=\"md-anchor\" href=\"#c-id\">c-title</a></h1>
+
+       </body>"
+      Jsoup/parse
+      (.getElementsByTag "body")
+      .first
+      (md-soup->doc-segments "My doc title"))
+
+  nil)


### PR DESCRIPTION
No longer defaulting to generic parsing for markdown docs.
This means the lovely code that parses section headings out is now invoked.

Replaced generic doc parsing with asciidoc specific parsing.
So we now cover both our rendered document format types.

Now collecting text via JSoup nodes instead of JSoup elements.
JSoup elements skips text only nodes.

Bump the client side index version to force refetch.

Closes #592