### PR TITLE
maint: update clj-kondo and lint script

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -3,9 +3,7 @@
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "35ed39645038e81b42cb15ed6753b8462e60a06d"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}}
- :tasks {lint {:task lint/-main :doc "[--rebuild-cache] lint source code using clj-kondo"}
+ :tasks {lint {:task lint/-main :doc "[--rebuild] lint source code using clj-kondo"}
          code-format {:task code-format/-main :doc "(check|fix) check whitespace formatting"}
          outdated {:task outdated/-main :doc "report on outdated Clojure and JavaScript dependencies"}
-         doc-update-readme {:task doc-update-readme/-main :doc "honour our contributors in README"}
-
- }}
+         doc-update-readme {:task doc-update-readme/-main :doc "honour our contributors in README"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -102,7 +102,7 @@
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.04.25"}}
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.05.27"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :cli

--- a/deps.edn
+++ b/deps.edn
@@ -102,7 +102,7 @@
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.05.27"}}
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.05.28"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :cli

--- a/script/helper/shell.clj
+++ b/script/helper/shell.clj
@@ -19,3 +19,12 @@
                           [nil cmd args])
         opts (merge opts default-opts)]
     (apply tasks/shell opts cmd args)))
+
+(defn clojure
+  "Wrap tasks/clojure for my loud error reporting treatment"
+  [& args]
+  (let [[opts args] (if (map? (first args))
+                      [(first args) (rest args)]
+                      [nil args])
+        opts (merge opts default-opts)]
+    (apply tasks/clojure opts args)))

--- a/script/lint.clj
+++ b/script/lint.clj
@@ -18,14 +18,18 @@
     (fs/delete-tree clj-kondo-cache)))
 
 (defn- build-cache []
-  (status/line :detail "Building cache")
   (when (cache-exists?)
     (delete-cache))
-  (let [clj-cp (-> (shell/command {:out :string}
-                                  "clojure -Spath -A:test")
-                   :out string/trim)
+  (let [clj-cp (-> (shell/clojure {:out :string}
+                                  "-Spath -M:test")
+                   with-out-str
+                   string/trim)
         bb-cp (bbcp/get-classpath)]
-    (shell/command "clojure -M:clj-kondo --dependencies --copy-configs --lint" clj-cp bb-cp)))
+
+    (status/line :detail "- copying configs")
+    (shell/command "clojure -M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
+    (status/line :detail "- creating cache")
+    (shell/command "clojure -M:clj-kondo --dependencies --parallel --lint" clj-cp bb-cp)))
 
 (defn- check-cache [{:keys [rebuild-cache]}]
   (status/line :head "clj-kondo: cache check")
@@ -58,12 +62,12 @@
 (def args-usage "Valid args: [options]
 
 Options:
-  --rebuild-cache  Force rebuild of clj-kondo lint cache.
-  --help           Show this help.")
+  --rebuild   Force rebuild of clj-kondo lint cache.
+  --help      Show this help.")
 
 (defn -main [& args]
   (when-let [opts (main/doc-arg-opt args-usage args)]
-    (lint {:rebuild-cache (get opts "--rebuild-cache")})))
+    (lint {:rebuild-cache (get opts "--rebuild")})))
 
 (main/when-invoked-as-script
  (apply -main *command-line-args*))


### PR DESCRIPTION
Bump our beloved clj-kondo.
Update lint script to follow clj-kondo docs re bringing in import configs.