### PR TITLE
Fix TypeScript issue and add ci front end check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,15 +64,21 @@ jobs:
 
       - run:
           name: Report Tools Versions
-          command: node --version
+          command: |
+            node --version
+            npx tsc --version
 
       - run:
           name: Install JavaScript Depedencies
           command: npm ci
 
       - run:
-          name: Lint Front End Source
+          name: Lint Front End Source Format
           command: npm run lint
+
+      - run:
+          name: Compile TypeScript to Check for Issues
+          command: npx tsc
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,14 +63,14 @@ jobs:
             - v1-npm-dependencies-{{ checksum "package-lock.json" }}
 
       - run:
+          name: Install JavaScript Depedencies
+          command: npm ci
+
+      - run:
           name: Report Tools Versions
           command: |
             node --version
             npx tsc --version
-
-      - run:
-          name: Install JavaScript Depedencies
-          command: npm ci
 
       - run:
           name: Lint Front End Source Format

--- a/doc/cljdoc-developer-technical-guide.adoc
+++ b/doc/cljdoc-developer-technical-guide.adoc
@@ -189,7 +189,7 @@ Note that clj-kondo really shines when you
 https://github.com/borkdude/clj-kondo/blob/master/doc/editor-integration.md[integrate
 it with your development environment].
 
-NOTE: CI also lints JavaScript source via `npm run lint`.
+NOTE: CI also lints JavaScript source via `npm run lint` and TypeScript via `npx tsc`.
 
 === Coding style
 

--- a/js/library.ts
+++ b/js/library.ts
@@ -1,0 +1,19 @@
+export interface Library {
+  group_id: string;
+  artifact_id: string;
+  version: string;
+}
+
+export function docsUri(library: Library) {
+  return (
+    "/d/" + library.group_id + "/" + library.artifact_id + "/" + library.version
+  );
+}
+
+export function project(library: Library) {
+  return (
+    library.group_id === library.artifact_id
+      ? library.group_id
+      : library.group_id + "/" + library.artifact_id
+  );
+}

--- a/js/library.ts
+++ b/js/library.ts
@@ -11,9 +11,7 @@ export function docsUri(library: Library) {
 }
 
 export function project(library: Library) {
-  return (
-    library.group_id === library.artifact_id
-      ? library.group_id
-      : library.group_id + "/" + library.artifact_id
-  );
+  return library.group_id === library.artifact_id
+    ? library.group_id
+    : library.group_id + "/" + library.artifact_id;
 }

--- a/js/listselect.tsx
+++ b/js/listselect.tsx
@@ -1,5 +1,4 @@
 import { h, Component, FunctionComponent } from "preact";
-import { CljdocProject } from "./switcher";
 
 // Various functions and components used to show lists of results
 
@@ -31,25 +30,25 @@ function restrictToViewport(container: Element, selectedIndex: number) {
 //   - isSelected: whether the result should be displayed as currently selected
 //   - onMouseOver: a no-args function to call when hovering the result
 
-export type ResultViewComponent = FunctionComponent<{
-  result: CljdocProject;
+export type ResultViewComponent<Type> = FunctionComponent<{
+  result: Type;
   isSelected: boolean;
   selectResult: () => any;
 }>;
 
-type ResultsViewProps = {
-  resultView: ResultViewComponent;
-  results: CljdocProject[];
+type ResultsViewProps<Type> = {
+  resultView: ResultViewComponent<Type>;
+  results: Type[];
   selectedIndex: number;
   onMouseOver: (index: number) => any;
 };
 
 type ResultsViewState = any;
 
-export class ResultsView extends Component<ResultsViewProps, ResultsViewState> {
+export class ResultsView<Type> extends Component<ResultsViewProps<Type>, ResultsViewState> {
   resultsViewNode?: Element | null;
 
-  componentDidUpdate(prevProps: ResultsViewProps, _state: ResultsViewState) {
+  componentDidUpdate(prevProps: ResultsViewProps<Type>, _state: ResultsViewState) {
     if (
       this.props.selectedIndex !== prevProps.selectedIndex &&
       this.resultsViewNode
@@ -58,7 +57,7 @@ export class ResultsView extends Component<ResultsViewProps, ResultsViewState> {
     }
   }
 
-  render(props: ResultsViewProps, _state: any) {
+  render(props: ResultsViewProps<Type>, _state: any) {
     return (
       <div
         className="bg-white br1 br--bottom bb bl br b--blue w-100 overflow-y-scroll"

--- a/js/listselect.tsx
+++ b/js/listselect.tsx
@@ -45,10 +45,16 @@ type ResultsViewProps<Type> = {
 
 type ResultsViewState = any;
 
-export class ResultsView<Type> extends Component<ResultsViewProps<Type>, ResultsViewState> {
+export class ResultsView<Type> extends Component<
+  ResultsViewProps<Type>,
+  ResultsViewState
+> {
   resultsViewNode?: Element | null;
 
-  componentDidUpdate(prevProps: ResultsViewProps<Type>, _state: ResultsViewState) {
+  componentDidUpdate(
+    prevProps: ResultsViewProps<Type>,
+    _state: ResultsViewState
+  ) {
     if (
       this.props.selectedIndex !== prevProps.selectedIndex &&
       this.resultsViewNode

--- a/js/listselect.tsx
+++ b/js/listselect.tsx
@@ -30,8 +30,8 @@ function restrictToViewport(container: Element, selectedIndex: number) {
 //   - isSelected: whether the result should be displayed as currently selected
 //   - onMouseOver: a no-args function to call when hovering the result
 
-export type ResultViewComponent<Type> = FunctionComponent<{
-  result: Type;
+export type ResultViewComponent<ResultType> = FunctionComponent<{
+  result: ResultType;
   isSelected: boolean;
   selectResult: () => any;
 }>;
@@ -45,14 +45,14 @@ type ResultsViewProps<Type> = {
 
 type ResultsViewState = any;
 
-export class ResultsView<Type> extends Component<
-  ResultsViewProps<Type>,
+export class ResultsView<ResultType> extends Component<
+  ResultsViewProps<ResultType>,
   ResultsViewState
 > {
   resultsViewNode?: Element | null;
 
   componentDidUpdate(
-    prevProps: ResultsViewProps<Type>,
+    prevProps: ResultsViewProps<ResultType>,
     _state: ResultsViewState
   ) {
     if (
@@ -63,7 +63,7 @@ export class ResultsView<Type> extends Component<
     }
   }
 
-  render(props: ResultsViewProps<Type>, _state: any) {
+  render(props: ResultsViewProps<ResultType>, _state: any) {
     return (
       <div
         className="bg-white br1 br--bottom bb bl br b--blue w-100 overflow-y-scroll"

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -43,10 +43,7 @@ export const initRecentDocLinks = (docLinks: Element) => {
             .map(visited => {
               return (
                 <li className="mr1 pt2">
-                  <a
-                    className="link blue nowrap"
-                    href={docsUri(visited)}
-                  >
+                  <a className="link blue nowrap" href={docsUri(visited)}>
                     {project(visited)}
                     <span className="gray f6">
                       {lastViewedMessage(visited.last_viewed)}

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -1,5 +1,6 @@
 import { h, render } from "preact";
-import { CljdocProject } from "./switcher";
+import { VisitedLibrary } from "./switcher";
+import { docsUri, project } from "./library";
 import { formatDistanceToNowStrict } from "date-fns";
 
 const dayInMs = 86400000;
@@ -24,7 +25,7 @@ const lastViewedMessage = (last_viewed: string | undefined) => {
 };
 
 export const initRecentDocLinks = (docLinks: Element) => {
-  const previouslyOpened: Array<CljdocProject> = JSON.parse(
+  const previouslyOpened: Array<VisitedLibrary> = JSON.parse(
     localStorage.getItem("previouslyOpened") || "[]"
   );
   if (previouslyOpened.length > 0) {
@@ -39,16 +40,16 @@ export const initRecentDocLinks = (docLinks: Element) => {
           {previouslyOpened
             .reverse()
             .slice(0, 3)
-            .map(({ group_id, artifact_id, version, last_viewed }) => {
+            .map(visited => {
               return (
                 <li className="mr1 pt2">
                   <a
                     className="link blue nowrap"
-                    href={`/d/${group_id}/${artifact_id}/${version}`}
+                    href={docsUri(visited)}
                   >
-                    {artifact_id}
+                    {project(visited)}
                     <span className="gray f6">
-                      {lastViewedMessage(last_viewed)}
+                      {lastViewedMessage(visited.last_viewed)}
                     </span>
                   </a>
                 </li>

--- a/js/search.tsx
+++ b/js/search.tsx
@@ -48,7 +48,7 @@ interface SearchResult extends Library {
   blurb: string;
   origin: string;
   score: number;
-};
+}
 
 type SearchResults = {
   count: number;
@@ -143,7 +143,7 @@ class SearchInput extends Component<SearchInputProps> {
   }
 }
 
-const SingleResultView: ResultViewComponent <SearchResult> = props => {
+const SingleResultView: ResultViewComponent<SearchResult> = props => {
   const { result, isSelected, selectResult } = props;
   const uri = docsUri(result);
   const rowClass = isSelected

--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -1,237 +1,228 @@
 import { h, Component } from "preact";
 import fuzzysort from "fuzzysort";
+import { Library, docsUri, project } from "./library";
 import { ResultsView, ResultViewComponent } from "./listselect";
 
-export type CljdocProject = {
-  group_id: string;
-  artifact_id: string;
-  version: string;
-  project_id?: string;
-  last_viewed?: string;
+export interface VisitedLibrary extends Library {
+    project_id: string;
+    last_viewed: string;
 };
 
-function isSameProject(p1: CljdocProject, p2: CljdocProject): boolean {
-  // I can't believe you have to do this
-  return p1.group_id === p2.group_id && p1.artifact_id === p2.artifact_id; //&& p1.version == p2.version
+function isSameProject(p1: Library, p2: Library): boolean {
+    return p1.group_id === p2.group_id && p1.artifact_id === p2.artifact_id;
 }
 
-function parseCljdocURI(uri: string): CljdocProject | void {
-  const splitted = uri.split("/");
-  if (splitted.length >= 5 && splitted[1] === "d") {
-    return {
-      group_id: splitted[2],
-      artifact_id: splitted[3],
-      version: splitted[4]
-    };
-  }
+function parseCljdocURI(uri: string): Library | void {
+    const splitted = uri.split("/");
+    if (splitted.length >= 5 && splitted[1] === "d") {
+        return {
+            group_id: splitted[2],
+            artifact_id: splitted[3],
+            version: splitted[4]
+        };
+    }
 }
 
 function trackProjectOpened() {
-  const maxTrackedCount = 15;
-  const project = parseCljdocURI(window.location.pathname);
-  if (project) {
-    var previouslyOpened: CljdocProject[] = JSON.parse(
-      localStorage.getItem("previouslyOpened") || "[]"
-    );
-    // remove identical values
-    previouslyOpened = previouslyOpened.filter(p => !isSameProject(p, project));
-    project.last_viewed = new Date().toUTCString();
-    previouslyOpened.push(project);
-    // truncate from the front to not have localstorage grow too large
-    if (previouslyOpened.length > maxTrackedCount) {
-      previouslyOpened = previouslyOpened.slice(
-        previouslyOpened.length - maxTrackedCount,
-        previouslyOpened.length
-      );
+    const maxTrackedCount = 15;
+    const project = parseCljdocURI(window.location.pathname) as VisitedLibrary;
+    if (project) {
+        var previouslyOpened: VisitedLibrary[] = JSON.parse(
+            localStorage.getItem("previouslyOpened") || "[]"
+        );
+        // remove identical values
+        previouslyOpened = previouslyOpened.filter(p => !isSameProject(p, project));
+        project.last_viewed = new Date().toUTCString();
+        previouslyOpened.push(project);
+        // truncate from the front to not have localstorage grow too large
+        if (previouslyOpened.length > maxTrackedCount) {
+            previouslyOpened = previouslyOpened.slice(
+                previouslyOpened.length - maxTrackedCount,
+                previouslyOpened.length
+            );
+        }
+        localStorage.setItem("previouslyOpened", JSON.stringify(previouslyOpened));
     }
-    localStorage.setItem("previouslyOpened", JSON.stringify(previouslyOpened));
-  }
 }
 
-const SwitcherSingleResultView: ResultViewComponent = props => {
-  const { result, isSelected, selectResult } = props;
-  const project =
-    result.group_id === result.artifact_id
-      ? result.group_id
-      : result.group_id + "/" + result.artifact_id;
-  const docsUri =
-    "/d/" + result.group_id + "/" + result.artifact_id + "/" + result.version;
-  return (
-    <a className="no-underline black" href={docsUri} onMouseOver={selectResult}>
-      <div
-        className={
-          isSelected
-            ? "pa3 bb b--light-gray bg-light-blue"
-            : "pa3 bb b--light-gray"
-        }
-      >
-        <h4 className="dib ma0">
-          #{project} <span className="ml2 gray normal">{result.version}</span>
-        </h4>
-        <a className="link blue ml2" href={docsUri}>
-          view docs
+const SwitcherSingleResultView: ResultViewComponent <VisitedLibrary> = props => {
+    const { result, isSelected, selectResult } = props;
+    const uri = docsUri(result);
+    return (
+        <a className="no-underline black" href={uri} onMouseOver={selectResult}>
+            <div
+                className={
+                    isSelected
+                        ? "pa3 bb b--light-gray bg-light-blue"
+                        : "pa3 bb b--light-gray"
+                }
+            >
+                <h4 className="dib ma0">
+                   {project(result)} <span className="ml2 gray normal">{result.version}</span>
+                </h4>
+                <a className="link blue ml2" href={uri}>
+                    view docs
+                </a>
+            </div>
         </a>
-      </div>
-    </a>
-  );
+    );
 };
 
 type SwitcherProps = any;
 
 type SwitcherState = {
-  results: CljdocProject[];
-  previouslyOpened: CljdocProject[];
-  selectedIndex: number;
-  show: boolean;
+    results: VisitedLibrary[];
+    previouslyOpened: VisitedLibrary[];
+    selectedIndex: number;
+    show: boolean;
 };
 
 class Switcher extends Component<SwitcherProps, SwitcherState> {
-  inputNode?: HTMLInputElement | null;
-  backgroundNode?: HTMLDivElement | null;
+    inputNode?: HTMLInputElement | null;
+    backgroundNode?: HTMLDivElement | null;
 
-  handleKeyDown(e: KeyboardEvent) {
-    if (e.target === this.inputNode) {
-      if (e.key === "ArrowUp") {
-        e.preventDefault(); // prevents caret from moving in input field
+    handleKeyDown(e: KeyboardEvent) {
+        if (e.target === this.inputNode) {
+            if (e.key === "ArrowUp") {
+                e.preventDefault(); // prevents caret from moving in input field
+                this.setState({
+                    selectedIndex: Math.max(this.state.selectedIndex - 1, 0)
+                });
+            } else if (e.key === "ArrowDown") {
+                e.preventDefault(); // prevents caret from moving in input field
+                this.setState({
+                    selectedIndex: Math.min(
+                        this.state.selectedIndex + 1,
+                        this.state.results.length - 1
+                    )
+                });
+            }
+        }
+
+        // If target is document body, trigger  on key `cmd+k` for MacOs `ctrl+k` otherwise
+        let isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+        let switcherShortcut = false;
+
+        if (e.key === "k") {
+            if ((isMac && e.metaKey) || (!isMac && e.ctrlKey)) {
+                e.preventDefault();
+                switcherShortcut = true;
+            }
+        }
+
+        if (switcherShortcut && e.target === document.body) {
+            this.setState({ show: true, results: this.state.previouslyOpened });
+        } else if (e.key === "Escape") {
+            this.setState({ show: false, results: [] });
+        }
+    }
+
+    handleInputKeyUp(e: KeyboardEvent) {
+        if (e.key === "Enter") {
+            const r = this.state.results[this.state.selectedIndex];
+            window.location.href =
+                "/d/" + r.group_id + "/" + r.artifact_id + "/" + r.version;
+        }
+    }
+
+    updateResults(searchStr: string) {
+        if (searchStr === "") {
+            this.initializeState();
+        } else {
+            let fuzzysortOptions = {
+                allowTypo: false,
+                key: "project_id"
+            };
+            let results = fuzzysort.go(
+                searchStr,
+                this.state.previouslyOpened,
+                fuzzysortOptions
+            );
+            this.setState({
+                results: results.map(r => r.obj),
+                selectedIndex: 0
+            });
+        }
+    }
+
+    constructor() {
+        super();
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.handleInputKeyUp = this.handleInputKeyUp.bind(this);
+        this.updateResults = this.updateResults.bind(this);
+    }
+
+    initializeState() {
+        let previouslyOpened: VisitedLibrary[] = JSON.parse(
+            localStorage.getItem("previouslyOpened") || "[]"
+        );
+
+        previouslyOpened.forEach(
+            r =>
+            (r.project_id =
+                r.group_id === r.artifact_id
+                    ? r.group_id
+                    : r.group_id + "/" + r.artifact_id)
+        );
+        previouslyOpened.reverse();
+
         this.setState({
-          selectedIndex: Math.max(this.state.selectedIndex - 1, 0)
+            // Store previously opened states in reversed order (latest first)
+            previouslyOpened: previouslyOpened,
+            // For the initial state (i.e. no search query) recent docsets
+            results: previouslyOpened,
+            selectedIndex: 0
         });
-      } else if (e.key === "ArrowDown") {
-        e.preventDefault(); // prevents caret from moving in input field
-        this.setState({
-          selectedIndex: Math.min(
-            this.state.selectedIndex + 1,
-            this.state.results.length - 1
-          )
-        });
-      }
     }
 
-    // If target is document body, trigger  on key `cmd+k` for MacOs `ctrl+k` otherwise
-    let isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-    let switcherShortcut = false;
-
-    if (e.key === "k") {
-      if ((isMac && e.metaKey) || (!isMac && e.ctrlKey)) {
-        e.preventDefault();
-        switcherShortcut = true;
-      }
+    componentDidMount() {
+        document.addEventListener("keydown", this.handleKeyDown);
+        this.initializeState();
     }
 
-    if (switcherShortcut && e.target === document.body) {
-      this.setState({ show: true, results: this.state.previouslyOpened });
-    } else if (e.key === "Escape") {
-      this.setState({ show: false, results: [] });
+    componentDidUpdate(
+        _previousProps: SwitcherProps,
+        previousState: SwitcherState,
+        _previousContext: any
+    ) {
+        if (!previousState.show && this.state.show && this.inputNode) {
+            this.inputNode.focus();
+        }
     }
-  }
 
-  handleInputKeyUp(e: KeyboardEvent) {
-    if (e.key === "Enter") {
-      const r = this.state.results[this.state.selectedIndex];
-      window.location.href =
-        "/d/" + r.group_id + "/" + r.artifact_id + "/" + r.version;
-    }
-  }
-
-  updateResults(searchStr: string) {
-    if (searchStr === "") {
-      this.initializeState();
-    } else {
-      let fuzzysortOptions = {
-        allowTypo: false,
-        key: "project_id"
-        //keys: ['group_id', 'artifact_id']
-      };
-      let results = fuzzysort.go(
-        searchStr,
-        this.state.previouslyOpened,
-        fuzzysortOptions
-      );
-      this.setState({
-        results: results.map(r => r.obj),
-        selectedIndex: 0
-      });
-    }
-  }
-
-  constructor() {
-    super();
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleInputKeyUp = this.handleInputKeyUp.bind(this);
-    this.updateResults = this.updateResults.bind(this);
-  }
-
-  initializeState() {
-    let previouslyOpened: CljdocProject[] = JSON.parse(
-      localStorage.getItem("previouslyOpened") || "[]"
-    );
-
-    previouslyOpened.forEach(
-      r =>
-        (r.project_id =
-          r.group_id === r.artifact_id
-            ? r.group_id
-            : r.group_id + "/" + r.artifact_id)
-    );
-    previouslyOpened.reverse();
-
-    this.setState({
-      // Store previously opened states in reversed order (latest first)
-      previouslyOpened: previouslyOpened,
-      // For the initial state (i.e. no search query) recent docsets
-      results: previouslyOpened,
-      selectedIndex: 0
-    });
-  }
-
-  componentDidMount() {
-    document.addEventListener("keydown", this.handleKeyDown);
-    this.initializeState();
-  }
-
-  componentDidUpdate(
-    _previousProps: SwitcherProps,
-    previousState: SwitcherState,
-    _previousContext: any
-  ) {
-    if (!previousState.show && this.state.show && this.inputNode) {
-      this.inputNode.focus();
-    }
-  }
-
-  render(_props: SwitcherProps, state: SwitcherState) {
-    if (state.show) {
-      return (
-        <div
-          className="bg-black-30 fixed top-0 right-0 bottom-0 left-0 sans-serif"
-          ref={node => (this.backgroundNode = node)}
-          onClick={(e: MouseEvent) =>
-            e.target === this.backgroundNode
-              ? this.setState({ show: false })
-              : null
-          }
-        >
-          <div className="mw7 center mt6 bg-white pa3 br2 shadow-3">
-            <input
-              placeholder="Jump to recently viewed docs..."
-              className="pa2 w-100 br1 border-box b--blue ba input-reset"
-              ref={node => (this.inputNode = node)}
-              onKeyUp={(e: KeyboardEvent) => this.handleInputKeyUp(e)}
-              onInput={(e: Event) => {
-                const target = e.target as HTMLFormElement;
-                this.updateResults(target.value);
-              }}
-            />
-            {state.results.length > 0 ? (
-              <ResultsView
-                results={state.results}
-                selectedIndex={state.selectedIndex}
-                onMouseOver={index => this.setState({ selectedIndex: index })}
-                resultView={SwitcherSingleResultView}
-              />
-            ) : null}
-          </div>
-        </div>
+    render(_props: SwitcherProps, state: SwitcherState) {
+        if (state.show) {
+            return (
+                <div
+                    className="bg-black-30 fixed top-0 right-0 bottom-0 left-0 sans-serif"
+                    ref={node => (this.backgroundNode = node)}
+                    onClick={(e: MouseEvent) =>
+                        e.target === this.backgroundNode
+                            ? this.setState({ show: false })
+                            : null
+                    }
+                >
+                    <div className="mw7 center mt6 bg-white pa3 br2 shadow-3">
+                        <input
+                            placeholder="Jump to recently viewed docs..."
+                            className="pa2 w-100 br1 border-box b--blue ba input-reset"
+                            ref={node => (this.inputNode = node)}
+                            onKeyUp={(e: KeyboardEvent) => this.handleInputKeyUp(e)}
+                            onInput={(e: Event) => {
+                                const target = e.target as HTMLFormElement;
+                                this.updateResults(target.value);
+                            }}
+                        />
+                        {state.results.length > 0 ? (
+                            <ResultsView
+                                results={state.results}
+                                selectedIndex={state.selectedIndex}
+                                onMouseOver={index => this.setState({ selectedIndex: index })}
+                                resultView={SwitcherSingleResultView}
+                            />
+                        ) : null}
+                    </div>
+                </div>
       );
     } else {
       return null;

--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -4,225 +4,226 @@ import { Library, docsUri, project } from "./library";
 import { ResultsView, ResultViewComponent } from "./listselect";
 
 export interface VisitedLibrary extends Library {
-    project_id: string;
-    last_viewed: string;
-};
+  project_id: string;
+  last_viewed: string;
+}
 
 function isSameProject(p1: Library, p2: Library): boolean {
-    return p1.group_id === p2.group_id && p1.artifact_id === p2.artifact_id;
+  return p1.group_id === p2.group_id && p1.artifact_id === p2.artifact_id;
 }
 
 function parseCljdocURI(uri: string): Library | void {
-    const splitted = uri.split("/");
-    if (splitted.length >= 5 && splitted[1] === "d") {
-        return {
-            group_id: splitted[2],
-            artifact_id: splitted[3],
-            version: splitted[4]
-        };
-    }
+  const splitted = uri.split("/");
+  if (splitted.length >= 5 && splitted[1] === "d") {
+    return {
+      group_id: splitted[2],
+      artifact_id: splitted[3],
+      version: splitted[4]
+    };
+  }
 }
 
 function trackProjectOpened() {
-    const maxTrackedCount = 15;
-    const project = parseCljdocURI(window.location.pathname) as VisitedLibrary;
-    if (project) {
-        var previouslyOpened: VisitedLibrary[] = JSON.parse(
-            localStorage.getItem("previouslyOpened") || "[]"
-        );
-        // remove identical values
-        previouslyOpened = previouslyOpened.filter(p => !isSameProject(p, project));
-        project.last_viewed = new Date().toUTCString();
-        previouslyOpened.push(project);
-        // truncate from the front to not have localstorage grow too large
-        if (previouslyOpened.length > maxTrackedCount) {
-            previouslyOpened = previouslyOpened.slice(
-                previouslyOpened.length - maxTrackedCount,
-                previouslyOpened.length
-            );
-        }
-        localStorage.setItem("previouslyOpened", JSON.stringify(previouslyOpened));
+  const maxTrackedCount = 15;
+  const project = parseCljdocURI(window.location.pathname) as VisitedLibrary;
+  if (project) {
+    var previouslyOpened: VisitedLibrary[] = JSON.parse(
+      localStorage.getItem("previouslyOpened") || "[]"
+    );
+    // remove identical values
+    previouslyOpened = previouslyOpened.filter(p => !isSameProject(p, project));
+    project.last_viewed = new Date().toUTCString();
+    previouslyOpened.push(project);
+    // truncate from the front to not have localstorage grow too large
+    if (previouslyOpened.length > maxTrackedCount) {
+      previouslyOpened = previouslyOpened.slice(
+        previouslyOpened.length - maxTrackedCount,
+        previouslyOpened.length
+      );
     }
+    localStorage.setItem("previouslyOpened", JSON.stringify(previouslyOpened));
+  }
 }
 
-const SwitcherSingleResultView: ResultViewComponent <VisitedLibrary> = props => {
-    const { result, isSelected, selectResult } = props;
-    const uri = docsUri(result);
-    return (
-        <a className="no-underline black" href={uri} onMouseOver={selectResult}>
-            <div
-                className={
-                    isSelected
-                        ? "pa3 bb b--light-gray bg-light-blue"
-                        : "pa3 bb b--light-gray"
-                }
-            >
-                <h4 className="dib ma0">
-                   {project(result)} <span className="ml2 gray normal">{result.version}</span>
-                </h4>
-                <a className="link blue ml2" href={uri}>
-                    view docs
-                </a>
-            </div>
+const SwitcherSingleResultView: ResultViewComponent<VisitedLibrary> = props => {
+  const { result, isSelected, selectResult } = props;
+  const uri = docsUri(result);
+  return (
+    <a className="no-underline black" href={uri} onMouseOver={selectResult}>
+      <div
+        className={
+          isSelected
+            ? "pa3 bb b--light-gray bg-light-blue"
+            : "pa3 bb b--light-gray"
+        }
+      >
+        <h4 className="dib ma0">
+          {project(result)}{" "}
+          <span className="ml2 gray normal">{result.version}</span>
+        </h4>
+        <a className="link blue ml2" href={uri}>
+          view docs
         </a>
-    );
+      </div>
+    </a>
+  );
 };
 
 type SwitcherProps = any;
 
 type SwitcherState = {
-    results: VisitedLibrary[];
-    previouslyOpened: VisitedLibrary[];
-    selectedIndex: number;
-    show: boolean;
+  results: VisitedLibrary[];
+  previouslyOpened: VisitedLibrary[];
+  selectedIndex: number;
+  show: boolean;
 };
 
 class Switcher extends Component<SwitcherProps, SwitcherState> {
-    inputNode?: HTMLInputElement | null;
-    backgroundNode?: HTMLDivElement | null;
+  inputNode?: HTMLInputElement | null;
+  backgroundNode?: HTMLDivElement | null;
 
-    handleKeyDown(e: KeyboardEvent) {
-        if (e.target === this.inputNode) {
-            if (e.key === "ArrowUp") {
-                e.preventDefault(); // prevents caret from moving in input field
-                this.setState({
-                    selectedIndex: Math.max(this.state.selectedIndex - 1, 0)
-                });
-            } else if (e.key === "ArrowDown") {
-                e.preventDefault(); // prevents caret from moving in input field
-                this.setState({
-                    selectedIndex: Math.min(
-                        this.state.selectedIndex + 1,
-                        this.state.results.length - 1
-                    )
-                });
-            }
-        }
-
-        // If target is document body, trigger  on key `cmd+k` for MacOs `ctrl+k` otherwise
-        let isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-        let switcherShortcut = false;
-
-        if (e.key === "k") {
-            if ((isMac && e.metaKey) || (!isMac && e.ctrlKey)) {
-                e.preventDefault();
-                switcherShortcut = true;
-            }
-        }
-
-        if (switcherShortcut && e.target === document.body) {
-            this.setState({ show: true, results: this.state.previouslyOpened });
-        } else if (e.key === "Escape") {
-            this.setState({ show: false, results: [] });
-        }
-    }
-
-    handleInputKeyUp(e: KeyboardEvent) {
-        if (e.key === "Enter") {
-            const r = this.state.results[this.state.selectedIndex];
-            window.location.href =
-                "/d/" + r.group_id + "/" + r.artifact_id + "/" + r.version;
-        }
-    }
-
-    updateResults(searchStr: string) {
-        if (searchStr === "") {
-            this.initializeState();
-        } else {
-            let fuzzysortOptions = {
-                allowTypo: false,
-                key: "project_id"
-            };
-            let results = fuzzysort.go(
-                searchStr,
-                this.state.previouslyOpened,
-                fuzzysortOptions
-            );
-            this.setState({
-                results: results.map(r => r.obj),
-                selectedIndex: 0
-            });
-        }
-    }
-
-    constructor() {
-        super();
-        this.handleKeyDown = this.handleKeyDown.bind(this);
-        this.handleInputKeyUp = this.handleInputKeyUp.bind(this);
-        this.updateResults = this.updateResults.bind(this);
-    }
-
-    initializeState() {
-        let previouslyOpened: VisitedLibrary[] = JSON.parse(
-            localStorage.getItem("previouslyOpened") || "[]"
-        );
-
-        previouslyOpened.forEach(
-            r =>
-            (r.project_id =
-                r.group_id === r.artifact_id
-                    ? r.group_id
-                    : r.group_id + "/" + r.artifact_id)
-        );
-        previouslyOpened.reverse();
-
+  handleKeyDown(e: KeyboardEvent) {
+    if (e.target === this.inputNode) {
+      if (e.key === "ArrowUp") {
+        e.preventDefault(); // prevents caret from moving in input field
         this.setState({
-            // Store previously opened states in reversed order (latest first)
-            previouslyOpened: previouslyOpened,
-            // For the initial state (i.e. no search query) recent docsets
-            results: previouslyOpened,
-            selectedIndex: 0
+          selectedIndex: Math.max(this.state.selectedIndex - 1, 0)
         });
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault(); // prevents caret from moving in input field
+        this.setState({
+          selectedIndex: Math.min(
+            this.state.selectedIndex + 1,
+            this.state.results.length - 1
+          )
+        });
+      }
     }
 
-    componentDidMount() {
-        document.addEventListener("keydown", this.handleKeyDown);
-        this.initializeState();
+    // If target is document body, trigger  on key `cmd+k` for MacOs `ctrl+k` otherwise
+    let isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+    let switcherShortcut = false;
+
+    if (e.key === "k") {
+      if ((isMac && e.metaKey) || (!isMac && e.ctrlKey)) {
+        e.preventDefault();
+        switcherShortcut = true;
+      }
     }
 
-    componentDidUpdate(
-        _previousProps: SwitcherProps,
-        previousState: SwitcherState,
-        _previousContext: any
-    ) {
-        if (!previousState.show && this.state.show && this.inputNode) {
-            this.inputNode.focus();
-        }
+    if (switcherShortcut && e.target === document.body) {
+      this.setState({ show: true, results: this.state.previouslyOpened });
+    } else if (e.key === "Escape") {
+      this.setState({ show: false, results: [] });
     }
+  }
 
-    render(_props: SwitcherProps, state: SwitcherState) {
-        if (state.show) {
-            return (
-                <div
-                    className="bg-black-30 fixed top-0 right-0 bottom-0 left-0 sans-serif"
-                    ref={node => (this.backgroundNode = node)}
-                    onClick={(e: MouseEvent) =>
-                        e.target === this.backgroundNode
-                            ? this.setState({ show: false })
-                            : null
-                    }
-                >
-                    <div className="mw7 center mt6 bg-white pa3 br2 shadow-3">
-                        <input
-                            placeholder="Jump to recently viewed docs..."
-                            className="pa2 w-100 br1 border-box b--blue ba input-reset"
-                            ref={node => (this.inputNode = node)}
-                            onKeyUp={(e: KeyboardEvent) => this.handleInputKeyUp(e)}
-                            onInput={(e: Event) => {
-                                const target = e.target as HTMLFormElement;
-                                this.updateResults(target.value);
-                            }}
-                        />
-                        {state.results.length > 0 ? (
-                            <ResultsView
-                                results={state.results}
-                                selectedIndex={state.selectedIndex}
-                                onMouseOver={index => this.setState({ selectedIndex: index })}
-                                resultView={SwitcherSingleResultView}
-                            />
-                        ) : null}
-                    </div>
-                </div>
+  handleInputKeyUp(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      const r = this.state.results[this.state.selectedIndex];
+      window.location.href =
+        "/d/" + r.group_id + "/" + r.artifact_id + "/" + r.version;
+    }
+  }
+
+  updateResults(searchStr: string) {
+    if (searchStr === "") {
+      this.initializeState();
+    } else {
+      let fuzzysortOptions = {
+        allowTypo: false,
+        key: "project_id"
+      };
+      let results = fuzzysort.go(
+        searchStr,
+        this.state.previouslyOpened,
+        fuzzysortOptions
+      );
+      this.setState({
+        results: results.map(r => r.obj),
+        selectedIndex: 0
+      });
+    }
+  }
+
+  constructor() {
+    super();
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleInputKeyUp = this.handleInputKeyUp.bind(this);
+    this.updateResults = this.updateResults.bind(this);
+  }
+
+  initializeState() {
+    let previouslyOpened: VisitedLibrary[] = JSON.parse(
+      localStorage.getItem("previouslyOpened") || "[]"
+    );
+
+    previouslyOpened.forEach(
+      r =>
+        (r.project_id =
+          r.group_id === r.artifact_id
+            ? r.group_id
+            : r.group_id + "/" + r.artifact_id)
+    );
+    previouslyOpened.reverse();
+
+    this.setState({
+      // Store previously opened states in reversed order (latest first)
+      previouslyOpened: previouslyOpened,
+      // For the initial state (i.e. no search query) recent docsets
+      results: previouslyOpened,
+      selectedIndex: 0
+    });
+  }
+
+  componentDidMount() {
+    document.addEventListener("keydown", this.handleKeyDown);
+    this.initializeState();
+  }
+
+  componentDidUpdate(
+    _previousProps: SwitcherProps,
+    previousState: SwitcherState,
+    _previousContext: any
+  ) {
+    if (!previousState.show && this.state.show && this.inputNode) {
+      this.inputNode.focus();
+    }
+  }
+
+  render(_props: SwitcherProps, state: SwitcherState) {
+    if (state.show) {
+      return (
+        <div
+          className="bg-black-30 fixed top-0 right-0 bottom-0 left-0 sans-serif"
+          ref={node => (this.backgroundNode = node)}
+          onClick={(e: MouseEvent) =>
+            e.target === this.backgroundNode
+              ? this.setState({ show: false })
+              : null
+          }
+        >
+          <div className="mw7 center mt6 bg-white pa3 br2 shadow-3">
+            <input
+              placeholder="Jump to recently viewed docs..."
+              className="pa2 w-100 br1 border-box b--blue ba input-reset"
+              ref={node => (this.inputNode = node)}
+              onKeyUp={(e: KeyboardEvent) => this.handleInputKeyUp(e)}
+              onInput={(e: Event) => {
+                const target = e.target as HTMLFormElement;
+                this.updateResults(target.value);
+              }}
+            />
+            {state.results.length > 0 ? (
+              <ResultsView
+                results={state.results}
+                selectedIndex={state.selectedIndex}
+                onMouseOver={index => this.setState({ selectedIndex: index })}
+                resultView={SwitcherSingleResultView}
+              />
+            ) : null}
+          </div>
+        </div>
       );
     } else {
       return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -124,21 +124,50 @@
         "node": ">=4"
       }
     },
-    "node_modules/@parcel/bundler-default": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.4.0.tgz",
-      "integrity": "sha512-RaXlxo0M51739Ko3bsOJpDBZlJ+cqkDoBTozNeSc65jS2TMBIBWLMapm8095qmty39OrgYNhzjgPiIlKDS/LWA==",
+    "node_modules/@lezer/common": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "dev": true
+    },
+    "node_modules/@lezer/lr": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "node_modules/@mischnic/json-sourcemap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
+      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^0.15.7",
+        "@lezer/lr": "^0.15.4",
+        "json5": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@parcel/bundler-default": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.5.0.tgz",
+      "integrity": "sha512-7CJzE17SirCXjcRgBcnqWO/5EOA1raq/3OIKtT4cxbjpDQGHZpjpEEZiMNRpEpdNMxDSlsG8mAkXTYGL2VVWRw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -146,14 +175,14 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.4.0.tgz",
-      "integrity": "sha512-oOudoAafrCAHQY0zkU7gVHG1pAGBUz9rht7Tx4WupTmAH0O0F5UnZs6XbjoBJaPHg+CYUXK7v9wQcrNA72E3GA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
+      "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "lmdb": "2.2.4"
       },
       "engines": {
@@ -164,13 +193,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.0"
+        "@parcel/core": "^2.5.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.4.0.tgz",
-      "integrity": "sha512-PJ3W9Z0sjoS2CANyo50c+LEr9IRZrtu0WsVPSYZ5ZYRuSXrSa/6PcAlnkyDk2+hi7Od8ncT2bmDexl0Oar3Jyg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
+      "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -184,16 +213,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.4.0.tgz",
-      "integrity": "sha512-ZErX14fTc0gKIgtnuqW7Clfln4dpXWfUaJQQIf5C3x/LkpUeEhdXeKntkvSxOddDk2JpIKDwqzAxEMZUnDo4Nw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.5.0.tgz",
+      "integrity": "sha512-I5Zs+2f1ue4sTPdfT8BNsLfTZl48sMWLk2Io3elUJjH/SS9kO7ut5ChkuJtt77ZS35m0OF+ZCt3ICTJdnDG8eA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0"
+        "@parcel/plugin": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -201,76 +230,76 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.4.0.tgz",
-      "integrity": "sha512-pFOPBXPO6HGqNWTLkcK5i8haMOrRgUouUhcWPGWDpN9IPUYFK2E/O1E/uyMjIA1mSL3FnazI+jJwZ45NhKPpIA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.5.0.tgz",
+      "integrity": "sha512-r30V61958SONvP9I8KV8s44ZOFq0H219VyFjPysraSabHjZ+KMaCTQOuqaDtUMa272sHUQkBcZxKYj5jYPJlZg==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.4.0",
-        "@parcel/compressor-raw": "2.4.0",
-        "@parcel/namer-default": "2.4.0",
-        "@parcel/optimizer-css": "2.4.0",
-        "@parcel/optimizer-htmlnano": "2.4.0",
-        "@parcel/optimizer-image": "2.4.0",
-        "@parcel/optimizer-svgo": "2.4.0",
-        "@parcel/optimizer-terser": "2.4.0",
-        "@parcel/packager-css": "2.4.0",
-        "@parcel/packager-html": "2.4.0",
-        "@parcel/packager-js": "2.4.0",
-        "@parcel/packager-raw": "2.4.0",
-        "@parcel/packager-svg": "2.4.0",
-        "@parcel/reporter-dev-server": "2.4.0",
-        "@parcel/resolver-default": "2.4.0",
-        "@parcel/runtime-browser-hmr": "2.4.0",
-        "@parcel/runtime-js": "2.4.0",
-        "@parcel/runtime-react-refresh": "2.4.0",
-        "@parcel/runtime-service-worker": "2.4.0",
-        "@parcel/transformer-babel": "2.4.0",
-        "@parcel/transformer-css": "2.4.0",
-        "@parcel/transformer-html": "2.4.0",
-        "@parcel/transformer-image": "2.4.0",
-        "@parcel/transformer-js": "2.4.0",
-        "@parcel/transformer-json": "2.4.0",
-        "@parcel/transformer-postcss": "2.4.0",
-        "@parcel/transformer-posthtml": "2.4.0",
-        "@parcel/transformer-raw": "2.4.0",
-        "@parcel/transformer-react-refresh-wrap": "2.4.0",
-        "@parcel/transformer-svg": "2.4.0"
+        "@parcel/bundler-default": "2.5.0",
+        "@parcel/compressor-raw": "2.5.0",
+        "@parcel/namer-default": "2.5.0",
+        "@parcel/optimizer-css": "2.5.0",
+        "@parcel/optimizer-htmlnano": "2.5.0",
+        "@parcel/optimizer-image": "2.5.0",
+        "@parcel/optimizer-svgo": "2.5.0",
+        "@parcel/optimizer-terser": "2.5.0",
+        "@parcel/packager-css": "2.5.0",
+        "@parcel/packager-html": "2.5.0",
+        "@parcel/packager-js": "2.5.0",
+        "@parcel/packager-raw": "2.5.0",
+        "@parcel/packager-svg": "2.5.0",
+        "@parcel/reporter-dev-server": "2.5.0",
+        "@parcel/resolver-default": "2.5.0",
+        "@parcel/runtime-browser-hmr": "2.5.0",
+        "@parcel/runtime-js": "2.5.0",
+        "@parcel/runtime-react-refresh": "2.5.0",
+        "@parcel/runtime-service-worker": "2.5.0",
+        "@parcel/transformer-babel": "2.5.0",
+        "@parcel/transformer-css": "2.5.0",
+        "@parcel/transformer-html": "2.5.0",
+        "@parcel/transformer-image": "2.5.0",
+        "@parcel/transformer-js": "2.5.0",
+        "@parcel/transformer-json": "2.5.0",
+        "@parcel/transformer-postcss": "2.5.0",
+        "@parcel/transformer-posthtml": "2.5.0",
+        "@parcel/transformer-raw": "2.5.0",
+        "@parcel/transformer-react-refresh-wrap": "2.5.0",
+        "@parcel/transformer-svg": "2.5.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.0"
+        "@parcel/core": "^2.5.0"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-EWZ2UWtIuwDc3fgsKyyTLpNNPoG8Yk2L117ICWF/+cqY8z/wJHm2KwLbeplDeq524shav0GJ9O4CemP3JPx0Nw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-dygDmPsfAYJKTnUftcbEzjCik7AAaPbFvJW8ETYz8diyjkAG9y6hvCAZIrJE5pNOjFzg32en4v4UWv8Sqlzl9g==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.4.0",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/events": "2.4.0",
-        "@parcel/fs": "2.4.0",
-        "@parcel/graph": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/package-manager": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.5.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/events": "2.5.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/graph": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/package-manager": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
         "dotenv": "^7.0.0",
         "dotenv-expand": "^5.1.0",
-        "json-source-map": "^0.6.1",
         "json5": "^2.2.0",
         "msgpackr": "^1.5.4",
         "nullthrows": "^1.1.1",
@@ -285,9 +314,9 @@
       }
     },
     "node_modules/@parcel/css": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.7.2.tgz",
-      "integrity": "sha512-OcdGio5QCvshOJGXaqICC93yMDCi1baZ3yK/xHbKmu9R4p3IBp9+/hmjg5ZkfmJLvqsrguZ1JJndoSXITxPxpg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.8.2.tgz",
+      "integrity": "sha512-3vTyKHy2LnZ3YJEut+UQPVIxsaY/mdGk7cDXtmvH4xR48Pd6rYzChHCMl4Ru2DUkCBpr0KCQRPZTdYcsJhUmIA==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -300,20 +329,20 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/css-darwin-arm64": "1.7.2",
-        "@parcel/css-darwin-x64": "1.7.2",
-        "@parcel/css-linux-arm-gnueabihf": "1.7.2",
-        "@parcel/css-linux-arm64-gnu": "1.7.2",
-        "@parcel/css-linux-arm64-musl": "1.7.2",
-        "@parcel/css-linux-x64-gnu": "1.7.2",
-        "@parcel/css-linux-x64-musl": "1.7.2",
-        "@parcel/css-win32-x64-msvc": "1.7.2"
+        "@parcel/css-darwin-arm64": "1.8.2",
+        "@parcel/css-darwin-x64": "1.8.2",
+        "@parcel/css-linux-arm-gnueabihf": "1.8.2",
+        "@parcel/css-linux-arm64-gnu": "1.8.2",
+        "@parcel/css-linux-arm64-musl": "1.8.2",
+        "@parcel/css-linux-x64-gnu": "1.8.2",
+        "@parcel/css-linux-x64-musl": "1.8.2",
+        "@parcel/css-win32-x64-msvc": "1.8.2"
       }
     },
     "node_modules/@parcel/css-darwin-arm64": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.7.2.tgz",
-      "integrity": "sha512-i0b8n8FF+iSK8cLOQhzxXZbbWAGTRLYih4W7Jim4QOerTBvl0zmBajua0hst+phuDDgSO5GKm1/80X+7v8VW+g==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.8.2.tgz",
+      "integrity": "sha512-p5etxX3kPCuEQcipjqH9yc5j0x5/Yc++uB4MvG/sFbRgL2gI2zUuRo9sIgqA21boOP8lE4bQgz1ovPD/W1hj+Q==",
       "cpu": [
         "arm64"
       ],
@@ -331,9 +360,9 @@
       }
     },
     "node_modules/@parcel/css-darwin-x64": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.7.2.tgz",
-      "integrity": "sha512-RsidKHrUhOp9wSlyBOxBTPcskh/QRtUV0uOVhHVLZtr7ebWT7L0T6wZJGX3vpTewgwIPB66IjJCE8ovdJLeMEg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.8.2.tgz",
+      "integrity": "sha512-c3xi5DXRZYec5db4KPTxp69eHbomOuasgZNiuPPOi80k7jlOwfzCFQs0h6/KwWvTcJrKEFsLl8BKJU/aX7mETw==",
       "cpu": [
         "x64"
       ],
@@ -351,9 +380,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm-gnueabihf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.7.2.tgz",
-      "integrity": "sha512-NF6lvp2PDWqwUB16z1XQECyIIjO9EB6J9tMleLo1l6Set9nIaLRl3Jl06f3lFSBhxWQBqZ3Gr9c/5gvLtNjRew==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.8.2.tgz",
+      "integrity": "sha512-+ih3+mMpwbwtOjr/XW5pP0frsV1PMN+Qz7jCAM84h8xX+8UE/1IR0UVi3EPa8wQiIlcVcEwszQ1MV2UHacvo/A==",
       "cpu": [
         "arm"
       ],
@@ -371,9 +400,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm64-gnu": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.7.2.tgz",
-      "integrity": "sha512-sqSzj8eoTFJkajLIjCbb8qDXLwH+4CQU0c7598Dg8K/culVuGlGn5mwwgfSK/HIZq6Wt8SD5iG0HmtNAwrcpCw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.8.2.tgz",
+      "integrity": "sha512-jIoyXbjJ1trUHXtyJhi3hlF1ck6xM4CDyaY5N6eN+3+ovkdw6wxog9IiheYJ1jf9ellYevLvTF5kiYE9MiP04A==",
       "cpu": [
         "arm64"
       ],
@@ -391,9 +420,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm64-musl": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.7.2.tgz",
-      "integrity": "sha512-XDnf5eY0O5exsMpv+hwtrxsi7vrm/kz2+JRar+7vNalxzFEc6xJhh/sRQw4XU7Qn9oCgJ/BDp58c6uDeQInEAQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.8.2.tgz",
+      "integrity": "sha512-QVTc5a+HatoywIei3djKYmp3s5dbI2Q3QaYZf3gqhyjOkeC7bm6j5eeNzFO+wa5xtga5jdHkIuTRrJ/wCojKKw==",
       "cpu": [
         "arm64"
       ],
@@ -411,9 +440,9 @@
       }
     },
     "node_modules/@parcel/css-linux-x64-gnu": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.7.2.tgz",
-      "integrity": "sha512-9c912OgRIR5i4Pffxh123fgcsGy0njcBD9di+ipb6RHi8ZQLhiUhbdMAXINHwJT/7pSds+RJGL6VNGP3KqSxCA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.8.2.tgz",
+      "integrity": "sha512-9r2tSfa6i3ZQ3a6C9XufJWuTv3LB7JYzxzEqsI35SSA8D/DrfAHMaIhqog5wSxKZRWmQxckh2wdT96eIIGHSGA==",
       "cpu": [
         "x64"
       ],
@@ -431,9 +460,9 @@
       }
     },
     "node_modules/@parcel/css-linux-x64-musl": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.7.2.tgz",
-      "integrity": "sha512-D9ZEllB21G9PA9+f+jdOXh3qPeryg+6fGSe1dXfLvQ0yG41FeBQgbIpPabhLUCNEdHG11t43LkJT5RVuG/n6uw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.8.2.tgz",
+      "integrity": "sha512-5SetLWkxXRQ3NU6QwwbGf9tOmGW2m1cGt07Moybbe4RCXOY6R5wAYUtauZUp7pD/fJlE9mHge4jnNHKpVO9pvw==",
       "cpu": [
         "x64"
       ],
@@ -451,9 +480,9 @@
       }
     },
     "node_modules/@parcel/css-win32-x64-msvc": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.7.2.tgz",
-      "integrity": "sha512-9j8fu0nSqVj2w1NusgLJX9/XP5ITQke5/eRn6/no9cx4GD2YDsuKchDIc2yVxxuGD0WrDECScEtuXEKEmmxjxw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.8.2.tgz",
+      "integrity": "sha512-/EdW5Ejlnkvc/AYrAi/FmLNvM6a6eAx+A4Y7oW+8JSMvk6bYa2zmXi7XLU/QOQuH2VQa/3gIIMA+sYjPndvDpw==",
       "cpu": [
         "x64"
       ],
@@ -471,12 +500,12 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.4.0.tgz",
-      "integrity": "sha512-TjWO/b2zMFhub5ouwGjazMm7iAUvdmXBfWmjrg4TBhUbhoQwBnyWfvMDtAYo7PcvXfxVPgPZv86Nv6Ym5H6cHQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
+      "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
       "dev": true,
       "dependencies": {
-        "json-source-map": "^0.6.1",
+        "@mischnic/json-sourcemap": "^0.1.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -488,9 +517,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.4.0.tgz",
-      "integrity": "sha512-DEaEtFbhOhNAEmiXJ3MyF8Scq+sNDKiTyLax4lAC5/dpE5GvwfNnoD17C2+0gDuuDpdQkdHfXfvr50aYFt7jcw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
+      "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -501,16 +530,16 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.4.0.tgz",
-      "integrity": "sha512-CnUlWGUJ52SJVQi8QnaAPPQZOADmHMV9D9aX9GLcDm5XLT3Em7vmesG4bNLdMLwzYuzAtenhcWmuRCACuYztHw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
+      "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs-search": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/fs-search": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.4.0"
+        "@parcel/workers": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -520,13 +549,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.0"
+        "@parcel/core": "^2.5.0"
       }
     },
     "node_modules/@parcel/fs-search": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.4.0.tgz",
-      "integrity": "sha512-W/Vu6wbZk4wuB6AVdMkyymwh/S8Peed/PgJgSsApYD6lSTD315I6OuEdxZh3lWY+dqQdog/NJ7dvi/hdpH/Iqw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
+      "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -540,12 +569,12 @@
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.4.0.tgz",
-      "integrity": "sha512-5TZIAfDITkJCzgH4j4OQhnIvjV9IFwWqNBJanRl5QQTmKvdcODS3WbnK1SOJ+ZltcLVXMB+HNXmL0bX0tVolcw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.5.0.tgz",
+      "integrity": "sha512-qa2VtG08dJyTaWrxYAkMIlkoDRSPoiqLDNxxHKplkcxAjXBUw0/AkWaz82VO5r1G6jfOj+nM30ajH9uygZYwbw==",
       "dev": true,
       "dependencies": {
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -557,9 +586,9 @@
       }
     },
     "node_modules/@parcel/hash": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.4.0.tgz",
-      "integrity": "sha512-nB+wYNUhe6+G8M7vQhdeFXtpYJYwJgBHOPZ7Hd9O2jdlamWjDbw0t/u1dJbYvGJ8ZDtLDwiItawQVpuVdskQ9g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
+      "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -574,13 +603,13 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.4.0.tgz",
-      "integrity": "sha512-DqfU0Zcs/0a7VBk+MsjJ80C66w4kM9EbkO3G12NIyEjNeG50ayW2CE9rUuJ91JaM9j0NFM1P82eyLpQPFFaVPw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
+      "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/events": "2.4.0"
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/events": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -591,9 +620,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.4.0.tgz",
-      "integrity": "sha512-gPUP1xikxHiu2kFyPy35pfuVkFgAmcywO8YDQj7iYcB+k7l4QPpIYFYGXn2QADV4faf66ncMeTD4uYV8c0GqjQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
+      "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -607,18 +636,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.4.0.tgz",
-      "integrity": "sha512-DfL+Gx0Tyoa0vsgRpNybXjuKbWNw8MTVpy7Dk7r0btfVsn1jy3SSwlxH4USf76gb00/pK6XBsMp9zn7Z8ePREQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
+      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -626,13 +655,13 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.4.0.tgz",
-      "integrity": "sha512-qiN97XcfW2fYNoYuVEhNKuVPEJKj5ONQl0fqr/NEMmYvWz3bVKjgiXNJwW558elZvCI08gEbdxgyThpuFFQeKQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.5.0.tgz",
+      "integrity": "sha512-XQvpguiIwQcu75cscLDFOVhjsjuPzXbuMaaZ7XxxUEl0PscIgu/GfKYxTfTruN3cRl+CaQH6qBAMfjLaFng6lQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -644,22 +673,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.4.0.tgz",
-      "integrity": "sha512-LQmjjOGsHEHKTJqfHR2eJyhWhLXvHP0uOAU+qopBttYYlB2J/vMK9RYAye5cyAb8bQmV8wAdi2mq9rnt7FMSPw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.5.0.tgz",
+      "integrity": "sha512-J00bLF+4SsnKc+YbYrNuBr44/zz3cg++CoXteXhH27PxP1rScGQx36Rui8WORgil5mlX2VYN79DuqJC7V3Ynbg==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.7.2",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/css": "^1.8.1",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -667,12 +696,12 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.4.0.tgz",
-      "integrity": "sha512-02EbeElLgNOAYhGU7fFBahpoKrX5G/yzahpaoKB/ypScM4roSsAMBkGcluboR5L10YRsvfvJEpxvfGyDA3tPmw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.5.0.tgz",
+      "integrity": "sha512-Fr0zPqgxoNaOVdROAjNGDWCts3+wByNQ82Mxhu8Tzc25A2cPjcr1H2sa/TE3hf79c92DxdKf2FaC1ZOgR5YPdg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
+        "@parcel/plugin": "2.5.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -680,7 +709,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -688,20 +717,20 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.4.0.tgz",
-      "integrity": "sha512-Q4onaBMPkDyYxPzrb8ytBUftaQZFepj9dSUgq+ETuHDzkgia0tomDPfCqrw6ld0qvYyANzXTP5+LC4g0i5yh+A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.5.0.tgz",
+      "integrity": "sha512-nbo2pdnAt21WLGjzTpsE8ZEL0xNoP7c3wBj9y70Pysmasg1SrRVCbfE8jTy+lHBQwq2yjC6lV/Usv+9lfA7S/w==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "detect-libc": "^1.0.3"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -709,19 +738,19 @@
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.4.0.tgz",
-      "integrity": "sha512-mwvGuCqVuNCAuMlp2maFE/Uz9ud1T1AuX0f6cCRczjFYiwZuIr/0iDdfFzSziOkVo1MRAGAZNa0dRR/UzCZtVg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.5.0.tgz",
+      "integrity": "sha512-pgZqwU0RLc/wr4WcQY/W1GJmddnEANDEpz1mdppUOqBz1EfTQ7zh5NgUA3hV1i05Hbecp3mHSvXJPV0mhNOl5Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "svgo": "^2.4.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -729,21 +758,21 @@
       }
     },
     "node_modules/@parcel/optimizer-terser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.4.0.tgz",
-      "integrity": "sha512-PdCgRgXNSY6R1HTV9VG2MHp1CgUbP5pslCyxvlbUmQAS6bvEpMOpn3qSd+U28o7mGE/qXIhvpDyi808sb+MEcg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.5.0.tgz",
+      "integrity": "sha512-PZ3UHBGfjE49/Jloopsd38Hxg4qzsrdepWP53mCuVP7Aw605Y4QtYuB1ho3VV0oXfKQVq+uI7lVIBsuW4K6vqA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -751,17 +780,17 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.4.0.tgz",
-      "integrity": "sha512-21AEfAQnZbHRVViTn7QsPGe/CiGaFaDUH5f0m8qVC7fDjjhC8LM8blkqU72goaO9FbaLMadtEf2txhzly7h/bg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
+      "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/fs": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "semver": "^5.7.1"
       },
       "engines": {
@@ -772,23 +801,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.0"
+        "@parcel/core": "^2.5.0"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.4.0.tgz",
-      "integrity": "sha512-LmPDWzkXi60Oy3WrPF0jPKQxeTwW5hmNBgrcXJMHSu+VcXdaQZNzNxVzhnZkJUbDd2z9vAUrUGzdLh8TquC8iQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.5.0.tgz",
+      "integrity": "sha512-c0mGBFdVSPhAxaX3+zN8KEIqOOUhkIPKbZex1pnGYfy03Qe2/Mb4nyt5DAGlw9gjka1UCHIN/wszLmKC8YyUeg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -796,20 +825,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.4.0.tgz",
-      "integrity": "sha512-OPMIQ1uHYQFpRPrsmm5BqONbAyzjlhVsPRAzHlcBrglG4BTUeOR2ow4MUKblHmVVqc3QHnfZG4nHHtFkeuNQ3A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.5.0.tgz",
+      "integrity": "sha512-ZFGUPRMWKrm8kQHdkEJ5S22C05qpSymx+o+57EfuNjCrGyj3M59WyGYYXYJ175bFYZ/jp5yy+VxMh6fZefe+Pw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -817,22 +846,22 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.4.0.tgz",
-      "integrity": "sha512-cfslIH43CJFgBS9PmdFaSnbInMCoejsFCnxtJa2GeUpjCXSfelPRp0OPx7m8n+fap4czftPhoxBALeDUElOZGQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.5.0.tgz",
+      "integrity": "sha512-aJAKOTgXdxO3V9O7+2DCVOtne128WwXmUAOVThnMRo7f3zMVSAR7Mxc9pEsuTzPfj8UBXgFBRfdJUSCgsMxiSw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -840,16 +869,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.4.0.tgz",
-      "integrity": "sha512-SFfw7chMFITj3J26ZVDJxbO6xwtPFcFBm1js8cwWMgzwuwS6CEc43k5+Abj+2/EqHU9kNJU9eWV5vT6lQwf3HA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.5.0.tgz",
+      "integrity": "sha512-aHV0oogeiqxhxS1lsttw15EvG3DDWK3FV7+F+7hoaAy+xg89K56NTp6j43Jtw9iyU1/HnZRGBE2hF3C7N73oKw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0"
+        "@parcel/plugin": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -857,19 +886,19 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.4.0.tgz",
-      "integrity": "sha512-DwkgrdLEQop+tu9Ocr1ZaadmpsbSgVruJPr80xq1LaB0Jiwrl9HjHStMNH1laNFueK1yydxhnj9C2JQfW28qag==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.5.0.tgz",
+      "integrity": "sha512-XSMFn30K/kpjcPpQqt88GmPJsNUSVL3RNeigXkIAcLpfO6Tb2eV4iOt4yVCagaDrRJ19alXut0TxjMm5bm41/g==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -877,19 +906,19 @@
       }
     },
     "node_modules/@parcel/packager-xml": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-xml/-/packager-xml-2.4.0.tgz",
-      "integrity": "sha512-05zi6Pt4V2xm52owKeLeVmGNixdweOJ4sbgb+x6iBB7EhFANfBFQXGgHC7FAf9GmVS0Q0r6QgTYNFqb2w+LEZw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-xml/-/packager-xml-2.5.0.tgz",
+      "integrity": "sha512-KFu3I7b2LAlnJxcJD0bufMCOmFEwZlvsNKrtOVooXUIbhe6Oe9yhQ4iw+FcosCdT0dI1U8jb808bkB6o+mhuAA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "@xmldom/xmldom": "^0.7.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -897,12 +926,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.4.0.tgz",
-      "integrity": "sha512-ehFUAL2+h27Lv+cYbbXA74UGy8C+eglUjcpvASOOjVRFuD6poMAMliKkKAXBhQaFx/Rvhz27A2PIPv9lL2i4UQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
+      "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.4.0"
+        "@parcel/types": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -913,20 +942,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.4.0.tgz",
-      "integrity": "sha512-Q9bIFMaGvQgypCDxdMEKOwrJzIHAXScKkuFsqTHnUL6mmH3Mo2CoEGAq/wpMXuPhXRn1dPJcHgTNDwZ2fSzz0A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.5.0.tgz",
+      "integrity": "sha512-miJt2YbRJBmYSVeoUWUj8YL85Pwj1CmGQB0/btqhulGLH/Fvkbv6T4sJ4gl4l5xIt9mJQsZ70pOWwa8BId3rWw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -934,17 +963,17 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.4.0.tgz",
-      "integrity": "sha512-24h++wevs7XYuX4dKa4PUfLSstvn3g7udajFv6CeQoME+dR25RL/wH/2LUbhV5ilgXXab76rWIndSqp78xHxPA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.5.0.tgz",
+      "integrity": "sha512-wvxAiW42AxJ3B8jtvowJcP4/cTV8zY48SfKg61YKYu1yUO+TtyJIjHQzDW2XuT34cIGFY97Gr0i+AVu44RyUuQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0"
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -952,17 +981,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.4.0.tgz",
-      "integrity": "sha512-K7pIIFmGm1hjg/7Mzkg99i8tfCClKfBUTuc2R5j8cdr2n0mCAi4/f2mFf5svLrb5XZrnDgoQ05tHKklLEfUDUw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.5.0.tgz",
+      "integrity": "sha512-39PkZpVr/+iYS11u+lA84vIsKm/yisltTVmUjlYsDnExiuV1c8OSbSdYZ3JMx+7CYPE0bWbosX2AGilIwIMWpQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "2.4.0",
-        "@parcel/plugin": "2.4.0"
+        "@parcel/node-resolver-core": "2.5.0",
+        "@parcel/plugin": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -970,17 +999,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.4.0.tgz",
-      "integrity": "sha512-swPFtvxGoCA9LEjU/pHPNjxG1l0fte8447zXwRN/AaYrtjNu9Ww117OSKCyvCnE143E79jZOFStodTQGFuH+9A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.5.0.tgz",
+      "integrity": "sha512-oPAo8Zf06gXCpt41nyvK7kv2HH1RrHAGgOqttyjStwAFlm5MZKs7BgtJzO58LfJN8g3sMY0cNdG17fB/4f8q6Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0"
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -988,18 +1017,18 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.4.0.tgz",
-      "integrity": "sha512-67OOvmkDdtmgzZVP/EyAzoXhJ/Ug3LUVUt7idg9arun5rdJptqEb3Um3wmH0zjcNa9jMbJt7Kl5x1wA8dJgPYg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.5.0.tgz",
+      "integrity": "sha512-gPC2PbNAiooULP71wF5twe4raekuXsR1Hw/ahITDoqsZdXHzG3CkoCjYL3CkmBGiKQgMMocCyN1E2oBzAH8Kyw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1007,18 +1036,18 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.4.0.tgz",
-      "integrity": "sha512-flnr+bf06lMZPbXZZLLaFNrPHvYpfuXTVovEghyUW46qLVpaHj33dpsU/LqZplIuHgBp2ibgrKhr/hY9ell68w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.5.0.tgz",
+      "integrity": "sha512-+8RuDKFdFYIQTrXG4MRhG9XqkkYEHn0zxKyOJ/IkDDfSEhY0na+EyhrneFUwIvDX63gLPkxceXAg0gwBqXPK/Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1026,18 +1055,18 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.4.0.tgz",
-      "integrity": "sha512-RgM5QUqW22WzstW03CtV+Oih8VGVuwsf94Cc4hLouU2EAD0NUJgATWbFocZVTZIBTKELAWh2gjpSQDdnL4Ur+A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.5.0.tgz",
+      "integrity": "sha512-STuDlU0fPXeWpAmbayY7o04F0eHy6FTOFeT5KQ0PTxtdEa3Ey8QInP/NVE52Yv0aVQtesWukGrNEFCERlkbFRw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1057,15 +1086,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.4.0.tgz",
-      "integrity": "sha512-iWDa7KzJTMP3HNmrYxiYq/S6redk2qminx/9MwmKIN9jzm8mgts2Lj9lOg/t66YaDGky6JAvw4DhB2qW4ni6yQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.5.0.tgz",
+      "integrity": "sha512-EFb866C9jCoBHIcebWF7goAcYj1wkObx0GDxshlazFtvym1RM27xSWWjRYyqb5+HNOxB3voaNvQOVjcD+DXjCA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -1073,7 +1102,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1081,22 +1110,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.4.0.tgz",
-      "integrity": "sha512-D2u48LuiQsQvbknABE0wVKFp9r6yCgWrHKEP1J6EJ31c49nXGXDHrpHJJwqq9BvAs/124eBI5mSsehTJyFEMwg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.5.0.tgz",
+      "integrity": "sha512-p8FOvKWWSbS6H8PbD9a0KZqyaKNpSD2BUTzSRYnNj3TBUv7/ZXaP6Om295XTQ/MPht1o7XTQzvfpF/7yEhr02Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.7.2",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/css": "^1.8.1",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1104,14 +1133,14 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.4.0.tgz",
-      "integrity": "sha512-2/8X/o5QaCNVPr4wkxLCUub7v/YVvVN2L5yCEcTatNeFhNg/2iz7P2ekfqOaoDCHWZEOBT1VTwPbdBt+TMM71Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.5.0.tgz",
+      "integrity": "sha512-iEjNyAF0wQmY3DMw7FS+UzoOMng76UsSngh+WWA1E5lv5XyqrP8Mk2QLTJp1nWetUhSLhZr58LGmPYBTB4l9ZQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1120,7 +1149,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1128,31 +1157,34 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.4.0.tgz",
-      "integrity": "sha512-JZkQvGGoGiD0AVKLIbAYYUWxepMmUaWZ4XXx71MmS/kA7cUDwTZ0CXq63YnSY1m+DX+ClTuTN8mBlwe2dkcGbA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.5.0.tgz",
+      "integrity": "sha512-vVEXTHZl8m/9yopgK0dWHLOQX2zOnghq6pZnWdWVG6fsvXZln7kP1YN5iwWDoADQYkiKzP+Ymn6UwP9pZpHFzA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.5.0"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.4.0.tgz",
-      "integrity": "sha512-eeLHFwv3jT3GmIxpLC7B8EXExGK0MFaK91HXljOMh6l8a+GlQYw27MSFQVtoXr0Olx9Uq2uvjXP1+zSsq3LQUQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.5.0.tgz",
+      "integrity": "sha512-Cp8Ic+Au3OcskCRZszmo47z3bqcZ7rfPv2xZYXpXY2TzEc3IV0bKje57bZektoY8LW9LkYM9iBO/WhkVoT6LIg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/utils": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "@swc/helpers": "^0.3.6",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
@@ -1162,25 +1194,28 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.5.0"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.4.0.tgz",
-      "integrity": "sha512-3nR+d39mbURoXIypDfVCaxpwL65qMV+h8SLD78up2uhaRGklHQfN7GuemR7L+mcVAgNrmwVvZHhyNjdgYwWqqg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.5.0.tgz",
+      "integrity": "sha512-661sByA7TkR6Lmxt+hqV4h2SAt+7lgc58DzmUYArpEl1fQnMuQuaB0kQeHzi6fDD2+2G6o7EC+DuwBZKa479TA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
+        "@parcel/plugin": "2.5.0",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1188,15 +1223,15 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.4.0.tgz",
-      "integrity": "sha512-ijIa2x+dbKnJhr7zO5WlXkvuj832fDoGksMBk2DX3u2WMrbh2rqVWPpGFsDhESx7EAy38nUoV/5KUdrNqUmCEA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.5.0.tgz",
+      "integrity": "sha512-IPNlWElekdQHMTBqhdwJNBCQomuYyo7xgNBdnTrt9VJ+R5ihy6n7ZJSWIAJXAH9VZxETTtunfrzRtgkmtjTeZQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -1204,7 +1239,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1212,13 +1247,13 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.4.0.tgz",
-      "integrity": "sha512-xoL3AzgtVeRRAo6bh0AHAYm9bt1jZ+HiH86/7oARj/uJs6Wd8kXK/DZf6fH+F87hj4e7bnjmDDc0GPVK0lPz1w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.5.0.tgz",
+      "integrity": "sha512-AZxg1XD8OXOS4bEGEmBBR+X9T9qoFdVsbVUg498zzejYSka1ZQHF7TgLI/+pUnE+ZVYNIp7/G0xXqsRVKMKmdQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1227,7 +1262,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1235,16 +1270,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.4.0.tgz",
-      "integrity": "sha512-fciFbNrzj0kLlDgr6OsI0PUv414rVygDWAsgbCCq4BexDkuemMs9f9FjMctx9B2VZlctE8dTT4RGkuQumTIpUg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.5.0.tgz",
+      "integrity": "sha512-I3zjE1u9+Wj90Qqs1V2FTm6iC6SAyOVUthwVZkZey+qbQG/ok682Ez2XjLu7MyQCo9BJNwF/nfOa1hHr3MaJEQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0"
+        "@parcel/plugin": "2.5.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1252,18 +1287,18 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.4.0.tgz",
-      "integrity": "sha512-9+f6sGOWkf0jyUQ1CuFWk+04Mq3KTOCU9kRiwCHX1YdUCv5uki6r9XUSpqiYodrV+L6w9CCwLvGMLCDHxtCxMg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.5.0.tgz",
+      "integrity": "sha512-VPqVBxhTN4OQwcjsdyxrv+smjAm4s6dbSWAplgPwdOITMv+a0tjhhJU37WnRC+xxTrbEqRcOt96JvGOkPb8i7g==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1271,14 +1306,14 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.4.0.tgz",
-      "integrity": "sha512-D+yzVtSxtQML3d26fd/g4E/xYW68+OMbMUVLXORtoYMU42fnXQkJP6jGOdqy8Td+WORNY7EwVtQnESLwhBmolw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.5.0.tgz",
+      "integrity": "sha512-zCGJcrCpICFe0Q/dgjQZfW7sYFkbJEC7NGT4zEJnMo8Cm/kq8Qh6+2ApX6c+vv5Q0WZn5Ic+N0OvxIMkvgdC/w==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1287,7 +1322,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1295,17 +1330,17 @@
       }
     },
     "node_modules/@parcel/transformer-xml": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-xml/-/transformer-xml-2.4.0.tgz",
-      "integrity": "sha512-/xrkbmewrB0pqbgJih3vBT+8+glANZwh4Ev803Ckzl+G8fYAVNH16aaNzi/IgMol+5SNfQE/VsMKiuV0BYvF1Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-xml/-/transformer-xml-2.5.0.tgz",
+      "integrity": "sha512-ndkAcE1ESFOIYtTx5BacDH45AfkHWyjolVh/JlIq3WxKTMxi1cN3gv0Hd3lL2oSgJGv9YmHnpsLIhVk2QlGFrA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.4.0",
+        "@parcel/plugin": "2.5.0",
         "@xmldom/xmldom": "^0.7.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.0"
+        "parcel": "^2.5.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1313,31 +1348,31 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-nysGIbBEnp+7R+tKTysdcTFOZDTCodsiXFeAhYQa5bhiOnG1l9gzhxQnE2OsdsgvMm40IOsgKprqvM/DbdLfnQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.4.0",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/fs": "2.4.0",
-        "@parcel/package-manager": "2.4.0",
+        "@parcel/cache": "2.5.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/package-manager": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/workers": "2.5.0",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.4.0.tgz",
-      "integrity": "sha512-sdNo+mZqDZT8LJYB6WWRKa4wFVZcK6Zb5Jh6Du76QvXXwHbPIQNZgJBb6gd/Rbk4GLOp2tW7MnBfq6zP9E9E2g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.4.0",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/markdown-ansi": "2.4.0",
+        "@parcel/codeframe": "2.5.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/markdown-ansi": "2.5.0",
         "@parcel/source-map": "^2.0.0",
         "chalk": "^4.1.0"
       },
@@ -1368,15 +1403,15 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.4.0.tgz",
-      "integrity": "sha512-eSFyvEoXXPgFzQfKIlpkUjpHfIbezUCRFTPKyJAKCxvU5DSXOpb1kz5vDESWQ4qTZXKnrKvxS1PPWN6bam9z0g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
+      "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       },
@@ -1388,14 +1423,17 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.0"
+        "@parcel/core": "^2.5.0"
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.8.tgz",
-      "integrity": "sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg==",
-      "dev": true
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.13.tgz",
+      "integrity": "sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -1407,9 +1445,9 @@
       }
     },
     "node_modules/@types/elasticlunr": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@types/elasticlunr/-/elasticlunr-0.9.4.tgz",
-      "integrity": "sha512-vrFREPCWi2sd33P8/iBzpN0+N1j3tpC/F7OJAUX0MogtbgzOx3EM0XG37WraDAJGsjyq+BqkaS4/J+3ntOF+2w==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@types/elasticlunr/-/elasticlunr-0.9.5.tgz",
+      "integrity": "sha512-gzY3gZLI6HczDO3vXM+u3P0dClEQ68k2d0UsZY1lyOaOZiGiamu7Ha/YBoc8CgAu5/3R+/u0HguDgD+xakmSEA==",
       "dev": true
     },
     "node_modules/@types/lunr": {
@@ -1446,9 +1484,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1531,9 +1569,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
       "dev": true,
       "funding": [
         {
@@ -1546,10 +1584,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
+        "caniuse-lite": "^1.0.30001332",
+        "electron-to-chromium": "^1.4.118",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
+        "node-releases": "^2.0.3",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -1575,9 +1613,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001319",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
-      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==",
+      "version": "1.0.30001338",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
       "dev": true,
       "funding": [
         {
@@ -1693,14 +1731,14 @@
       }
     },
     "node_modules/css-select": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
-      "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.1.0",
-        "domhandler": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
       },
@@ -1722,9 +1760,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "dev": true,
       "engines": {
         "node": ">= 6"
@@ -1770,9 +1808,9 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
@@ -1793,9 +1831,9 @@
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
         {
@@ -1854,9 +1892,9 @@
       "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.91",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.91.tgz",
-      "integrity": "sha512-Z7Jkc4+ouEg8F6RrrgLOs0kkJjI0cnyFQmnGVpln8pPifuKBNbUr37GMgJsCTSwy6Z9TK7oTwW33Oe+3aERYew==",
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -1944,9 +1982,9 @@
       }
     },
     "node_modules/fuzzysort": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.2.1.tgz",
-      "integrity": "sha512-egTSF3U6H6T9tXtAhEm5P5guSSDjd96/NUWrbmoGlIu3ATMdXra13gwQdEFRY6ehsFe8xec7UnQz+k34CGWCIg=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.9.0.tgz",
+      "integrity": "sha512-MOxCT0qLTwLqmEwc7UtU045RKef7mc8Qz8eR4r2bLNEq9dy/c3ZKMEFp6IEst69otkQdFZ4FfgH2dmZD+ddX1g=="
     },
     "node_modules/get-port": {
       "version": "4.2.0",
@@ -1973,9 +2011,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.14.0.tgz",
+      "integrity": "sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1997,9 +2035,9 @@
       }
     },
     "node_modules/htmlnano": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.0.tgz",
-      "integrity": "sha512-thKQfhcp2xgtsWNE27A2bliEeqVL5xjAgGn0wajyttvFFsvFWWah1ntV9aEX61gz0T6MBQ5xK/1lXuEumhJTcg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.2.tgz",
+      "integrity": "sha512-+ZrQFS4Ub+zd+/fWwfvoYCEGNEa0/zrpys6CyXxvZDwtL7Pl+pOtRkiujyvBQ7Lmfp7/iEPxtOFgxWA16Gkj3w==",
       "dev": true,
       "dependencies": {
         "cosmiconfig": "^7.0.1",
@@ -2143,12 +2181,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
-      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
-      "dev": true
-    },
     "node_modules/json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -2193,6 +2225,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -2236,25 +2274,110 @@
       }
     },
     "node_modules/msgpackr": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.5.tgz",
-      "integrity": "sha512-JG0V47xRIQ9pyUnx6Hb4+3TrQoia2nA3UIdmyTldhxaxtKFkekkKpUW/N6fwHwod9o4BGuJGtouxOk+yCP5PEA==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.7.tgz",
+      "integrity": "sha512-Hsa80i8W4BiObSMHslfnwC+CC1CYHZzoXJZn0+3EvoCEOgt3c5QlXhdcjgFk2aZxMgpV8aUFZqJyQUCIp4UrzA==",
       "dev": true,
       "optionalDependencies": {
-        "msgpackr-extract": "^1.0.14"
+        "msgpackr-extract": "^1.1.4"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.0.16.tgz",
-      "integrity": "sha512-fxdRfQUxPrL/TizyfYfMn09dK58e+d65bRD/fcaVH4052vj30QOzzqxcQIS7B0NsqlypEQ/6Du3QmP2DhWFfCA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.1.4.tgz",
+      "integrity": "sha512-WQbHvsThprXh+EqZYy+SQFEs7z6bNM7a0vgirwUfwUcphWGT2mdPcpyLCNiRsN6w5q5VKJUMblHY+tNEyceb9Q==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3"
+        "node-gyp-build-optional-packages": "^4.3.2"
+      },
+      "optionalDependencies": {
+        "msgpackr-extract-darwin-arm64": "1.1.0",
+        "msgpackr-extract-darwin-x64": "1.1.0",
+        "msgpackr-extract-linux-arm": "1.1.0",
+        "msgpackr-extract-linux-arm64": "1.1.0",
+        "msgpackr-extract-linux-x64": "1.1.0",
+        "msgpackr-extract-win32-x64": "1.1.0"
       }
+    },
+    "node_modules/msgpackr-extract-darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-s1kHoT12tS2cCQOv+Wl3I+/cYNJXBPtwQqGA+dPYoXmchhXiE0Nso+BIfvQ5PxbmAyjj54Q5o7PnLTqVquNfZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/msgpackr-extract-darwin-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-yx/H/i12IKg4eWGu/eKdKzJD4jaYvvujQSaVmeOMCesbSQnWo5X6YR9TFjoiNoU9Aexk1KufzL9gW+1DozG1yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/msgpackr-extract-linux-arm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-1.1.0.tgz",
+      "integrity": "sha512-0VvSCqi12xpavxl14gMrauwIzHqHbmSChUijy/uo3mpjB1Pk4vlisKpZsaOZvNJyNKj0ACi5jYtbWnnOd7hYGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/msgpackr-extract-linux-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-1.1.0.tgz",
+      "integrity": "sha512-AxFle3fHNwz2V4CYDIGFxI6o/ZuI0lBKg0uHI8EcCMUmDE5mVAUWYge5WXmORVvb8sVWyVgFlmi3MTu4Ve6tNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/msgpackr-extract-linux-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-1.1.0.tgz",
+      "integrity": "sha512-O+XoyNFWpdB8oQL6O/YyzffPpmG5rTNrr1nKLW70HD2ENJUhcITzbV7eZimHPzkn8LAGls1tBaMTHQezTBpFOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/msgpackr-extract-win32-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-1.1.0.tgz",
+      "integrity": "sha512-6AJdM5rNsL4yrskRfhujVSPEd6IBpgvsnIT/TPowKNLQ62iIdryizPY2PJNFiW3AJcY249AHEiDBXS1cTDPxzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/multimatch": {
       "version": "4.0.0",
@@ -2285,9 +2408,9 @@
       "dev": true
     },
     "node_modules/node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -2295,10 +2418,22 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.2.tgz",
+      "integrity": "sha512-P5Ep3ISdmwcCkZIaBaQamQtWAG0facC89phWZgi5Z3hBU//J6S48OIvyZWSPPf6yQMklLZiqoosWAZUj7N+esA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "dev": true
     },
     "node_modules/npm-run-path": {
@@ -2356,9 +2491,9 @@
       }
     },
     "node_modules/ordered-binary": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.4.tgz",
-      "integrity": "sha512-A/csN0d3n+igxBPfUrjbV5GC69LWj2pjZzAAeeHXLukQ4+fytfP4T1Lg0ju7MSPSwq7KtHkGaiwO8URZN5IpLg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.5.tgz",
+      "integrity": "sha512-djRmZoEpOGvIRW7ufsCDHtvcUa18UC9TxnPbHhSVFZHsoyg0dtut1bWtBZ/fmxdPN62oWXrV6adM7NoWU+CneA==",
       "dev": true
     },
     "node_modules/p-limit": {
@@ -2398,21 +2533,21 @@
       }
     },
     "node_modules/parcel": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.4.0.tgz",
-      "integrity": "sha512-dPWpu4RnxG9HqiLvaF8COEWEnT/KrigrC6PyPaQ0zEgpBfp7/jzXZFBVaZk2N+lpvrbNEYMjN9bv5UQGJJszIw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.5.0.tgz",
+      "integrity": "sha512-er0mj/BaMjWyzQ/jedLUi/LNAuQcFT8lCvoNqANF+jTaX9rohaBwxIvKVJVAZgyCnmyfbbldp496wPMW0R0+CA==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.4.0",
-        "@parcel/core": "2.4.0",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/events": "2.4.0",
-        "@parcel/fs": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/package-manager": "2.4.0",
-        "@parcel/reporter-cli": "2.4.0",
-        "@parcel/reporter-dev-server": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/config-default": "2.5.0",
+        "@parcel/core": "2.5.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/events": "2.5.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/package-manager": "2.5.0",
+        "@parcel/reporter-cli": "2.5.0",
+        "@parcel/reporter-dev-server": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0",
@@ -2572,18 +2707,18 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.6.6",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.6.tgz",
-      "integrity": "sha512-dgxpTFV2vs4vizwKohYKkk7g7rmp1wOOcfd4Tz3IB3Wi+ivZzsn/SpeKJhRENSE+n8sUfsAl4S3HiCVT923ABw==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.2.tgz",
+      "integrity": "sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -2639,6 +2774,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react-refresh": {
@@ -2801,14 +2945,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
+      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
+        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -2825,10 +2969,13 @@
       "dev": true
     },
     "node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
       "dev": true,
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
       "engines": {
         "node": ">= 8"
       }
@@ -2837,6 +2984,21 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "dev": true
+    },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/type-fest": {
@@ -2852,9 +3014,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2884,6 +3046,23 @@
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2939,9 +3118,9 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -3001,113 +3180,139 @@
         }
       }
     },
-    "@parcel/bundler-default": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.4.0.tgz",
-      "integrity": "sha512-RaXlxo0M51739Ko3bsOJpDBZlJ+cqkDoBTozNeSc65jS2TMBIBWLMapm8095qmty39OrgYNhzjgPiIlKDS/LWA==",
+    "@lezer/common": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "dev": true
+    },
+    "@lezer/lr": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "@mischnic/json-sourcemap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
+      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^0.15.7",
+        "@lezer/lr": "^0.15.4",
+        "json5": "^2.2.1"
+      }
+    },
+    "@parcel/bundler-default": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.5.0.tgz",
+      "integrity": "sha512-7CJzE17SirCXjcRgBcnqWO/5EOA1raq/3OIKtT4cxbjpDQGHZpjpEEZiMNRpEpdNMxDSlsG8mAkXTYGL2VVWRw==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.4.0.tgz",
-      "integrity": "sha512-oOudoAafrCAHQY0zkU7gVHG1pAGBUz9rht7Tx4WupTmAH0O0F5UnZs6XbjoBJaPHg+CYUXK7v9wQcrNA72E3GA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
+      "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "lmdb": "2.2.4"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.4.0.tgz",
-      "integrity": "sha512-PJ3W9Z0sjoS2CANyo50c+LEr9IRZrtu0WsVPSYZ5ZYRuSXrSa/6PcAlnkyDk2+hi7Od8ncT2bmDexl0Oar3Jyg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
+      "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/compressor-raw": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.4.0.tgz",
-      "integrity": "sha512-ZErX14fTc0gKIgtnuqW7Clfln4dpXWfUaJQQIf5C3x/LkpUeEhdXeKntkvSxOddDk2JpIKDwqzAxEMZUnDo4Nw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.5.0.tgz",
+      "integrity": "sha512-I5Zs+2f1ue4sTPdfT8BNsLfTZl48sMWLk2Io3elUJjH/SS9kO7ut5ChkuJtt77ZS35m0OF+ZCt3ICTJdnDG8eA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0"
+        "@parcel/plugin": "2.5.0"
       }
     },
     "@parcel/config-default": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.4.0.tgz",
-      "integrity": "sha512-pFOPBXPO6HGqNWTLkcK5i8haMOrRgUouUhcWPGWDpN9IPUYFK2E/O1E/uyMjIA1mSL3FnazI+jJwZ45NhKPpIA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.5.0.tgz",
+      "integrity": "sha512-r30V61958SONvP9I8KV8s44ZOFq0H219VyFjPysraSabHjZ+KMaCTQOuqaDtUMa272sHUQkBcZxKYj5jYPJlZg==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.4.0",
-        "@parcel/compressor-raw": "2.4.0",
-        "@parcel/namer-default": "2.4.0",
-        "@parcel/optimizer-css": "2.4.0",
-        "@parcel/optimizer-htmlnano": "2.4.0",
-        "@parcel/optimizer-image": "2.4.0",
-        "@parcel/optimizer-svgo": "2.4.0",
-        "@parcel/optimizer-terser": "2.4.0",
-        "@parcel/packager-css": "2.4.0",
-        "@parcel/packager-html": "2.4.0",
-        "@parcel/packager-js": "2.4.0",
-        "@parcel/packager-raw": "2.4.0",
-        "@parcel/packager-svg": "2.4.0",
-        "@parcel/reporter-dev-server": "2.4.0",
-        "@parcel/resolver-default": "2.4.0",
-        "@parcel/runtime-browser-hmr": "2.4.0",
-        "@parcel/runtime-js": "2.4.0",
-        "@parcel/runtime-react-refresh": "2.4.0",
-        "@parcel/runtime-service-worker": "2.4.0",
-        "@parcel/transformer-babel": "2.4.0",
-        "@parcel/transformer-css": "2.4.0",
-        "@parcel/transformer-html": "2.4.0",
-        "@parcel/transformer-image": "2.4.0",
-        "@parcel/transformer-js": "2.4.0",
-        "@parcel/transformer-json": "2.4.0",
-        "@parcel/transformer-postcss": "2.4.0",
-        "@parcel/transformer-posthtml": "2.4.0",
-        "@parcel/transformer-raw": "2.4.0",
-        "@parcel/transformer-react-refresh-wrap": "2.4.0",
-        "@parcel/transformer-svg": "2.4.0"
+        "@parcel/bundler-default": "2.5.0",
+        "@parcel/compressor-raw": "2.5.0",
+        "@parcel/namer-default": "2.5.0",
+        "@parcel/optimizer-css": "2.5.0",
+        "@parcel/optimizer-htmlnano": "2.5.0",
+        "@parcel/optimizer-image": "2.5.0",
+        "@parcel/optimizer-svgo": "2.5.0",
+        "@parcel/optimizer-terser": "2.5.0",
+        "@parcel/packager-css": "2.5.0",
+        "@parcel/packager-html": "2.5.0",
+        "@parcel/packager-js": "2.5.0",
+        "@parcel/packager-raw": "2.5.0",
+        "@parcel/packager-svg": "2.5.0",
+        "@parcel/reporter-dev-server": "2.5.0",
+        "@parcel/resolver-default": "2.5.0",
+        "@parcel/runtime-browser-hmr": "2.5.0",
+        "@parcel/runtime-js": "2.5.0",
+        "@parcel/runtime-react-refresh": "2.5.0",
+        "@parcel/runtime-service-worker": "2.5.0",
+        "@parcel/transformer-babel": "2.5.0",
+        "@parcel/transformer-css": "2.5.0",
+        "@parcel/transformer-html": "2.5.0",
+        "@parcel/transformer-image": "2.5.0",
+        "@parcel/transformer-js": "2.5.0",
+        "@parcel/transformer-json": "2.5.0",
+        "@parcel/transformer-postcss": "2.5.0",
+        "@parcel/transformer-posthtml": "2.5.0",
+        "@parcel/transformer-raw": "2.5.0",
+        "@parcel/transformer-react-refresh-wrap": "2.5.0",
+        "@parcel/transformer-svg": "2.5.0"
       }
     },
     "@parcel/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-EWZ2UWtIuwDc3fgsKyyTLpNNPoG8Yk2L117ICWF/+cqY8z/wJHm2KwLbeplDeq524shav0GJ9O4CemP3JPx0Nw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-dygDmPsfAYJKTnUftcbEzjCik7AAaPbFvJW8ETYz8diyjkAG9y6hvCAZIrJE5pNOjFzg32en4v4UWv8Sqlzl9g==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.4.0",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/events": "2.4.0",
-        "@parcel/fs": "2.4.0",
-        "@parcel/graph": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/package-manager": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.5.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/events": "2.5.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/graph": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/package-manager": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
         "dotenv": "^7.0.0",
         "dotenv-expand": "^5.1.0",
-        "json-source-map": "^0.6.1",
         "json5": "^2.2.0",
         "msgpackr": "^1.5.4",
         "nullthrows": "^1.1.1",
@@ -3115,130 +3320,130 @@
       }
     },
     "@parcel/css": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.7.2.tgz",
-      "integrity": "sha512-OcdGio5QCvshOJGXaqICC93yMDCi1baZ3yK/xHbKmu9R4p3IBp9+/hmjg5ZkfmJLvqsrguZ1JJndoSXITxPxpg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.8.2.tgz",
+      "integrity": "sha512-3vTyKHy2LnZ3YJEut+UQPVIxsaY/mdGk7cDXtmvH4xR48Pd6rYzChHCMl4Ru2DUkCBpr0KCQRPZTdYcsJhUmIA==",
       "dev": true,
       "requires": {
-        "@parcel/css-darwin-arm64": "1.7.2",
-        "@parcel/css-darwin-x64": "1.7.2",
-        "@parcel/css-linux-arm-gnueabihf": "1.7.2",
-        "@parcel/css-linux-arm64-gnu": "1.7.2",
-        "@parcel/css-linux-arm64-musl": "1.7.2",
-        "@parcel/css-linux-x64-gnu": "1.7.2",
-        "@parcel/css-linux-x64-musl": "1.7.2",
-        "@parcel/css-win32-x64-msvc": "1.7.2",
+        "@parcel/css-darwin-arm64": "1.8.2",
+        "@parcel/css-darwin-x64": "1.8.2",
+        "@parcel/css-linux-arm-gnueabihf": "1.8.2",
+        "@parcel/css-linux-arm64-gnu": "1.8.2",
+        "@parcel/css-linux-arm64-musl": "1.8.2",
+        "@parcel/css-linux-x64-gnu": "1.8.2",
+        "@parcel/css-linux-x64-musl": "1.8.2",
+        "@parcel/css-win32-x64-msvc": "1.8.2",
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/css-darwin-arm64": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.7.2.tgz",
-      "integrity": "sha512-i0b8n8FF+iSK8cLOQhzxXZbbWAGTRLYih4W7Jim4QOerTBvl0zmBajua0hst+phuDDgSO5GKm1/80X+7v8VW+g==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.8.2.tgz",
+      "integrity": "sha512-p5etxX3kPCuEQcipjqH9yc5j0x5/Yc++uB4MvG/sFbRgL2gI2zUuRo9sIgqA21boOP8lE4bQgz1ovPD/W1hj+Q==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-darwin-x64": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.7.2.tgz",
-      "integrity": "sha512-RsidKHrUhOp9wSlyBOxBTPcskh/QRtUV0uOVhHVLZtr7ebWT7L0T6wZJGX3vpTewgwIPB66IjJCE8ovdJLeMEg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.8.2.tgz",
+      "integrity": "sha512-c3xi5DXRZYec5db4KPTxp69eHbomOuasgZNiuPPOi80k7jlOwfzCFQs0h6/KwWvTcJrKEFsLl8BKJU/aX7mETw==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm-gnueabihf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.7.2.tgz",
-      "integrity": "sha512-NF6lvp2PDWqwUB16z1XQECyIIjO9EB6J9tMleLo1l6Set9nIaLRl3Jl06f3lFSBhxWQBqZ3Gr9c/5gvLtNjRew==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.8.2.tgz",
+      "integrity": "sha512-+ih3+mMpwbwtOjr/XW5pP0frsV1PMN+Qz7jCAM84h8xX+8UE/1IR0UVi3EPa8wQiIlcVcEwszQ1MV2UHacvo/A==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm64-gnu": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.7.2.tgz",
-      "integrity": "sha512-sqSzj8eoTFJkajLIjCbb8qDXLwH+4CQU0c7598Dg8K/culVuGlGn5mwwgfSK/HIZq6Wt8SD5iG0HmtNAwrcpCw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.8.2.tgz",
+      "integrity": "sha512-jIoyXbjJ1trUHXtyJhi3hlF1ck6xM4CDyaY5N6eN+3+ovkdw6wxog9IiheYJ1jf9ellYevLvTF5kiYE9MiP04A==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm64-musl": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.7.2.tgz",
-      "integrity": "sha512-XDnf5eY0O5exsMpv+hwtrxsi7vrm/kz2+JRar+7vNalxzFEc6xJhh/sRQw4XU7Qn9oCgJ/BDp58c6uDeQInEAQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.8.2.tgz",
+      "integrity": "sha512-QVTc5a+HatoywIei3djKYmp3s5dbI2Q3QaYZf3gqhyjOkeC7bm6j5eeNzFO+wa5xtga5jdHkIuTRrJ/wCojKKw==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-x64-gnu": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.7.2.tgz",
-      "integrity": "sha512-9c912OgRIR5i4Pffxh123fgcsGy0njcBD9di+ipb6RHi8ZQLhiUhbdMAXINHwJT/7pSds+RJGL6VNGP3KqSxCA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.8.2.tgz",
+      "integrity": "sha512-9r2tSfa6i3ZQ3a6C9XufJWuTv3LB7JYzxzEqsI35SSA8D/DrfAHMaIhqog5wSxKZRWmQxckh2wdT96eIIGHSGA==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-x64-musl": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.7.2.tgz",
-      "integrity": "sha512-D9ZEllB21G9PA9+f+jdOXh3qPeryg+6fGSe1dXfLvQ0yG41FeBQgbIpPabhLUCNEdHG11t43LkJT5RVuG/n6uw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.8.2.tgz",
+      "integrity": "sha512-5SetLWkxXRQ3NU6QwwbGf9tOmGW2m1cGt07Moybbe4RCXOY6R5wAYUtauZUp7pD/fJlE9mHge4jnNHKpVO9pvw==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-win32-x64-msvc": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.7.2.tgz",
-      "integrity": "sha512-9j8fu0nSqVj2w1NusgLJX9/XP5ITQke5/eRn6/no9cx4GD2YDsuKchDIc2yVxxuGD0WrDECScEtuXEKEmmxjxw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.8.2.tgz",
+      "integrity": "sha512-/EdW5Ejlnkvc/AYrAi/FmLNvM6a6eAx+A4Y7oW+8JSMvk6bYa2zmXi7XLU/QOQuH2VQa/3gIIMA+sYjPndvDpw==",
       "dev": true,
       "optional": true
     },
     "@parcel/diagnostic": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.4.0.tgz",
-      "integrity": "sha512-TjWO/b2zMFhub5ouwGjazMm7iAUvdmXBfWmjrg4TBhUbhoQwBnyWfvMDtAYo7PcvXfxVPgPZv86Nv6Ym5H6cHQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
+      "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
       "dev": true,
       "requires": {
-        "json-source-map": "^0.6.1",
+        "@mischnic/json-sourcemap": "^0.1.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/events": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.4.0.tgz",
-      "integrity": "sha512-DEaEtFbhOhNAEmiXJ3MyF8Scq+sNDKiTyLax4lAC5/dpE5GvwfNnoD17C2+0gDuuDpdQkdHfXfvr50aYFt7jcw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
+      "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.4.0.tgz",
-      "integrity": "sha512-CnUlWGUJ52SJVQi8QnaAPPQZOADmHMV9D9aX9GLcDm5XLT3Em7vmesG4bNLdMLwzYuzAtenhcWmuRCACuYztHw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
+      "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
       "dev": true,
       "requires": {
-        "@parcel/fs-search": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/fs-search": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.4.0"
+        "@parcel/workers": "2.5.0"
       }
     },
     "@parcel/fs-search": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.4.0.tgz",
-      "integrity": "sha512-W/Vu6wbZk4wuB6AVdMkyymwh/S8Peed/PgJgSsApYD6lSTD315I6OuEdxZh3lWY+dqQdog/NJ7dvi/hdpH/Iqw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
+      "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/graph": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.4.0.tgz",
-      "integrity": "sha512-5TZIAfDITkJCzgH4j4OQhnIvjV9IFwWqNBJanRl5QQTmKvdcODS3WbnK1SOJ+ZltcLVXMB+HNXmL0bX0tVolcw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.5.0.tgz",
+      "integrity": "sha512-qa2VtG08dJyTaWrxYAkMIlkoDRSPoiqLDNxxHKplkcxAjXBUw0/AkWaz82VO5r1G6jfOj+nM30ajH9uygZYwbw==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/hash": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.4.0.tgz",
-      "integrity": "sha512-nB+wYNUhe6+G8M7vQhdeFXtpYJYwJgBHOPZ7Hd9O2jdlamWjDbw0t/u1dJbYvGJ8ZDtLDwiItawQVpuVdskQ9g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
+      "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -3246,68 +3451,68 @@
       }
     },
     "@parcel/logger": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.4.0.tgz",
-      "integrity": "sha512-DqfU0Zcs/0a7VBk+MsjJ80C66w4kM9EbkO3G12NIyEjNeG50ayW2CE9rUuJ91JaM9j0NFM1P82eyLpQPFFaVPw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
+      "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/events": "2.4.0"
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/events": "2.5.0"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.4.0.tgz",
-      "integrity": "sha512-gPUP1xikxHiu2kFyPy35pfuVkFgAmcywO8YDQj7iYcB+k7l4QPpIYFYGXn2QADV4faf66ncMeTD4uYV8c0GqjQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
+      "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/namer-default": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.4.0.tgz",
-      "integrity": "sha512-DfL+Gx0Tyoa0vsgRpNybXjuKbWNw8MTVpy7Dk7r0btfVsn1jy3SSwlxH4USf76gb00/pK6XBsMp9zn7Z8ePREQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
+      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.4.0.tgz",
-      "integrity": "sha512-qiN97XcfW2fYNoYuVEhNKuVPEJKj5ONQl0fqr/NEMmYvWz3bVKjgiXNJwW558elZvCI08gEbdxgyThpuFFQeKQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.5.0.tgz",
+      "integrity": "sha512-XQvpguiIwQcu75cscLDFOVhjsjuPzXbuMaaZ7XxxUEl0PscIgu/GfKYxTfTruN3cRl+CaQH6qBAMfjLaFng6lQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-css": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.4.0.tgz",
-      "integrity": "sha512-LQmjjOGsHEHKTJqfHR2eJyhWhLXvHP0uOAU+qopBttYYlB2J/vMK9RYAye5cyAb8bQmV8wAdi2mq9rnt7FMSPw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.5.0.tgz",
+      "integrity": "sha512-J00bLF+4SsnKc+YbYrNuBr44/zz3cg++CoXteXhH27PxP1rScGQx36Rui8WORgil5mlX2VYN79DuqJC7V3Ynbg==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.7.2",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/css": "^1.8.1",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.4.0.tgz",
-      "integrity": "sha512-02EbeElLgNOAYhGU7fFBahpoKrX5G/yzahpaoKB/ypScM4roSsAMBkGcluboR5L10YRsvfvJEpxvfGyDA3tPmw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.5.0.tgz",
+      "integrity": "sha512-Fr0zPqgxoNaOVdROAjNGDWCts3+wByNQ82Mxhu8Tzc25A2cPjcr1H2sa/TE3hf79c92DxdKf2FaC1ZOgR5YPdg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
+        "@parcel/plugin": "2.5.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -3315,214 +3520,214 @@
       }
     },
     "@parcel/optimizer-image": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.4.0.tgz",
-      "integrity": "sha512-Q4onaBMPkDyYxPzrb8ytBUftaQZFepj9dSUgq+ETuHDzkgia0tomDPfCqrw6ld0qvYyANzXTP5+LC4g0i5yh+A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.5.0.tgz",
+      "integrity": "sha512-nbo2pdnAt21WLGjzTpsE8ZEL0xNoP7c3wBj9y70Pysmasg1SrRVCbfE8jTy+lHBQwq2yjC6lV/Usv+9lfA7S/w==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/optimizer-svgo": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.4.0.tgz",
-      "integrity": "sha512-mwvGuCqVuNCAuMlp2maFE/Uz9ud1T1AuX0f6cCRczjFYiwZuIr/0iDdfFzSziOkVo1MRAGAZNa0dRR/UzCZtVg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.5.0.tgz",
+      "integrity": "sha512-pgZqwU0RLc/wr4WcQY/W1GJmddnEANDEpz1mdppUOqBz1EfTQ7zh5NgUA3hV1i05Hbecp3mHSvXJPV0mhNOl5Q==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "svgo": "^2.4.0"
       }
     },
     "@parcel/optimizer-terser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.4.0.tgz",
-      "integrity": "sha512-PdCgRgXNSY6R1HTV9VG2MHp1CgUbP5pslCyxvlbUmQAS6bvEpMOpn3qSd+U28o7mGE/qXIhvpDyi808sb+MEcg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.5.0.tgz",
+      "integrity": "sha512-PZ3UHBGfjE49/Jloopsd38Hxg4qzsrdepWP53mCuVP7Aw605Y4QtYuB1ho3VV0oXfKQVq+uI7lVIBsuW4K6vqA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       }
     },
     "@parcel/package-manager": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.4.0.tgz",
-      "integrity": "sha512-21AEfAQnZbHRVViTn7QsPGe/CiGaFaDUH5f0m8qVC7fDjjhC8LM8blkqU72goaO9FbaLMadtEf2txhzly7h/bg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
+      "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/fs": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "semver": "^5.7.1"
       }
     },
     "@parcel/packager-css": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.4.0.tgz",
-      "integrity": "sha512-LmPDWzkXi60Oy3WrPF0jPKQxeTwW5hmNBgrcXJMHSu+VcXdaQZNzNxVzhnZkJUbDd2z9vAUrUGzdLh8TquC8iQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.5.0.tgz",
+      "integrity": "sha512-c0mGBFdVSPhAxaX3+zN8KEIqOOUhkIPKbZex1pnGYfy03Qe2/Mb4nyt5DAGlw9gjka1UCHIN/wszLmKC8YyUeg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.4.0.tgz",
-      "integrity": "sha512-OPMIQ1uHYQFpRPrsmm5BqONbAyzjlhVsPRAzHlcBrglG4BTUeOR2ow4MUKblHmVVqc3QHnfZG4nHHtFkeuNQ3A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.5.0.tgz",
+      "integrity": "sha512-ZFGUPRMWKrm8kQHdkEJ5S22C05qpSymx+o+57EfuNjCrGyj3M59WyGYYXYJ175bFYZ/jp5yy+VxMh6fZefe+Pw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.4.0.tgz",
-      "integrity": "sha512-cfslIH43CJFgBS9PmdFaSnbInMCoejsFCnxtJa2GeUpjCXSfelPRp0OPx7m8n+fap4czftPhoxBALeDUElOZGQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.5.0.tgz",
+      "integrity": "sha512-aJAKOTgXdxO3V9O7+2DCVOtne128WwXmUAOVThnMRo7f3zMVSAR7Mxc9pEsuTzPfj8UBXgFBRfdJUSCgsMxiSw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.4.0.tgz",
-      "integrity": "sha512-SFfw7chMFITj3J26ZVDJxbO6xwtPFcFBm1js8cwWMgzwuwS6CEc43k5+Abj+2/EqHU9kNJU9eWV5vT6lQwf3HA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.5.0.tgz",
+      "integrity": "sha512-aHV0oogeiqxhxS1lsttw15EvG3DDWK3FV7+F+7hoaAy+xg89K56NTp6j43Jtw9iyU1/HnZRGBE2hF3C7N73oKw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0"
+        "@parcel/plugin": "2.5.0"
       }
     },
     "@parcel/packager-svg": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.4.0.tgz",
-      "integrity": "sha512-DwkgrdLEQop+tu9Ocr1ZaadmpsbSgVruJPr80xq1LaB0Jiwrl9HjHStMNH1laNFueK1yydxhnj9C2JQfW28qag==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.5.0.tgz",
+      "integrity": "sha512-XSMFn30K/kpjcPpQqt88GmPJsNUSVL3RNeigXkIAcLpfO6Tb2eV4iOt4yVCagaDrRJ19alXut0TxjMm5bm41/g==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "posthtml": "^0.16.4"
       }
     },
     "@parcel/packager-xml": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-xml/-/packager-xml-2.4.0.tgz",
-      "integrity": "sha512-05zi6Pt4V2xm52owKeLeVmGNixdweOJ4sbgb+x6iBB7EhFANfBFQXGgHC7FAf9GmVS0Q0r6QgTYNFqb2w+LEZw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-xml/-/packager-xml-2.5.0.tgz",
+      "integrity": "sha512-KFu3I7b2LAlnJxcJD0bufMCOmFEwZlvsNKrtOVooXUIbhe6Oe9yhQ4iw+FcosCdT0dI1U8jb808bkB6o+mhuAA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "@xmldom/xmldom": "^0.7.5"
       }
     },
     "@parcel/plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.4.0.tgz",
-      "integrity": "sha512-ehFUAL2+h27Lv+cYbbXA74UGy8C+eglUjcpvASOOjVRFuD6poMAMliKkKAXBhQaFx/Rvhz27A2PIPv9lL2i4UQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
+      "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.4.0"
+        "@parcel/types": "2.5.0"
       }
     },
     "@parcel/reporter-cli": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.4.0.tgz",
-      "integrity": "sha512-Q9bIFMaGvQgypCDxdMEKOwrJzIHAXScKkuFsqTHnUL6mmH3Mo2CoEGAq/wpMXuPhXRn1dPJcHgTNDwZ2fSzz0A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.5.0.tgz",
+      "integrity": "sha512-miJt2YbRJBmYSVeoUWUj8YL85Pwj1CmGQB0/btqhulGLH/Fvkbv6T4sJ4gl4l5xIt9mJQsZ70pOWwa8BId3rWw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.4.0.tgz",
-      "integrity": "sha512-24h++wevs7XYuX4dKa4PUfLSstvn3g7udajFv6CeQoME+dR25RL/wH/2LUbhV5ilgXXab76rWIndSqp78xHxPA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.5.0.tgz",
+      "integrity": "sha512-wvxAiW42AxJ3B8jtvowJcP4/cTV8zY48SfKg61YKYu1yUO+TtyJIjHQzDW2XuT34cIGFY97Gr0i+AVu44RyUuQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0"
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0"
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.4.0.tgz",
-      "integrity": "sha512-K7pIIFmGm1hjg/7Mzkg99i8tfCClKfBUTuc2R5j8cdr2n0mCAi4/f2mFf5svLrb5XZrnDgoQ05tHKklLEfUDUw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.5.0.tgz",
+      "integrity": "sha512-39PkZpVr/+iYS11u+lA84vIsKm/yisltTVmUjlYsDnExiuV1c8OSbSdYZ3JMx+7CYPE0bWbosX2AGilIwIMWpQ==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "2.4.0",
-        "@parcel/plugin": "2.4.0"
+        "@parcel/node-resolver-core": "2.5.0",
+        "@parcel/plugin": "2.5.0"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.4.0.tgz",
-      "integrity": "sha512-swPFtvxGoCA9LEjU/pHPNjxG1l0fte8447zXwRN/AaYrtjNu9Ww117OSKCyvCnE143E79jZOFStodTQGFuH+9A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.5.0.tgz",
+      "integrity": "sha512-oPAo8Zf06gXCpt41nyvK7kv2HH1RrHAGgOqttyjStwAFlm5MZKs7BgtJzO58LfJN8g3sMY0cNdG17fB/4f8q6Q==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0"
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.4.0.tgz",
-      "integrity": "sha512-67OOvmkDdtmgzZVP/EyAzoXhJ/Ug3LUVUt7idg9arun5rdJptqEb3Um3wmH0zjcNa9jMbJt7Kl5x1wA8dJgPYg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.5.0.tgz",
+      "integrity": "sha512-gPC2PbNAiooULP71wF5twe4raekuXsR1Hw/ahITDoqsZdXHzG3CkoCjYL3CkmBGiKQgMMocCyN1E2oBzAH8Kyw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.4.0.tgz",
-      "integrity": "sha512-flnr+bf06lMZPbXZZLLaFNrPHvYpfuXTVovEghyUW46qLVpaHj33dpsU/LqZplIuHgBp2ibgrKhr/hY9ell68w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.5.0.tgz",
+      "integrity": "sha512-+8RuDKFdFYIQTrXG4MRhG9XqkkYEHn0zxKyOJ/IkDDfSEhY0na+EyhrneFUwIvDX63gLPkxceXAg0gwBqXPK/Q==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/runtime-service-worker": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.4.0.tgz",
-      "integrity": "sha512-RgM5QUqW22WzstW03CtV+Oih8VGVuwsf94Cc4hLouU2EAD0NUJgATWbFocZVTZIBTKELAWh2gjpSQDdnL4Ur+A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.5.0.tgz",
+      "integrity": "sha512-STuDlU0fPXeWpAmbayY7o04F0eHy6FTOFeT5KQ0PTxtdEa3Ey8QInP/NVE52Yv0aVQtesWukGrNEFCERlkbFRw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1"
       }
     },
@@ -3536,15 +3741,15 @@
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.4.0.tgz",
-      "integrity": "sha512-iWDa7KzJTMP3HNmrYxiYq/S6redk2qminx/9MwmKIN9jzm8mgts2Lj9lOg/t66YaDGky6JAvw4DhB2qW4ni6yQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.5.0.tgz",
+      "integrity": "sha512-EFb866C9jCoBHIcebWF7goAcYj1wkObx0GDxshlazFtvym1RM27xSWWjRYyqb5+HNOxB3voaNvQOVjcD+DXjCA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -3552,29 +3757,29 @@
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.4.0.tgz",
-      "integrity": "sha512-D2u48LuiQsQvbknABE0wVKFp9r6yCgWrHKEP1J6EJ31c49nXGXDHrpHJJwqq9BvAs/124eBI5mSsehTJyFEMwg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.5.0.tgz",
+      "integrity": "sha512-p8FOvKWWSbS6H8PbD9a0KZqyaKNpSD2BUTzSRYnNj3TBUv7/ZXaP6Om295XTQ/MPht1o7XTQzvfpF/7yEhr02Q==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.7.2",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/css": "^1.8.1",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/utils": "2.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.4.0.tgz",
-      "integrity": "sha512-2/8X/o5QaCNVPr4wkxLCUub7v/YVvVN2L5yCEcTatNeFhNg/2iz7P2ekfqOaoDCHWZEOBT1VTwPbdBt+TMM71Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.5.0.tgz",
+      "integrity": "sha512-iEjNyAF0wQmY3DMw7FS+UzoOMng76UsSngh+WWA1E5lv5XyqrP8Mk2QLTJp1nWetUhSLhZr58LGmPYBTB4l9ZQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3583,27 +3788,27 @@
       }
     },
     "@parcel/transformer-image": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.4.0.tgz",
-      "integrity": "sha512-JZkQvGGoGiD0AVKLIbAYYUWxepMmUaWZ4XXx71MmS/kA7cUDwTZ0CXq63YnSY1m+DX+ClTuTN8mBlwe2dkcGbA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.5.0.tgz",
+      "integrity": "sha512-vVEXTHZl8m/9yopgK0dWHLOQX2zOnghq6pZnWdWVG6fsvXZln7kP1YN5iwWDoADQYkiKzP+Ymn6UwP9pZpHFzA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.4.0.tgz",
-      "integrity": "sha512-eeLHFwv3jT3GmIxpLC7B8EXExGK0MFaK91HXljOMh6l8a+GlQYw27MSFQVtoXr0Olx9Uq2uvjXP1+zSsq3LQUQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.5.0.tgz",
+      "integrity": "sha512-Cp8Ic+Au3OcskCRZszmo47z3bqcZ7rfPv2xZYXpXY2TzEc3IV0bKje57bZektoY8LW9LkYM9iBO/WhkVoT6LIg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/utils": "2.5.0",
+        "@parcel/workers": "2.5.0",
         "@swc/helpers": "^0.3.6",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
@@ -3613,25 +3818,25 @@
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.4.0.tgz",
-      "integrity": "sha512-3nR+d39mbURoXIypDfVCaxpwL65qMV+h8SLD78up2uhaRGklHQfN7GuemR7L+mcVAgNrmwVvZHhyNjdgYwWqqg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.5.0.tgz",
+      "integrity": "sha512-661sByA7TkR6Lmxt+hqV4h2SAt+7lgc58DzmUYArpEl1fQnMuQuaB0kQeHzi6fDD2+2G6o7EC+DuwBZKa479TA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
+        "@parcel/plugin": "2.5.0",
         "json5": "^2.2.0"
       }
     },
     "@parcel/transformer-postcss": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.4.0.tgz",
-      "integrity": "sha512-ijIa2x+dbKnJhr7zO5WlXkvuj832fDoGksMBk2DX3u2WMrbh2rqVWPpGFsDhESx7EAy38nUoV/5KUdrNqUmCEA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.5.0.tgz",
+      "integrity": "sha512-IPNlWElekdQHMTBqhdwJNBCQomuYyo7xgNBdnTrt9VJ+R5ihy6n7ZJSWIAJXAH9VZxETTtunfrzRtgkmtjTeZQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -3639,13 +3844,13 @@
       }
     },
     "@parcel/transformer-posthtml": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.4.0.tgz",
-      "integrity": "sha512-xoL3AzgtVeRRAo6bh0AHAYm9bt1jZ+HiH86/7oARj/uJs6Wd8kXK/DZf6fH+F87hj4e7bnjmDDc0GPVK0lPz1w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.5.0.tgz",
+      "integrity": "sha512-AZxg1XD8OXOS4bEGEmBBR+X9T9qoFdVsbVUg498zzejYSka1ZQHF7TgLI/+pUnE+ZVYNIp7/G0xXqsRVKMKmdQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3654,34 +3859,34 @@
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.4.0.tgz",
-      "integrity": "sha512-fciFbNrzj0kLlDgr6OsI0PUv414rVygDWAsgbCCq4BexDkuemMs9f9FjMctx9B2VZlctE8dTT4RGkuQumTIpUg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.5.0.tgz",
+      "integrity": "sha512-I3zjE1u9+Wj90Qqs1V2FTm6iC6SAyOVUthwVZkZey+qbQG/ok682Ez2XjLu7MyQCo9BJNwF/nfOa1hHr3MaJEQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0"
+        "@parcel/plugin": "2.5.0"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.4.0.tgz",
-      "integrity": "sha512-9+f6sGOWkf0jyUQ1CuFWk+04Mq3KTOCU9kRiwCHX1YdUCv5uki6r9XUSpqiYodrV+L6w9CCwLvGMLCDHxtCxMg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.5.0.tgz",
+      "integrity": "sha512-VPqVBxhTN4OQwcjsdyxrv+smjAm4s6dbSWAplgPwdOITMv+a0tjhhJU37WnRC+xxTrbEqRcOt96JvGOkPb8i7g==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/plugin": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/transformer-svg": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.4.0.tgz",
-      "integrity": "sha512-D+yzVtSxtQML3d26fd/g4E/xYW68+OMbMUVLXORtoYMU42fnXQkJP6jGOdqy8Td+WORNY7EwVtQnESLwhBmolw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.5.0.tgz",
+      "integrity": "sha512-zCGJcrCpICFe0Q/dgjQZfW7sYFkbJEC7NGT4zEJnMo8Cm/kq8Qh6+2ApX6c+vv5Q0WZn5Ic+N0OvxIMkvgdC/w==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/plugin": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/plugin": "2.5.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3690,41 +3895,41 @@
       }
     },
     "@parcel/transformer-xml": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-xml/-/transformer-xml-2.4.0.tgz",
-      "integrity": "sha512-/xrkbmewrB0pqbgJih3vBT+8+glANZwh4Ev803Ckzl+G8fYAVNH16aaNzi/IgMol+5SNfQE/VsMKiuV0BYvF1Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-xml/-/transformer-xml-2.5.0.tgz",
+      "integrity": "sha512-ndkAcE1ESFOIYtTx5BacDH45AfkHWyjolVh/JlIq3WxKTMxi1cN3gv0Hd3lL2oSgJGv9YmHnpsLIhVk2QlGFrA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.4.0",
+        "@parcel/plugin": "2.5.0",
         "@xmldom/xmldom": "^0.7.5"
       }
     },
     "@parcel/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-nysGIbBEnp+7R+tKTysdcTFOZDTCodsiXFeAhYQa5bhiOnG1l9gzhxQnE2OsdsgvMm40IOsgKprqvM/DbdLfnQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.4.0",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/fs": "2.4.0",
-        "@parcel/package-manager": "2.4.0",
+        "@parcel/cache": "2.5.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/package-manager": "2.5.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.4.0",
+        "@parcel/workers": "2.5.0",
         "utility-types": "^3.10.0"
       }
     },
     "@parcel/utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.4.0.tgz",
-      "integrity": "sha512-sdNo+mZqDZT8LJYB6WWRKa4wFVZcK6Zb5Jh6Du76QvXXwHbPIQNZgJBb6gd/Rbk4GLOp2tW7MnBfq6zP9E9E2g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
       "dev": true,
       "requires": {
-        "@parcel/codeframe": "2.4.0",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/hash": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/markdown-ansi": "2.4.0",
+        "@parcel/codeframe": "2.5.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/hash": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/markdown-ansi": "2.5.0",
         "@parcel/source-map": "^2.0.0",
         "chalk": "^4.1.0"
       }
@@ -3740,24 +3945,27 @@
       }
     },
     "@parcel/workers": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.4.0.tgz",
-      "integrity": "sha512-eSFyvEoXXPgFzQfKIlpkUjpHfIbezUCRFTPKyJAKCxvU5DSXOpb1kz5vDESWQ4qTZXKnrKvxS1PPWN6bam9z0g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
+      "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/types": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/types": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@swc/helpers": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.8.tgz",
-      "integrity": "sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg==",
-      "dev": true
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.13.tgz",
+      "integrity": "sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "@trysound/sax": {
       "version": "0.2.0",
@@ -3766,9 +3974,9 @@
       "dev": true
     },
     "@types/elasticlunr": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@types/elasticlunr/-/elasticlunr-0.9.4.tgz",
-      "integrity": "sha512-vrFREPCWi2sd33P8/iBzpN0+N1j3tpC/F7OJAUX0MogtbgzOx3EM0XG37WraDAJGsjyq+BqkaS4/J+3ntOF+2w==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@types/elasticlunr/-/elasticlunr-0.9.5.tgz",
+      "integrity": "sha512-gzY3gZLI6HczDO3vXM+u3P0dClEQ68k2d0UsZY1lyOaOZiGiamu7Ha/YBoc8CgAu5/3R+/u0HguDgD+xakmSEA==",
       "dev": true
     },
     "@types/lunr": {
@@ -3802,9 +4010,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true
     },
     "ansi-styles": {
@@ -3866,15 +4074,15 @@
       }
     },
     "browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
+        "caniuse-lite": "^1.0.30001332",
+        "electron-to-chromium": "^1.4.118",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
+        "node-releases": "^2.0.3",
         "picocolors": "^1.0.0"
       }
     },
@@ -3891,9 +4099,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001319",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
-      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==",
+      "version": "1.0.30001338",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
       "dev": true
     },
     "chalk": {
@@ -3975,14 +4183,14 @@
       }
     },
     "css-select": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
-      "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.1.0",
-        "domhandler": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
       }
@@ -3998,9 +4206,9 @@
       }
     },
     "css-what": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "dev": true
     },
     "csso": {
@@ -4024,9 +4232,9 @@
       "dev": true
     },
     "dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
@@ -4043,9 +4251,9 @@
       }
     },
     "domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true
     },
     "domhandler": {
@@ -4086,9 +4294,9 @@
       "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU="
     },
     "electron-to-chromium": {
-      "version": "1.4.91",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.91.tgz",
-      "integrity": "sha512-Z7Jkc4+ouEg8F6RrrgLOs0kkJjI0cnyFQmnGVpln8pPifuKBNbUr37GMgJsCTSwy6Z9TK7oTwW33Oe+3aERYew==",
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
     },
     "end-of-stream": {
@@ -4155,9 +4363,9 @@
       }
     },
     "fuzzysort": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.2.1.tgz",
-      "integrity": "sha512-egTSF3U6H6T9tXtAhEm5P5guSSDjd96/NUWrbmoGlIu3ATMdXra13gwQdEFRY6ehsFe8xec7UnQz+k34CGWCIg=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.9.0.tgz",
+      "integrity": "sha512-MOxCT0qLTwLqmEwc7UtU045RKef7mc8Qz8eR4r2bLNEq9dy/c3ZKMEFp6IEst69otkQdFZ4FfgH2dmZD+ddX1g=="
     },
     "get-port": {
       "version": "4.2.0",
@@ -4175,9 +4383,9 @@
       }
     },
     "globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.14.0.tgz",
+      "integrity": "sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -4190,9 +4398,9 @@
       "dev": true
     },
     "htmlnano": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.0.tgz",
-      "integrity": "sha512-thKQfhcp2xgtsWNE27A2bliEeqVL5xjAgGn0wajyttvFFsvFWWah1ntV9aEX61gz0T6MBQ5xK/1lXuEumhJTcg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.2.tgz",
+      "integrity": "sha512-+ZrQFS4Ub+zd+/fWwfvoYCEGNEa0/zrpys6CyXxvZDwtL7Pl+pOtRkiujyvBQ7Lmfp7/iEPxtOFgxWA16Gkj3w==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^7.0.1",
@@ -4275,12 +4483,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
-      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
-      "dev": true
-    },
     "json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -4314,6 +4516,12 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "mdn-data": {
       "version": "2.0.14",
@@ -4349,24 +4557,71 @@
       "dev": true
     },
     "msgpackr": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.5.tgz",
-      "integrity": "sha512-JG0V47xRIQ9pyUnx6Hb4+3TrQoia2nA3UIdmyTldhxaxtKFkekkKpUW/N6fwHwod9o4BGuJGtouxOk+yCP5PEA==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.7.tgz",
+      "integrity": "sha512-Hsa80i8W4BiObSMHslfnwC+CC1CYHZzoXJZn0+3EvoCEOgt3c5QlXhdcjgFk2aZxMgpV8aUFZqJyQUCIp4UrzA==",
       "dev": true,
       "requires": {
-        "msgpackr-extract": "^1.0.14"
+        "msgpackr-extract": "^1.1.4"
       }
     },
     "msgpackr-extract": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.0.16.tgz",
-      "integrity": "sha512-fxdRfQUxPrL/TizyfYfMn09dK58e+d65bRD/fcaVH4052vj30QOzzqxcQIS7B0NsqlypEQ/6Du3QmP2DhWFfCA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.1.4.tgz",
+      "integrity": "sha512-WQbHvsThprXh+EqZYy+SQFEs7z6bNM7a0vgirwUfwUcphWGT2mdPcpyLCNiRsN6w5q5VKJUMblHY+tNEyceb9Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3"
+        "msgpackr-extract-darwin-arm64": "1.1.0",
+        "msgpackr-extract-darwin-x64": "1.1.0",
+        "msgpackr-extract-linux-arm": "1.1.0",
+        "msgpackr-extract-linux-arm64": "1.1.0",
+        "msgpackr-extract-linux-x64": "1.1.0",
+        "msgpackr-extract-win32-x64": "1.1.0",
+        "node-gyp-build-optional-packages": "^4.3.2"
       }
+    },
+    "msgpackr-extract-darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-s1kHoT12tS2cCQOv+Wl3I+/cYNJXBPtwQqGA+dPYoXmchhXiE0Nso+BIfvQ5PxbmAyjj54Q5o7PnLTqVquNfZA==",
+      "dev": true,
+      "optional": true
+    },
+    "msgpackr-extract-darwin-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-yx/H/i12IKg4eWGu/eKdKzJD4jaYvvujQSaVmeOMCesbSQnWo5X6YR9TFjoiNoU9Aexk1KufzL9gW+1DozG1yw==",
+      "dev": true,
+      "optional": true
+    },
+    "msgpackr-extract-linux-arm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-1.1.0.tgz",
+      "integrity": "sha512-0VvSCqi12xpavxl14gMrauwIzHqHbmSChUijy/uo3mpjB1Pk4vlisKpZsaOZvNJyNKj0ACi5jYtbWnnOd7hYGw==",
+      "dev": true,
+      "optional": true
+    },
+    "msgpackr-extract-linux-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-1.1.0.tgz",
+      "integrity": "sha512-AxFle3fHNwz2V4CYDIGFxI6o/ZuI0lBKg0uHI8EcCMUmDE5mVAUWYge5WXmORVvb8sVWyVgFlmi3MTu4Ve6tNQ==",
+      "dev": true,
+      "optional": true
+    },
+    "msgpackr-extract-linux-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-1.1.0.tgz",
+      "integrity": "sha512-O+XoyNFWpdB8oQL6O/YyzffPpmG5rTNrr1nKLW70HD2ENJUhcITzbV7eZimHPzkn8LAGls1tBaMTHQezTBpFOw==",
+      "dev": true,
+      "optional": true
+    },
+    "msgpackr-extract-win32-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-1.1.0.tgz",
+      "integrity": "sha512-6AJdM5rNsL4yrskRfhujVSPEd6IBpgvsnIT/TPowKNLQ62iIdryizPY2PJNFiW3AJcY249AHEiDBXS1cTDPxzA==",
+      "dev": true,
+      "optional": true
     },
     "multimatch": {
       "version": "4.0.0",
@@ -4394,15 +4649,22 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
       "dev": true
     },
+    "node-gyp-build-optional-packages": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.2.tgz",
+      "integrity": "sha512-P5Ep3ISdmwcCkZIaBaQamQtWAG0facC89phWZgi5Z3hBU//J6S48OIvyZWSPPf6yQMklLZiqoosWAZUj7N+esA==",
+      "dev": true,
+      "optional": true
+    },
     "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "dev": true
     },
     "npm-run-path": {
@@ -4448,9 +4710,9 @@
       }
     },
     "ordered-binary": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.4.tgz",
-      "integrity": "sha512-A/csN0d3n+igxBPfUrjbV5GC69LWj2pjZzAAeeHXLukQ4+fytfP4T1Lg0ju7MSPSwq7KtHkGaiwO8URZN5IpLg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.5.tgz",
+      "integrity": "sha512-djRmZoEpOGvIRW7ufsCDHtvcUa18UC9TxnPbHhSVFZHsoyg0dtut1bWtBZ/fmxdPN62oWXrV6adM7NoWU+CneA==",
       "dev": true
     },
     "p-limit": {
@@ -4478,21 +4740,21 @@
       "dev": true
     },
     "parcel": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.4.0.tgz",
-      "integrity": "sha512-dPWpu4RnxG9HqiLvaF8COEWEnT/KrigrC6PyPaQ0zEgpBfp7/jzXZFBVaZk2N+lpvrbNEYMjN9bv5UQGJJszIw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.5.0.tgz",
+      "integrity": "sha512-er0mj/BaMjWyzQ/jedLUi/LNAuQcFT8lCvoNqANF+jTaX9rohaBwxIvKVJVAZgyCnmyfbbldp496wPMW0R0+CA==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.4.0",
-        "@parcel/core": "2.4.0",
-        "@parcel/diagnostic": "2.4.0",
-        "@parcel/events": "2.4.0",
-        "@parcel/fs": "2.4.0",
-        "@parcel/logger": "2.4.0",
-        "@parcel/package-manager": "2.4.0",
-        "@parcel/reporter-cli": "2.4.0",
-        "@parcel/reporter-dev-server": "2.4.0",
-        "@parcel/utils": "2.4.0",
+        "@parcel/config-default": "2.5.0",
+        "@parcel/core": "2.5.0",
+        "@parcel/diagnostic": "2.5.0",
+        "@parcel/events": "2.5.0",
+        "@parcel/fs": "2.5.0",
+        "@parcel/logger": "2.5.0",
+        "@parcel/package-manager": "2.5.0",
+        "@parcel/reporter-cli": "2.5.0",
+        "@parcel/reporter-dev-server": "2.5.0",
+        "@parcel/utils": "2.5.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0",
@@ -4605,14 +4867,14 @@
       }
     },
     "preact": {
-      "version": "10.6.6",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.6.tgz",
-      "integrity": "sha512-dgxpTFV2vs4vizwKohYKkk7g7rmp1wOOcfd4Tz3IB3Wi+ivZzsn/SpeKJhRENSE+n8sUfsAl4S3HiCVT923ABw=="
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.2.tgz",
+      "integrity": "sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ=="
     },
     "prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true
     },
     "pretty-quick": {
@@ -4650,6 +4912,12 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "react-refresh": {
       "version": "0.9.0",
@@ -4761,14 +5029,14 @@
       "dev": true
     },
     "terser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
+      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
       "dev": true,
       "requires": {
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
+        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
@@ -4779,10 +5047,13 @@
           "dev": true
         },
         "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
+          "version": "0.8.0-beta.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^7.0.0"
+          }
         }
       }
     },
@@ -4792,6 +5063,21 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -4799,9 +5085,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "utility-types": {
@@ -4821,6 +5107,23 @@
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "which": {
       "version": "2.0.2",


### PR DESCRIPTION
Over time we started to reuse a CljdocProject type beyond its initially
designed scope. TypeScript got to the "huh?" point. Here's the fix I
applied:

1. Create a new Library interface (which only describes maven coordinate)
2. Replace general CljdocProject with specific but equivalent VisitedLibrary
which extends Library
3. Have SearchResult extend Library (otherwise unchanged)
4. Have ResultView use generics so that it is no longer tied to a specific
type/interface (it was tied to CljdocProject)

Switched from using TypeScript type to TypeScript interface to allow me to
express what I wanted to express.
I think this is ok: https://stackoverflow.com/a/65948871

Close https://github.com/cljdoc/cljdoc/issues/619

Also (because I was there):
- Moved redudant code to docsUri and project functions alongside Library.
- Turfed a # character prefixing the project name presented to the user in
the project switcher
- Now presenting the full project name instead of just the artifact-id for the
recently visited projects on home page. Presenting the group-id is helpful
because of recent-ish clojars changes that forced many projects to
change their group-id.