### PR TITLE
ci: tease out jobs, update docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run:
           name: Bring Down Clojure deps
-          command: clojure -Spath
+          command: clojure -P -X:cli:test
 
       - run:
           name: Lint
@@ -104,7 +104,7 @@ jobs:
 
       - run:
           name: Bring Down Clojure deps
-          command: clojure -Spath
+          command: clojure -P -X:cli:test
 
       - run:
           name: Build Docs for Sample Library

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           command: npm ci
 
       - run:
-          name: Lint Front End Sourc
+          name: Lint Front End Source
           command: npm run lint
 
       - save_cache:
@@ -84,7 +84,7 @@ jobs:
   #
   test:
     docker:
-      - image: cimg/clojure:1.11.1
+      - image: cimg/clojure:1.11.1-node
 
     working_directory: ~/repo
 
@@ -96,11 +96,24 @@ jobs:
             - v1-dependencies-{{ checksum "deps.edn" }}-{{ checksum "bb.edn" }}
             - v1-dependencies- # fallback if cache not found
 
+      - restore_cache:
+          keys:
+            - v1-npm-dependencies-{{ checksum "package-lock.json" }}
+
       - run:
           name: Report Tools Versions
           command: |
+           node --version
            java --version
            clojure --version
+
+      - run:
+          name: Install JavaScript Depedencies
+          command: npm ci
+
+      - run:
+          name: Build Front End
+          command: npm run build
 
       - run:
           name: Bring Down Clojure deps
@@ -119,6 +132,11 @@ jobs:
             - ~/.m2
             - ~/.gitlibs
           key: v1-dependencies-{{ checksum "deps.edn" }}-{{ checksum "bb.edn" }}
+
+      - save_cache:
+          paths:
+            - ./node_modules
+          key: v1-npm-dependencies-{{ checksum "package-lock.json" }}
 
   #
   # build: package, output used by:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,47 +1,32 @@
-# Clojure CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-clojure/ for more details
-#
 version: 2.1
 jobs:
-  build:
+  #
+  # build: back-end-checks
+  #
+  back-end-checks:
     docker:
-      - image: cimg/clojure:1.11.1-node
+      - image: cimg/clojure:1.11.1
 
     working_directory: ~/repo
 
     steps:
       - checkout
 
-      - run:
-          name: "Validate our own cljdoc.edn"
-          command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
-
       - restore_cache:
           keys:
-            - v1-npm-dependencies-{{ checksum "package-lock.json" }}
-            - v1-npm-dependencies- # fallback if cache not found
+            - v1-dependencies-{{ checksum "deps.edn" }}-{{ checksum "bb.edn" }}
+            - v1-dependencies- # fallback if cache not found
+
+      - run:
+          name: Validate our own cljdoc.edn
+          command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
 
       - run:
           name: Report Tools Versions
           command: |
-            node --version
             java --version
             clojure --version
             bb --version
-
-      - run:
-          name: Install JavaScript Depedencies
-          command: npm ci
-
-      - run:
-          name: Package cljdoc
-          command: ./script/package
-
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "deps.edn" }}
-            - v1-dependencies- # fallback if cache not found
 
       - run:
           name: Bring Down Clojure deps
@@ -55,6 +40,72 @@ jobs:
           name: Code Style Check
           command: bb code-format check
 
+      - save_cache:
+          paths:
+            - ~/.m2
+            - ~/.gitlibs
+          key: v1-dependencies-{{ checksum "deps.edn" }}-{{ checksum "bb.edn" }}
+
+  #
+  # build: front-end-checks
+  #
+  front-end-checks:
+    docker:
+      - image: cimg/node:16.4.2
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-npm-dependencies-{{ checksum "package-lock.json" }}
+
+      - run:
+          name: Report Tools Versions
+          command: node --version
+
+      - run:
+          name: Install JavaScript Depedencies
+          command: npm ci
+
+      - run:
+          name: Lint Front End Sourc
+          command: npm run lint
+
+      - save_cache:
+          paths:
+            - ./node_modules
+          key: v1-npm-dependencies-{{ checksum "package-lock.json" }}
+
+  #
+  # build: test
+  #
+  test:
+    docker:
+      - image: cimg/clojure:1.11.1
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "deps.edn" }}-{{ checksum "bb.edn" }}
+            - v1-dependencies- # fallback if cache not found
+
+      - run:
+          name: Report Tools Versions
+          command: |
+           java --version
+           clojure --version
+
+      - run:
+          name: Bring Down Clojure deps
+          command: clojure -Spath
+
       - run:
           name: Build Docs for Sample Library
           command: ./script/cljdoc ingest --project bidi --version 2.1.3
@@ -63,6 +114,45 @@ jobs:
           name: Run Tests
           command: clojure -M:test --reporter documentation
 
+      - save_cache:
+          paths:
+            - ~/.m2
+            - ~/.gitlibs
+          key: v1-dependencies-{{ checksum "deps.edn" }}-{{ checksum "bb.edn" }}
+
+  #
+  # build: package, output used by:
+  # - publish-zip-build
+  # - publish-docker
+  #
+  package:
+    docker:
+      - image: cimg/node:16.4.2
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-npm-dependencies-{{ checksum "package-lock.json" }}
+            - v1-npm-dependencies- # fallback if cache not found
+
+      - run:
+          name: Report Tools Versions
+          command: |
+            node --version
+
+      - run:
+          name: Install JavaScript Depedencies
+          command: npm ci
+
+      - run:
+          name: Package cljdoc
+          command: ./script/package
+
+      # for publish-zip-build job
       - persist_to_workspace:
           root: .
           paths:
@@ -70,35 +160,40 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.m2
-          key: v1-dependencies-{{ checksum "deps.edn" }}
-
-      - save_cache:
-          paths:
             - ./node_modules
           key: v1-npm-dependencies-{{ checksum "package-lock.json" }}
-
-  prettier:
+  #
+  # build - used later in workflow to group all build jobs
+  #
+  build:
     docker:
-      - image: circleci/node:latest
+      - image: alpine
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-npm-dependencies-{{ checksum "package-lock.json" }}
-      - run: npm ci
-      - run: npm run lint
+      - run: echo build done
 
+  #
+  # deploy: publish-zip-build
+  # (relies on output saved by package)
+  #
   publish-zip-build:
     docker:
-      - image: circleci/python:2.7-jessie
+      - image: cimg/python:3.10
     steps:
+      # from package job
       - attach_workspace:
           at: workspace
       - run: ls workspace
+
       - run:
           name: Install awscli
-          command: sudo pip install awscli
+          command: pip3 install awscli
+
+      - run:
+          name: Tools Versions
+          command: |
+            pip3 --version
+            aws --version
+
       - run:
           name: Set AWS env vars
           # vars are coming from terraform setup
@@ -106,20 +201,26 @@ jobs:
             echo 'export AWS_ACCESS_KEY_ID=$RELEASES_BUCKET_ACCESS_KEY' >> $BASH_ENV
             echo 'export AWS_SECRET_ACCESS_KEY=$RELEASES_BUCKET_SECRET_KEY' >> $BASH_ENV
             source $BASH_ENV
+
       - run:
           name: Deploy to S3
           command: aws s3 sync workspace/target s3://$RELEASES_BUCKET_NAME/build-$CIRCLE_SHA1/ --delete
 
+  #
+  # deploy: make and image and publish to docker
+  # (relies on output saved by package)
+  #
   publish-docker:
     machine:
       image: ubuntu-2004:202201-02
     steps:
       - checkout
+      # from package job
       - attach_workspace:
           at: .
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
       # because target/ has been put into place `make image` can be
-      # ran without running ./script/package (which would require npm)
+      # run without running ./script/package (which would require npm)
       - run: cd ops/docker && make image
       - run: docker push --all-tags cljdoc/cljdoc
 
@@ -129,8 +230,8 @@ jobs:
   # cat ~/.ssh/cljdoc_deploy.pub | ssh root@cljdoc.org 'cat >> .ssh/authorized_keys'
   deploy-to-nomad:
     docker:
-      - image: circleci/clojure:openjdk-11-tools-deps-1.10.3.1058-buster-node
-        command: "/bin/bash"
+      - image: cimg/clojure:1.11.1-node
+
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -143,8 +244,16 @@ jobs:
 workflows:
   build-and-deploy:
     jobs:
-      - build
-      - prettier
+      - front-end-checks
+      - back-end-checks
+      - test
+      - package
+      - build:
+          requires:
+            - front-end-checks
+            - back-end-checks
+            - test
+            - package
       - publish-docker:
           requires:
             - build


### PR DESCRIPTION
The build job is now a noop job that depends on:
- back-end-checks - does back end linty things
  (teased out from old build job)
- front-end-checks - does front end linty things
  (was formerly prettier job)
- test - runs cljdoc tests
  (teased out from old build job)
- package - packages cljdoc for potential deployment
  (teased out from old build job)

Potential benefits are:
1. shorten build time by running jobs in parallel (TBD)
2. separting build job out allows each individual job to fail separately,
giving us more more info. (Failing slower).

Other changes:
- front-end-checks now fails build if it fails
- moved entirely away from deprecated circleci docker images and now using their new cimg images.
  (this sometimes required other changes)
- now also basing cache id on bb.edn where appropriate
- now also caching ~/.gitlibs for Clojure deps

Closes #626