### PR TITLE
Try excluding var names from stop words for single docset search

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,4 @@
-{ "trailingComma": "none", "arrowParens": "avoid" }
+{
+  "trailingComma": "none",
+  "arrowParens": "avoid"
+}

--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -175,14 +175,14 @@ const fetchIndexItems = async (url: string, db: IDBPDatabase<SearchsetsDB>) => {
 };
 
 const buildSearchIndex = (indexItems: IndexItem[]): Index => {
-  const newStopWords = {...elasticlunr.defaultStopWords}
+  const newStopWords = { ...elasticlunr.defaultStopWords };
 
-  for (const indexItem of indexItems) {
-    delete newStopWords[indexItem.name]
-  }
+  indexItems
+    .flatMap(ii => elasticlunr.tokenizer(ii.name))
+    .forEach(word => delete newStopWords[word]);
 
   elasticlunr.clearStopWords();
-  elasticlunr.addStopWords(Object.keys(newStopWords))
+  elasticlunr.addStopWords(Object.keys(newStopWords));
 
   const searchIndex = elasticlunr<IndexItem>(index => {
     index.setRef("id");

--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -175,6 +175,15 @@ const fetchIndexItems = async (url: string, db: IDBPDatabase<SearchsetsDB>) => {
 };
 
 const buildSearchIndex = (indexItems: IndexItem[]): Index => {
+  const newStopWords = {...elasticlunr.defaultStopWords}
+
+  for (const indexItem of indexItems) {
+    delete newStopWords[indexItem.name]
+  }
+
+  elasticlunr.clearStopWords();
+  elasticlunr.addStopWords(Object.keys(newStopWords))
+
   const searchIndex = elasticlunr<IndexItem>(index => {
     index.setRef("id");
     index.addField("name");


### PR DESCRIPTION
## Problem

When a project has a var that is a stop word, that var is unfindable in single docset search.

Ex: Go to https://cljdoc.org/d/babashka/fs/0.1.5/api/babashka.fs and type "with" to find "with-temp-dir". What's missing here? Oh darn, "with" is a stop-word.

## Proposed Solution

Remove var names from stop-words for that individual index. Be sure to split on non-word characters so that we still match. Look and see if we can also match non-word characters since those are valid clojure var names (e.g. `<<`).

