### PR TITLE
maint: bump npm deps

### DIFF
--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -131,7 +131,6 @@ class Switcher extends Component<SwitcherProps, SwitcherState> {
       this.initializeState();
     } else {
       let fuzzysortOptions = {
-        allowTypo: false,
         key: "project_id"
       };
       let results = fuzzysort.go(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,52 +9,52 @@
         "classnames": "^2.3.1",
         "date-fns": "^2.28.0",
         "elasticlunr": "^0.9.5",
-        "fuzzysort": "^1.2.1",
-        "idb": "^7.0.1",
-        "preact": "^10.6.6"
+        "fuzzysort": "^2.0.1",
+        "idb": "^7.0.2",
+        "preact": "^10.10.0"
       },
       "devDependencies": {
-        "@parcel/packager-xml": "^2.4.0",
-        "@parcel/transformer-image": "^2.4.0",
-        "@parcel/transformer-xml": "^2.4.0",
+        "@parcel/packager-xml": "^2.6.2",
+        "@parcel/transformer-image": "^2.6.2",
+        "@parcel/transformer-xml": "^2.6.2",
         "@types/elasticlunr": "^0.9.4",
         "@types/lunr": "^2.3.4",
-        "parcel": "^2.4.0",
+        "parcel": "^2.6.2",
         "parcel-reporter-static-files-copy": "^1.3.4",
-        "parcel-resolver-ignore": "^2.0.0",
-        "prettier": "^2.6.0",
+        "parcel-resolver-ignore": "^2.1.3",
+        "prettier": "^2.7.1",
         "pretty-quick": "^3.1.3",
-        "typescript": "^4.6.2"
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -100,13 +100,13 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -124,6 +124,64 @@
         "node": ">=4"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@lezer/common": {
       "version": "0.15.12",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
@@ -139,6 +197,84 @@
         "@lezer/common": "^0.15.0"
       }
     },
+    "node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@mischnic/json-sourcemap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
@@ -153,21 +289,99 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.0.2.tgz",
+      "integrity": "sha512-FMX5i7a+ojIguHpWbzh5MCsCouJkwf4z4ejdUY/fsgB9Vkdak4ZnoIEskOyOUMMB4lctiZFGszFQJXUeFL8tRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.0.2.tgz",
+      "integrity": "sha512-DznYtF3lHuZDSRaIOYeif4JgO0NtO2Xf8DsngAugMx/bUdTFbg86jDTmkVJBNmV+cxszz6OjGvinnS8AbJ342g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.0.2.tgz",
+      "integrity": "sha512-Gy9+c3Wj+rUlD3YvCZTi92gs+cRX7ZQogtwq0IhRenloTTlsbpezNgk6OCkt59V4ATEWSic9rbU92H/l7XsRvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.0.2.tgz",
+      "integrity": "sha512-b0jMEo566YdM2K+BurSed7bswjo3a6bcdw5ETqoIfSuxKuRLPfAiOjVbZyZBgx3J/TAM/QrvEQ/VN89A0ZAxSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.0.2.tgz",
+      "integrity": "sha512-zrBHaePwcv4cQXxzYgNj0+A8I1uVN97E7/3LmkRocYZ+rMwUsnPpp4RuTAHSRoKlTQV3nSdCQW4Qdt4MXw/iHw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.0.2.tgz",
+      "integrity": "sha512-fpnI00dt+yO1cKx9qBXelKhPBdEgvc8ZPav1+0r09j0woYQU2N79w/jcGawSY5UGlgQ3vjaJsFHnGbGvvqdLzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.5.0.tgz",
-      "integrity": "sha512-7CJzE17SirCXjcRgBcnqWO/5EOA1raq/3OIKtT4cxbjpDQGHZpjpEEZiMNRpEpdNMxDSlsG8mAkXTYGL2VVWRw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.6.2.tgz",
+      "integrity": "sha512-XIa3had/MIaTGgRFkHApXwytYs77k4geaNcmlb6nzmAABcYjW1CLYh83Zt0AbzLFsDT9ZcRY3u2UjhNf6efSaw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -175,15 +389,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.2.tgz",
+      "integrity": "sha512-hhJ6AsEGybeQZd9c/GYqfcKTgZKQXu3Xih6TlnP3gdR3KZoJOnb40ovHD1yYg4COvfcXThKP1cVJ18J6rcv3IA==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "lmdb": "2.2.4"
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "lmdb": "2.5.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -193,13 +407,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.2"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
-      "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.2.tgz",
+      "integrity": "sha512-oFlHr6HCaYYsB4SHkU+gn9DKtbzvv3/4NdwMX0/6NAKyYVI7inEsXyPGw2Bbd2ZCFatW9QJZUETF0etvh5AEfQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -213,16 +427,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.5.0.tgz",
-      "integrity": "sha512-I5Zs+2f1ue4sTPdfT8BNsLfTZl48sMWLk2Io3elUJjH/SS9kO7ut5ChkuJtt77ZS35m0OF+ZCt3ICTJdnDG8eA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.6.2.tgz",
+      "integrity": "sha512-P3c8jjV5HVs+fNDjhvq7PtHXNm687nit1iwTS5VAt+ScXKhKBhoIJ56q+9opcw0jnXVjAAgZqcRZ50oAJBGdKw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -230,70 +444,70 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.5.0.tgz",
-      "integrity": "sha512-r30V61958SONvP9I8KV8s44ZOFq0H219VyFjPysraSabHjZ+KMaCTQOuqaDtUMa272sHUQkBcZxKYj5jYPJlZg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.6.2.tgz",
+      "integrity": "sha512-kuZFY0rhaioCRX2LqxaMM2ylui6ms/nmdVxuceP4/SAWi/9duc+y1lG2a1zGNShbc6OEgpdQr/W/jxdYM7NJDw==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.5.0",
-        "@parcel/compressor-raw": "2.5.0",
-        "@parcel/namer-default": "2.5.0",
-        "@parcel/optimizer-css": "2.5.0",
-        "@parcel/optimizer-htmlnano": "2.5.0",
-        "@parcel/optimizer-image": "2.5.0",
-        "@parcel/optimizer-svgo": "2.5.0",
-        "@parcel/optimizer-terser": "2.5.0",
-        "@parcel/packager-css": "2.5.0",
-        "@parcel/packager-html": "2.5.0",
-        "@parcel/packager-js": "2.5.0",
-        "@parcel/packager-raw": "2.5.0",
-        "@parcel/packager-svg": "2.5.0",
-        "@parcel/reporter-dev-server": "2.5.0",
-        "@parcel/resolver-default": "2.5.0",
-        "@parcel/runtime-browser-hmr": "2.5.0",
-        "@parcel/runtime-js": "2.5.0",
-        "@parcel/runtime-react-refresh": "2.5.0",
-        "@parcel/runtime-service-worker": "2.5.0",
-        "@parcel/transformer-babel": "2.5.0",
-        "@parcel/transformer-css": "2.5.0",
-        "@parcel/transformer-html": "2.5.0",
-        "@parcel/transformer-image": "2.5.0",
-        "@parcel/transformer-js": "2.5.0",
-        "@parcel/transformer-json": "2.5.0",
-        "@parcel/transformer-postcss": "2.5.0",
-        "@parcel/transformer-posthtml": "2.5.0",
-        "@parcel/transformer-raw": "2.5.0",
-        "@parcel/transformer-react-refresh-wrap": "2.5.0",
-        "@parcel/transformer-svg": "2.5.0"
+        "@parcel/bundler-default": "2.6.2",
+        "@parcel/compressor-raw": "2.6.2",
+        "@parcel/namer-default": "2.6.2",
+        "@parcel/optimizer-css": "2.6.2",
+        "@parcel/optimizer-htmlnano": "2.6.2",
+        "@parcel/optimizer-image": "2.6.2",
+        "@parcel/optimizer-svgo": "2.6.2",
+        "@parcel/optimizer-terser": "2.6.2",
+        "@parcel/packager-css": "2.6.2",
+        "@parcel/packager-html": "2.6.2",
+        "@parcel/packager-js": "2.6.2",
+        "@parcel/packager-raw": "2.6.2",
+        "@parcel/packager-svg": "2.6.2",
+        "@parcel/reporter-dev-server": "2.6.2",
+        "@parcel/resolver-default": "2.6.2",
+        "@parcel/runtime-browser-hmr": "2.6.2",
+        "@parcel/runtime-js": "2.6.2",
+        "@parcel/runtime-react-refresh": "2.6.2",
+        "@parcel/runtime-service-worker": "2.6.2",
+        "@parcel/transformer-babel": "2.6.2",
+        "@parcel/transformer-css": "2.6.2",
+        "@parcel/transformer-html": "2.6.2",
+        "@parcel/transformer-image": "2.6.2",
+        "@parcel/transformer-js": "2.6.2",
+        "@parcel/transformer-json": "2.6.2",
+        "@parcel/transformer-postcss": "2.6.2",
+        "@parcel/transformer-posthtml": "2.6.2",
+        "@parcel/transformer-raw": "2.6.2",
+        "@parcel/transformer-react-refresh-wrap": "2.6.2",
+        "@parcel/transformer-svg": "2.6.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.2"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-dygDmPsfAYJKTnUftcbEzjCik7AAaPbFvJW8ETYz8diyjkAG9y6hvCAZIrJE5pNOjFzg32en4v4UWv8Sqlzl9g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.2.tgz",
+      "integrity": "sha512-JlKS3Ux0ngmdooSBbzQLShHJdsapF9E7TGMo1hFaHRquZip/DaqzvysYrgMJlDuCoLArciq5ei7ZKzGeK9zexA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/graph": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/cache": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/graph": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -314,9 +528,9 @@
       }
     },
     "node_modules/@parcel/css": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.8.2.tgz",
-      "integrity": "sha512-3vTyKHy2LnZ3YJEut+UQPVIxsaY/mdGk7cDXtmvH4xR48Pd6rYzChHCMl4Ru2DUkCBpr0KCQRPZTdYcsJhUmIA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.12.0.tgz",
+      "integrity": "sha512-iDpbNOp5l6L7ZIX+rqutkdqvI01BBhUSJGXfDJFD5UfnG8VmDyQ2PYtVB+5+kJH4CICOI6oiO4JCi1O/fNpkJA==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -329,20 +543,20 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/css-darwin-arm64": "1.8.2",
-        "@parcel/css-darwin-x64": "1.8.2",
-        "@parcel/css-linux-arm-gnueabihf": "1.8.2",
-        "@parcel/css-linux-arm64-gnu": "1.8.2",
-        "@parcel/css-linux-arm64-musl": "1.8.2",
-        "@parcel/css-linux-x64-gnu": "1.8.2",
-        "@parcel/css-linux-x64-musl": "1.8.2",
-        "@parcel/css-win32-x64-msvc": "1.8.2"
+        "@parcel/css-darwin-arm64": "1.12.0",
+        "@parcel/css-darwin-x64": "1.12.0",
+        "@parcel/css-linux-arm-gnueabihf": "1.12.0",
+        "@parcel/css-linux-arm64-gnu": "1.12.0",
+        "@parcel/css-linux-arm64-musl": "1.12.0",
+        "@parcel/css-linux-x64-gnu": "1.12.0",
+        "@parcel/css-linux-x64-musl": "1.12.0",
+        "@parcel/css-win32-x64-msvc": "1.12.0"
       }
     },
     "node_modules/@parcel/css-darwin-arm64": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.8.2.tgz",
-      "integrity": "sha512-p5etxX3kPCuEQcipjqH9yc5j0x5/Yc++uB4MvG/sFbRgL2gI2zUuRo9sIgqA21boOP8lE4bQgz1ovPD/W1hj+Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.12.0.tgz",
+      "integrity": "sha512-zq2vdvIJNFetPFima2D/oytAlxlWP9Qy6WSri+l3TOMnxrvObqfMv71kmbwOFUApnaxmTMqdd/GQN6DvIL+gOQ==",
       "cpu": [
         "arm64"
       ],
@@ -360,9 +574,9 @@
       }
     },
     "node_modules/@parcel/css-darwin-x64": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.8.2.tgz",
-      "integrity": "sha512-c3xi5DXRZYec5db4KPTxp69eHbomOuasgZNiuPPOi80k7jlOwfzCFQs0h6/KwWvTcJrKEFsLl8BKJU/aX7mETw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.12.0.tgz",
+      "integrity": "sha512-N3bvj68peUquzh/6mA50+EgnddjxFjil5sfDSfvvOEQoTQB0e0T/Q2J7O9RqRLcK5mKHJ/27ByQAhoEZZ8AT6g==",
       "cpu": [
         "x64"
       ],
@@ -380,9 +594,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm-gnueabihf": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.8.2.tgz",
-      "integrity": "sha512-+ih3+mMpwbwtOjr/XW5pP0frsV1PMN+Qz7jCAM84h8xX+8UE/1IR0UVi3EPa8wQiIlcVcEwszQ1MV2UHacvo/A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.12.0.tgz",
+      "integrity": "sha512-Y2SQmYhUZllHFvv5BYRiZSFGoMOyLqhRcvRNrR6cgzIPBBUTLYgCTP1EKAXXaGqLZCjwPig/d1ZBvKI+cA75IA==",
       "cpu": [
         "arm"
       ],
@@ -400,9 +614,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm64-gnu": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.8.2.tgz",
-      "integrity": "sha512-jIoyXbjJ1trUHXtyJhi3hlF1ck6xM4CDyaY5N6eN+3+ovkdw6wxog9IiheYJ1jf9ellYevLvTF5kiYE9MiP04A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.12.0.tgz",
+      "integrity": "sha512-FDaqmvB6Iuv64oen3XzKfimnlXARUZ+rkxu9ivgv69Iwp1OQKLUxwCRxMrhotg8sryONhyg/tHWft7G0t4S14w==",
       "cpu": [
         "arm64"
       ],
@@ -420,9 +634,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm64-musl": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.8.2.tgz",
-      "integrity": "sha512-QVTc5a+HatoywIei3djKYmp3s5dbI2Q3QaYZf3gqhyjOkeC7bm6j5eeNzFO+wa5xtga5jdHkIuTRrJ/wCojKKw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.12.0.tgz",
+      "integrity": "sha512-PxkjtWk5B5DA8dkBJqd59NSr55RnDkVwVRqH5nCXux7gWPdp9v+LRrRJBpSQgLJaiatFiY+CXZNlFRnBqrqFTQ==",
       "cpu": [
         "arm64"
       ],
@@ -440,9 +654,9 @@
       }
     },
     "node_modules/@parcel/css-linux-x64-gnu": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.8.2.tgz",
-      "integrity": "sha512-9r2tSfa6i3ZQ3a6C9XufJWuTv3LB7JYzxzEqsI35SSA8D/DrfAHMaIhqog5wSxKZRWmQxckh2wdT96eIIGHSGA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.12.0.tgz",
+      "integrity": "sha512-zxD1bS4BF79F+4DV7+kccAs6gNrcilzTOCJ3GvxrNjh1OJtXUVi7Ls0r+pVwuhF7kzOi0AUYvnwHBeybxoIhuA==",
       "cpu": [
         "x64"
       ],
@@ -460,9 +674,9 @@
       }
     },
     "node_modules/@parcel/css-linux-x64-musl": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.8.2.tgz",
-      "integrity": "sha512-5SetLWkxXRQ3NU6QwwbGf9tOmGW2m1cGt07Moybbe4RCXOY6R5wAYUtauZUp7pD/fJlE9mHge4jnNHKpVO9pvw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.12.0.tgz",
+      "integrity": "sha512-oTHzmpTEkew/aoW4jyQ/sR+XJh+3Xl7J9dnJo4/FVvRjRSHdr/V8LEPx61Iv2Edx123WzrpNqpvUC1X6Q3M4fw==",
       "cpu": [
         "x64"
       ],
@@ -480,9 +694,9 @@
       }
     },
     "node_modules/@parcel/css-win32-x64-msvc": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.8.2.tgz",
-      "integrity": "sha512-/EdW5Ejlnkvc/AYrAi/FmLNvM6a6eAx+A4Y7oW+8JSMvk6bYa2zmXi7XLU/QOQuH2VQa/3gIIMA+sYjPndvDpw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.12.0.tgz",
+      "integrity": "sha512-FWlyrTezxfSvYdf9qX8XSbDimeF0+N8xyP2fIEMf1YFejxH6NJ5N4LSPfysBf4qqOVR0DYYTa+UHtZxN/g2B6A==",
       "cpu": [
         "x64"
       ],
@@ -500,9 +714,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
-      "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.2.tgz",
+      "integrity": "sha512-3ODSBkKVihENU763z1/1DhGAWFhYWRxOCOShC72KXp+GFnSgGiBsxclu8NBa/N948Rzp8lqQI8U1nLcKkh0O/w==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -517,9 +731,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
-      "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.2.tgz",
+      "integrity": "sha512-IaCjOeA5ercdFVi1EZOmUHhGfIysmCUgc2Th9hMugSFO0I3GzRsBcAdP6XPfWm+TV6sQ/qZRfdk/drUxoAupnw==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -530,16 +744,16 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
-      "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.2.tgz",
+      "integrity": "sha512-mIhqdF3tjgeoIGqW7Nc/xfM2ClID7o8livwUe5lpQEP+ZaIBiMigXs6ckv3WToCACK+3uylrSD2A/HmlhrxMqQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs-search": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/fs-search": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.5.0"
+        "@parcel/workers": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -549,13 +763,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.2"
       }
     },
     "node_modules/@parcel/fs-search": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
-      "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.2.tgz",
+      "integrity": "sha512-4STid1zqtGnmGjHD/2TG2g/zPDiCTtE3IAS24QYH3eiUAz2uoKGgEqd2tZbZ2yI96jtCuIhC1bzVu8Hbykls7w==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -569,12 +783,12 @@
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.5.0.tgz",
-      "integrity": "sha512-qa2VtG08dJyTaWrxYAkMIlkoDRSPoiqLDNxxHKplkcxAjXBUw0/AkWaz82VO5r1G6jfOj+nM30ajH9uygZYwbw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.2.tgz",
+      "integrity": "sha512-DPH4G/RBFJWayIN2fnhDXqhUw75n7k15YsGzdDKiXuwwz4wMOjoL4cyrI6zOf1SIyh3guRmeTYJ4jjPzwrLYww==",
       "dev": true,
       "dependencies": {
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -586,9 +800,9 @@
       }
     },
     "node_modules/@parcel/hash": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
-      "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.2.tgz",
+      "integrity": "sha512-tFB+cJU1Wqag6WyJgsmx3nx+xhmjcNZqtWh/MtK1lHNnZdDRk6bjr7SapnygBwruz+SmSt5bbdVThcpk2dRCcA==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -603,13 +817,13 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
-      "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.2.tgz",
+      "integrity": "sha512-Sz5YGCj1DbEiX0/G8Uw97LLZ0uEK+qtWcRAkHNpJpeMiSqDiRNevxXltz42EcLo+oCh4d4wyiVzwi9mNwzhS/Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0"
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -620,9 +834,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
-      "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.2.tgz",
+      "integrity": "sha512-N/h9J4eibhc+B+krzvPMzFUWL37GudBIZBa7XSLkcuH6MnYYfh6rrMvhIyyESwk6VkcZNVzAeZrGQqxEs0dHDQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -636,18 +850,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
-      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.2.tgz",
+      "integrity": "sha512-mp7bx/BQaIuohmZP0uE+gAmDBzzH0Yu8F4yCtE611lc6i0mou+nWRhzyKLNC/ieuI8DB3BFh2QQKeTxJn4W0qg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -655,14 +869,15 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.5.0.tgz",
-      "integrity": "sha512-XQvpguiIwQcu75cscLDFOVhjsjuPzXbuMaaZ7XxxUEl0PscIgu/GfKYxTfTruN3cRl+CaQH6qBAMfjLaFng6lQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.6.2.tgz",
+      "integrity": "sha512-4b2L5QRYlTybvv3+TIRtwg4PPJXy+cRShCBa8eu1K0Fj297Afe8MOZrcVV+RIr2KPMIRXcIJoqDmOhyci/DynA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "nullthrows": "^1.1.1"
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -673,22 +888,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.5.0.tgz",
-      "integrity": "sha512-J00bLF+4SsnKc+YbYrNuBr44/zz3cg++CoXteXhH27PxP1rScGQx36Rui8WORgil5mlX2VYN79DuqJC7V3Ynbg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.6.2.tgz",
+      "integrity": "sha512-rjTQ9bOokUzzKDYpwMQxDtPqRcMljcTVvod5GT5azGnw1EbwNv30vqnTu81+sEMyttHydzYrKAM15UGV/JYu1Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.8.1",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/css": "^1.10.1",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -696,12 +911,12 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.5.0.tgz",
-      "integrity": "sha512-Fr0zPqgxoNaOVdROAjNGDWCts3+wByNQ82Mxhu8Tzc25A2cPjcr1H2sa/TE3hf79c92DxdKf2FaC1ZOgR5YPdg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.6.2.tgz",
+      "integrity": "sha512-Doi2hDmsQHLwuBo6w5gvw5u6GBDz8FhkzAlitfG3C96lZxEw2eu0vquY4Li8lbZT9MBNs8zuYiD1QW8sdlv9hA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.2",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -709,7 +924,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -717,20 +932,20 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.5.0.tgz",
-      "integrity": "sha512-nbo2pdnAt21WLGjzTpsE8ZEL0xNoP7c3wBj9y70Pysmasg1SrRVCbfE8jTy+lHBQwq2yjC6lV/Usv+9lfA7S/w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.6.2.tgz",
+      "integrity": "sha512-XwFk43s8Dar4N+wXOkpKkeXf1vtu3PSu4ic+M9J0EwNKElrktQ0+paLYmwwp7Xv0tZbRedLAROomUxdXqEMupg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
         "detect-libc": "^1.0.3"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -738,19 +953,19 @@
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.5.0.tgz",
-      "integrity": "sha512-pgZqwU0RLc/wr4WcQY/W1GJmddnEANDEpz1mdppUOqBz1EfTQ7zh5NgUA3hV1i05Hbecp3mHSvXJPV0mhNOl5Q==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.6.2.tgz",
+      "integrity": "sha512-X2wPy1VeT2d9oUCue/vAXX907kmLf0o+w0LHghhbApuXjkvJNS2Vz182HIo1rtcS0RH5k3lXxUV0OPQjOC7BOw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "svgo": "^2.4.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -758,21 +973,21 @@
       }
     },
     "node_modules/@parcel/optimizer-terser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.5.0.tgz",
-      "integrity": "sha512-PZ3UHBGfjE49/Jloopsd38Hxg4qzsrdepWP53mCuVP7Aw605Y4QtYuB1ho3VV0oXfKQVq+uI7lVIBsuW4K6vqA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.2.tgz",
+      "integrity": "sha512-ZSEVQ3G3zOiVPeHvH+BrHegZybrQj9kWQAaAA92leSqbvf6UaX4xqXbGRg2OttNFtbGYBzIl28Zm4t2SLeUIuA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -780,17 +995,17 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
-      "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.2.tgz",
+      "integrity": "sha512-xGMqTgnwTE3rgzYwUZMKxR8fzmP5iSYz/gj2H8FR3pEmwh/8xCMtNjTSth+hPVGuqgRZ6JxwpfdY/fXdZ61ViQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
         "semver": "^5.7.1"
       },
       "engines": {
@@ -801,23 +1016,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.2"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.5.0.tgz",
-      "integrity": "sha512-c0mGBFdVSPhAxaX3+zN8KEIqOOUhkIPKbZex1pnGYfy03Qe2/Mb4nyt5DAGlw9gjka1UCHIN/wszLmKC8YyUeg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.6.2.tgz",
+      "integrity": "sha512-zifJqgNUtLZoJ2oeFeLz6OFOBy8FNlVGtGtOqTJZN1SeYd94xNYyeUTwnSsOh2OEDs6HJhggL3o4uEmpM1s9GA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -825,20 +1040,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.5.0.tgz",
-      "integrity": "sha512-ZFGUPRMWKrm8kQHdkEJ5S22C05qpSymx+o+57EfuNjCrGyj3M59WyGYYXYJ175bFYZ/jp5yy+VxMh6fZefe+Pw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.6.2.tgz",
+      "integrity": "sha512-NTJoKcqApMgFOpulok4Ru9QW3BD7d5931ymoow9/bmgDwvJNh2SOMHVx6lqzKRU5x+wlShpYfDur4zOipRev8g==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -846,22 +1061,22 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.5.0.tgz",
-      "integrity": "sha512-aJAKOTgXdxO3V9O7+2DCVOtne128WwXmUAOVThnMRo7f3zMVSAR7Mxc9pEsuTzPfj8UBXgFBRfdJUSCgsMxiSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.6.2.tgz",
+      "integrity": "sha512-fm5rKWtaExR0W+UEKWivXNPysRFxuBCdskdxDByb1J1JeGMvp7dJElbi8oXDAQM4MnM5EyG7cg47SlMZNTLm4A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -869,16 +1084,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.5.0.tgz",
-      "integrity": "sha512-aHV0oogeiqxhxS1lsttw15EvG3DDWK3FV7+F+7hoaAy+xg89K56NTp6j43Jtw9iyU1/HnZRGBE2hF3C7N73oKw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.6.2.tgz",
+      "integrity": "sha512-Rl3ZkMtMjb+LEvRowijDD8fibUAS6rWK0/vZQMk9cDNYCP2gCpZayLk0HZIGxneeTbosf/0sbngHq4VeRQOnQA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -886,19 +1101,19 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.5.0.tgz",
-      "integrity": "sha512-XSMFn30K/kpjcPpQqt88GmPJsNUSVL3RNeigXkIAcLpfO6Tb2eV4iOt4yVCagaDrRJ19alXut0TxjMm5bm41/g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.6.2.tgz",
+      "integrity": "sha512-FrGlwtiMs7YBWoVA3vCNHlBcghVYueKzimvufl4r287g1iEmq59pchCqpi6rW83O/mnpUQg9mpP+BmXxuvjLNg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -906,19 +1121,19 @@
       }
     },
     "node_modules/@parcel/packager-xml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-xml/-/packager-xml-2.5.0.tgz",
-      "integrity": "sha512-KFu3I7b2LAlnJxcJD0bufMCOmFEwZlvsNKrtOVooXUIbhe6Oe9yhQ4iw+FcosCdT0dI1U8jb808bkB6o+mhuAA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-xml/-/packager-xml-2.6.2.tgz",
+      "integrity": "sha512-p0pC5VHzW6WOeQHSSzmT0hvGqf78xlf/4BNDt6AlzanOJx9bgQQ0UuHWW5nN+Oma2AePdU4vs6tREydVFS3wwA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "@xmldom/xmldom": "^0.7.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -926,12 +1141,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
-      "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.2.tgz",
+      "integrity": "sha512-wbbWsM23Pr+8xtLSvf+UopXdVYlpKCCx6PuuZaZcKo+9IcDCWoGXD4M8Kkz14qBmkFn5uM00mULUqmVdSibB2w==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.5.0"
+        "@parcel/types": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -942,20 +1157,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.5.0.tgz",
-      "integrity": "sha512-miJt2YbRJBmYSVeoUWUj8YL85Pwj1CmGQB0/btqhulGLH/Fvkbv6T4sJ4gl4l5xIt9mJQsZ70pOWwa8BId3rWw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.6.2.tgz",
+      "integrity": "sha512-5BWMtQRSXVXMlB/BOkCf8NVLh3qcQVMrj6owuekmqLi/GGC+kGZovzA6YrofVIdNHcoxOZwTIYwjoU3ibJ6yAA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -963,17 +1178,17 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.5.0.tgz",
-      "integrity": "sha512-wvxAiW42AxJ3B8jtvowJcP4/cTV8zY48SfKg61YKYu1yUO+TtyJIjHQzDW2XuT34cIGFY97Gr0i+AVu44RyUuQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.6.2.tgz",
+      "integrity": "sha512-5QtL3ETMFL161jehlIK6rjBM+Pqk5cMhr60s9yLYqE1GY4M4gMj+Act+FXViyM6gmMA38cPxDvUsxTKBYXpFCw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0"
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -981,17 +1196,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.5.0.tgz",
-      "integrity": "sha512-39PkZpVr/+iYS11u+lA84vIsKm/yisltTVmUjlYsDnExiuV1c8OSbSdYZ3JMx+7CYPE0bWbosX2AGilIwIMWpQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.6.2.tgz",
+      "integrity": "sha512-Lo5sWb5QkjWvdBr+TdmAF6Mszb/sMldBBatc1osQTkHXCy679VMH+lfyiWxHbwK+F1pmdMeBJpYcMxvrgT8EsA==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "2.5.0",
-        "@parcel/plugin": "2.5.0"
+        "@parcel/node-resolver-core": "2.6.2",
+        "@parcel/plugin": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -999,17 +1214,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.5.0.tgz",
-      "integrity": "sha512-oPAo8Zf06gXCpt41nyvK7kv2HH1RrHAGgOqttyjStwAFlm5MZKs7BgtJzO58LfJN8g3sMY0cNdG17fB/4f8q6Q==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.6.2.tgz",
+      "integrity": "sha512-M4X0+7dyfdI6smwGUGjGXb8Ns3HX7ZrTemyq4Gc7zp7P/5gWjR8i9eISz46sXmF9bf01a/4dKZpoCC9un1pH1g==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0"
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1017,18 +1232,18 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.5.0.tgz",
-      "integrity": "sha512-gPC2PbNAiooULP71wF5twe4raekuXsR1Hw/ahITDoqsZdXHzG3CkoCjYL3CkmBGiKQgMMocCyN1E2oBzAH8Kyw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.6.2.tgz",
+      "integrity": "sha512-0S3JFwgvs6FmEx2dHta9R0Sfu8vCnFAm4i7Y4efGHtAcTrF2CHjyiz4/hG+RQGJ70eoWW463Q+8qt6EKbkaOBQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1036,18 +1251,19 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.5.0.tgz",
-      "integrity": "sha512-+8RuDKFdFYIQTrXG4MRhG9XqkkYEHn0zxKyOJ/IkDDfSEhY0na+EyhrneFUwIvDX63gLPkxceXAg0gwBqXPK/Q==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.6.2.tgz",
+      "integrity": "sha512-DJTm5D/tUAGZm0o3ndDOPbKwdYrobuvm4jvkPq31LdEUqVvyuzBAMlqQFHc1yJEJDRRWOIQwQP9Y0NQbJmXFfg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1055,18 +1271,18 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.5.0.tgz",
-      "integrity": "sha512-STuDlU0fPXeWpAmbayY7o04F0eHy6FTOFeT5KQ0PTxtdEa3Ey8QInP/NVE52Yv0aVQtesWukGrNEFCERlkbFRw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.6.2.tgz",
+      "integrity": "sha512-9jV+RwVEeDUI5+eLy8j1tapTNoHHGOY2+JUprcObQkQ8fux7KltQBJWFhpkUdGtz5LTCNXtj9tdycFtS5lmSzg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1074,9 +1290,9 @@
       }
     },
     "node_modules/@parcel/source-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.2.tgz",
-      "integrity": "sha512-NnUrPYLpYB6qyx2v6bcRPn/gVigmGG6M6xL8wIg/i0dP1GLkuY1nf+Hqdf63FzPTqqT7K3k6eE5yHPQVMO5jcA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.0.tgz",
+      "integrity": "sha512-E7UOEIof2o89LrKk1agSLmwakjigmEdDp1ZaEdsLVEvq63R/bul4Ij5CT+0ZDcijGpl5tnTbQADY9EyYGtjYgQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -1086,15 +1302,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.5.0.tgz",
-      "integrity": "sha512-EFb866C9jCoBHIcebWF7goAcYj1wkObx0GDxshlazFtvym1RM27xSWWjRYyqb5+HNOxB3voaNvQOVjcD+DXjCA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.6.2.tgz",
+      "integrity": "sha512-R3qdfhnZhVhsDB8+0wC3CU86dmqx5DwxcTo10Wd1VbA6fiLRSGd4+ZrxJRg491mFTedgtTrUeO6LNYAmMFpCbQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -1102,7 +1318,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1110,22 +1326,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.5.0.tgz",
-      "integrity": "sha512-p8FOvKWWSbS6H8PbD9a0KZqyaKNpSD2BUTzSRYnNj3TBUv7/ZXaP6Om295XTQ/MPht1o7XTQzvfpF/7yEhr02Q==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.6.2.tgz",
+      "integrity": "sha512-6lsMdwBUgAyTcd7OIz2lG56jobptGkaRogDmbGFDhmuq/tQ/ZrNElUFmDVeh5cELQlByvj/Qh32cUMnsiMsk3g==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.8.1",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/css": "^1.10.1",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1133,14 +1349,14 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.5.0.tgz",
-      "integrity": "sha512-iEjNyAF0wQmY3DMw7FS+UzoOMng76UsSngh+WWA1E5lv5XyqrP8Mk2QLTJp1nWetUhSLhZr58LGmPYBTB4l9ZQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.6.2.tgz",
+      "integrity": "sha512-DEGv0Gd8BVAO/QZuXRg+A6YieVpIub7YT8xTNA/6vCIAl++y2hYyo9NF2j2xnooYbzW7zd7uDEFawOSd40lxig==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1149,7 +1365,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1157,35 +1373,35 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.5.0.tgz",
-      "integrity": "sha512-vVEXTHZl8m/9yopgK0dWHLOQX2zOnghq6pZnWdWVG6fsvXZln7kP1YN5iwWDoADQYkiKzP+Ymn6UwP9pZpHFzA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.6.2.tgz",
+      "integrity": "sha512-i2Ug6exFaX64M10Qsq4vza5NP0iRW+aIcao4uGvPHP6d36a0oUfT6tJsOLHh3sDj2ihT8RVJL2TRavSX17TjUA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/workers": "2.6.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.2"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.5.0.tgz",
-      "integrity": "sha512-Cp8Ic+Au3OcskCRZszmo47z3bqcZ7rfPv2xZYXpXY2TzEc3IV0bKje57bZektoY8LW9LkYM9iBO/WhkVoT6LIg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.6.2.tgz",
+      "integrity": "sha512-uhXAMTjE/Q61amflV8qVpb73mj+mIdXIMH0cSks1/gDIAxcgIvWvrE14P4TvY6zJ1q1iRJRIRUN6cFSXqjjLSA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
-        "@swc/helpers": "^0.3.6",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
+        "@swc/helpers": "^0.4.2",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
@@ -1194,28 +1410,28 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.2"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.5.0.tgz",
-      "integrity": "sha512-661sByA7TkR6Lmxt+hqV4h2SAt+7lgc58DzmUYArpEl1fQnMuQuaB0kQeHzi6fDD2+2G6o7EC+DuwBZKa479TA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.6.2.tgz",
+      "integrity": "sha512-QGcIIvbPF/u10ihYvQhxXqb2QMXWSzcBxJrOSIXIl74TUGrWX05D5LmjDA/rzm/n/kvRnBkFNP60R/smYb8x+Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.2",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1223,15 +1439,15 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.5.0.tgz",
-      "integrity": "sha512-IPNlWElekdQHMTBqhdwJNBCQomuYyo7xgNBdnTrt9VJ+R5ihy6n7ZJSWIAJXAH9VZxETTtunfrzRtgkmtjTeZQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.6.2.tgz",
+      "integrity": "sha512-yauLUofKnb09tzgg8FE33aDrbqgOgQtGyWfyiKWnoV1j8XTRu/t6R7e2qRysgNsm9Ghzxe1G83iJSli1MGTErA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -1239,7 +1455,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1247,13 +1463,13 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.5.0.tgz",
-      "integrity": "sha512-AZxg1XD8OXOS4bEGEmBBR+X9T9qoFdVsbVUg498zzejYSka1ZQHF7TgLI/+pUnE+ZVYNIp7/G0xXqsRVKMKmdQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.6.2.tgz",
+      "integrity": "sha512-Ly9znYdBnGLDmlyhKQJOekrs35w7fKTSxZ60B3nTtpwSFC/AMr3nv9kPTVi8KDRp2Kh1ahxQlfBIYHCa0RfkXA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1262,7 +1478,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1270,16 +1486,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.5.0.tgz",
-      "integrity": "sha512-I3zjE1u9+Wj90Qqs1V2FTm6iC6SAyOVUthwVZkZey+qbQG/ok682Ez2XjLu7MyQCo9BJNwF/nfOa1hHr3MaJEQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.6.2.tgz",
+      "integrity": "sha512-CsofYq5g9Zj/FNmhya2R7Xp3WHlzz34mEdN69bds3azRYHCrl/TS33xXcp/9J+74SEIY1Ufh552o1cM3fnSrDQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1287,18 +1503,18 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.5.0.tgz",
-      "integrity": "sha512-VPqVBxhTN4OQwcjsdyxrv+smjAm4s6dbSWAplgPwdOITMv+a0tjhhJU37WnRC+xxTrbEqRcOt96JvGOkPb8i7g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.6.2.tgz",
+      "integrity": "sha512-7EE68ebISz+oAHm64ZJbz6uJQT4aOoB8QiK3PvuY6+RsP7aK4/FEHGM1afW49KrZbP4lWjloEkcJm/88DfBiGw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1306,14 +1522,14 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.5.0.tgz",
-      "integrity": "sha512-zCGJcrCpICFe0Q/dgjQZfW7sYFkbJEC7NGT4zEJnMo8Cm/kq8Qh6+2ApX6c+vv5Q0WZn5Ic+N0OvxIMkvgdC/w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.6.2.tgz",
+      "integrity": "sha512-s7e/DVte2OT+jUL10+g2+l/y/MqxAb8Avw1asRH0683iEVj6GGS/K4KnHN8WagLwnS6Fb3/InVrzxtb0YKUt2w==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1322,7 +1538,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1330,17 +1546,17 @@
       }
     },
     "node_modules/@parcel/transformer-xml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-xml/-/transformer-xml-2.5.0.tgz",
-      "integrity": "sha512-ndkAcE1ESFOIYtTx5BacDH45AfkHWyjolVh/JlIq3WxKTMxi1cN3gv0Hd3lL2oSgJGv9YmHnpsLIhVk2QlGFrA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-xml/-/transformer-xml-2.6.2.tgz",
+      "integrity": "sha512-07mpNqjGGT8RzXPly99ClFhuKJWY/fqJsNsZ0EpLSqIdKX6YcAHQucTRpuwHQRFmXJyHewDIk7P3zAF9BVvqKQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.2",
         "@xmldom/xmldom": "^0.7.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1348,31 +1564,31 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
-      "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.2.tgz",
+      "integrity": "sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
+        "@parcel/cache": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/workers": "2.6.2",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
-      "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.2.tgz",
+      "integrity": "sha512-Ug7hpRxjgbY5AopW55nY7MmGMVmwmN+ihfCmxJkBUoESTG/3iq8uME7GjyOgW5DkQc2K7q62i8y8N0wCJT1u4Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/markdown-ansi": "2.5.0",
+        "@parcel/codeframe": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/markdown-ansi": "2.6.2",
         "@parcel/source-map": "^2.0.0",
         "chalk": "^4.1.0"
       },
@@ -1403,15 +1619,15 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
-      "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.2.tgz",
+      "integrity": "sha512-wBgUjJQm+lDd12fPRUmk09+ujTA9DgwPdqylSFK0OtI/yT6A+2kArUqjp8IwWo2tCJXoMzXBne2XQIWKqMiN4Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       },
@@ -1423,13 +1639,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.2"
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.13.tgz",
-      "integrity": "sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
+      "integrity": "sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1484,9 +1700,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1555,7 +1771,7 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
     "node_modules/brace-expansion": {
@@ -1569,9 +1785,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
       "funding": [
         {
@@ -1584,11 +1800,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1613,9 +1828,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001338",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
-      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true,
       "funding": [
         {
@@ -1661,7 +1876,7 @@
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
       "engines": {
         "node": ">=0.8"
@@ -1697,7 +1912,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/cosmiconfig": {
@@ -1798,7 +2013,7 @@
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -1889,12 +2104,12 @@
     "node_modules/elasticlunr": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/elasticlunr/-/elasticlunr-0.9.5.tgz",
-      "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU="
+      "integrity": "sha512-5YM9LFQgVYfuLNEoqMqVWIBuF2UNCA+xu/jz1TyryLN/wmBcQSb+GNAwvLKvEpGESwgGN8XA1nbLAt6rKlyHYQ=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -1939,7 +2154,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -1982,9 +2197,9 @@
       }
     },
     "node_modules/fuzzysort": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.9.0.tgz",
-      "integrity": "sha512-MOxCT0qLTwLqmEwc7UtU045RKef7mc8Qz8eR4r2bLNEq9dy/c3ZKMEFp6IEst69otkQdFZ4FfgH2dmZD+ddX1g=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-2.0.1.tgz",
+      "integrity": "sha512-SlgbPAq0eQ6JQ1h3l4MNeGH/t9DHKH8GGM0RD/6RhmJrNnSoWt3oIVaiQm9g9BPB+wAhRMeMqlUTbhbd7+Ufcg=="
     },
     "node_modules/get-port": {
       "version": "4.2.0",
@@ -2011,9 +2226,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.14.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.14.0.tgz",
-      "integrity": "sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2110,9 +2325,9 @@
       }
     },
     "node_modules/idb": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
-      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.2.tgz",
+      "integrity": "sha512-jjKrT1EnyZewQ/gCBb/eyiYrhGzws2FeY92Yx8qT9S9GeQAmo4JFVIiWRIfKW/6Ob9A+UDAOW9j9jn58fy2HIg=="
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -2142,13 +2357,13 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "node_modules/is-json": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=",
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
       "dev": true
     },
     "node_modules/is-stream": {
@@ -2166,7 +2381,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/js-tokens": {
@@ -2200,18 +2415,32 @@
       "dev": true
     },
     "node_modules/lmdb": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-      "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "msgpackr": "^1.5.4",
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
         "ordered-binary": "^1.2.4",
         "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2"
       }
+    },
+    "node_modules/lmdb/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -2224,12 +2453,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
     },
     "node_modules/mdn-data": {
       "version": "2.0.14",
@@ -2274,110 +2497,44 @@
       }
     },
     "node_modules/msgpackr": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.7.tgz",
-      "integrity": "sha512-Hsa80i8W4BiObSMHslfnwC+CC1CYHZzoXJZn0+3EvoCEOgt3c5QlXhdcjgFk2aZxMgpV8aUFZqJyQUCIp4UrzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.6.1.tgz",
+      "integrity": "sha512-Je+xBEfdjtvA4bKaOv8iRhjC8qX2oJwpYH4f7JrG4uMVJVmnmkAT4pjKdbztKprGj3iwjcxPzb5umVZ02Qq3tA==",
       "dev": true,
       "optionalDependencies": {
-        "msgpackr-extract": "^1.1.4"
+        "msgpackr-extract": "^2.0.2"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.1.4.tgz",
-      "integrity": "sha512-WQbHvsThprXh+EqZYy+SQFEs7z6bNM7a0vgirwUfwUcphWGT2mdPcpyLCNiRsN6w5q5VKJUMblHY+tNEyceb9Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.0.2.tgz",
+      "integrity": "sha512-coskCeJG2KDny23zWeu+6tNy7BLnAiOGgiwzlgdm4oeSsTpqEJJPguHIuKZcCdB7tzhZbXNYSg6jZAXkZErkJA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "node-gyp-build-optional-packages": "^4.3.2"
+        "node-gyp-build-optional-packages": "5.0.2"
       },
       "optionalDependencies": {
-        "msgpackr-extract-darwin-arm64": "1.1.0",
-        "msgpackr-extract-darwin-x64": "1.1.0",
-        "msgpackr-extract-linux-arm": "1.1.0",
-        "msgpackr-extract-linux-arm64": "1.1.0",
-        "msgpackr-extract-linux-x64": "1.1.0",
-        "msgpackr-extract-win32-x64": "1.1.0"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.0.2"
       }
     },
-    "node_modules/msgpackr-extract-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-s1kHoT12tS2cCQOv+Wl3I+/cYNJXBPtwQqGA+dPYoXmchhXiE0Nso+BIfvQ5PxbmAyjj54Q5o7PnLTqVquNfZA==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.2.tgz",
+      "integrity": "sha512-PiN4NWmlQPqvbEFcH/omQsswWQbe5Z9YK/zdB23irp5j2XibaA2IrGvpSWmVVG4qMZdmPdwPctSy4a86rOMn6g==",
       "dev": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/msgpackr-extract-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-yx/H/i12IKg4eWGu/eKdKzJD4jaYvvujQSaVmeOMCesbSQnWo5X6YR9TFjoiNoU9Aexk1KufzL9gW+1DozG1yw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/msgpackr-extract-linux-arm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-1.1.0.tgz",
-      "integrity": "sha512-0VvSCqi12xpavxl14gMrauwIzHqHbmSChUijy/uo3mpjB1Pk4vlisKpZsaOZvNJyNKj0ACi5jYtbWnnOd7hYGw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/msgpackr-extract-linux-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-1.1.0.tgz",
-      "integrity": "sha512-AxFle3fHNwz2V4CYDIGFxI6o/ZuI0lBKg0uHI8EcCMUmDE5mVAUWYge5WXmORVvb8sVWyVgFlmi3MTu4Ve6tNQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/msgpackr-extract-linux-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-1.1.0.tgz",
-      "integrity": "sha512-O+XoyNFWpdB8oQL6O/YyzffPpmG5rTNrr1nKLW70HD2ENJUhcITzbV7eZimHPzkn8LAGls1tBaMTHQezTBpFOw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/msgpackr-extract-win32-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-1.1.0.tgz",
-      "integrity": "sha512-6AJdM5rNsL4yrskRfhujVSPEd6IBpgvsnIT/TPowKNLQ62iIdryizPY2PJNFiW3AJcY249AHEiDBXS1cTDPxzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "bin": {
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/multimatch": {
       "version": "4.0.0",
@@ -2395,12 +2552,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true
-    },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -2408,9 +2559,9 @@
       "dev": true
     },
     "node_modules/node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -2419,21 +2570,20 @@
       }
     },
     "node_modules/node-gyp-build-optional-packages": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.2.tgz",
-      "integrity": "sha512-P5Ep3ISdmwcCkZIaBaQamQtWAG0facC89phWZgi5Z3hBU//J6S48OIvyZWSPPf6yQMklLZiqoosWAZUj7N+esA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
       "dev": true,
-      "optional": true,
       "bin": {
-        "node-gyp-build-optional": "optional.js",
         "node-gyp-build-optional-packages": "bin.js",
-        "node-gyp-build-test": "build-test.js"
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
     "node_modules/npm-run-path": {
@@ -2449,9 +2599,9 @@
       }
     },
     "node_modules/nth-check": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
-      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
@@ -2469,7 +2619,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -2491,9 +2641,9 @@
       }
     },
     "node_modules/ordered-binary": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.5.tgz",
-      "integrity": "sha512-djRmZoEpOGvIRW7ufsCDHtvcUa18UC9TxnPbHhSVFZHsoyg0dtut1bWtBZ/fmxdPN62oWXrV6adM7NoWU+CneA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.3.0.tgz",
+      "integrity": "sha512-knIeYepTI6BDAzGxqFEDGtI/iGqs57H32CInAIxEvAHG46vk1Di0CEpyc1A7iY39B1mfik3g3KLYwOTNnnMHLA==",
       "dev": true
     },
     "node_modules/p-limit": {
@@ -2533,21 +2683,21 @@
       }
     },
     "node_modules/parcel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.5.0.tgz",
-      "integrity": "sha512-er0mj/BaMjWyzQ/jedLUi/LNAuQcFT8lCvoNqANF+jTaX9rohaBwxIvKVJVAZgyCnmyfbbldp496wPMW0R0+CA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.6.2.tgz",
+      "integrity": "sha512-q6hrD3rm9M4S/VBVTcOs3pl55cnRwWfco7n8hZoAqnInWjWB+Khu92LRBMerMBTdE15Y+lJhWrXNdimDYstfhQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.5.0",
-        "@parcel/core": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/reporter-cli": "2.5.0",
-        "@parcel/reporter-dev-server": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/config-default": "2.6.2",
+        "@parcel/core": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
+        "@parcel/reporter-cli": "2.6.2",
+        "@parcel/reporter-dev-server": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0",
@@ -2577,15 +2727,18 @@
       }
     },
     "node_modules/parcel-resolver-ignore": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parcel-resolver-ignore/-/parcel-resolver-ignore-2.0.0.tgz",
-      "integrity": "sha512-68ZxMKFTMHJsK4dE2MNIuDthWMql8gpQ2mDxr9yx6Q7xa29h7H9REi0bb17juuYwzAt6pOk3xl2YG3NFQzoGiA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/parcel-resolver-ignore/-/parcel-resolver-ignore-2.1.3.tgz",
+      "integrity": "sha512-C8uLvR4o7SPRSsQ/Nylm1/PdsLwn/Z9bzCs66qT3XIebJC7ojaFFF3MDl/mie5audngjcFF8wzU0AoEQkZq2pA==",
       "dev": true,
       "engines": {
         "parcel": ">=2.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/vladimirmikulic"
+      },
+      "peerDependencies": {
+        "parcel": ">=2.0.0"
       }
     },
     "node_modules/parent-module": {
@@ -2707,18 +2860,18 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.7.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.2.tgz",
-      "integrity": "sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.10.0.tgz",
+      "integrity": "sha512-fszkg1iJJjq68I4lI8ZsmBiaoQiQHbxf1lNq+72EmC/mZOsFF5zn3k1yv9QGoFgIXzgsdSKtYymLJsrJPoamjQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -2776,14 +2929,11 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
+    "node_modules/react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+      "dev": true
     },
     "node_modules/react-refresh": {
       "version": "0.9.0",
@@ -2888,6 +3038,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
       "dev": true
     },
     "node_modules/strip-final-newline": {
@@ -2945,14 +3096,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -2968,32 +3119,11 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
       "dev": true
-    },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
     },
     "node_modules/tslib": {
       "version": "2.4.0",
@@ -3014,9 +3144,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3024,6 +3154,32 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/utility-types": {
@@ -3047,23 +3203,6 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
     },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3082,7 +3221,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/xxhash-wasm": {
@@ -3103,27 +3242,27 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -3160,13 +3299,13 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -3178,6 +3317,55 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "@lezer/common": {
@@ -3195,6 +3383,48 @@
         "@lezer/common": "^0.15.0"
       }
     },
+    "@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "dev": true,
+      "optional": true
+    },
     "@mischnic/json-sourcemap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
@@ -3206,107 +3436,149 @@
         "json5": "^2.2.1"
       }
     },
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.0.2.tgz",
+      "integrity": "sha512-FMX5i7a+ojIguHpWbzh5MCsCouJkwf4z4ejdUY/fsgB9Vkdak4ZnoIEskOyOUMMB4lctiZFGszFQJXUeFL8tRg==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.0.2.tgz",
+      "integrity": "sha512-DznYtF3lHuZDSRaIOYeif4JgO0NtO2Xf8DsngAugMx/bUdTFbg86jDTmkVJBNmV+cxszz6OjGvinnS8AbJ342g==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.0.2.tgz",
+      "integrity": "sha512-Gy9+c3Wj+rUlD3YvCZTi92gs+cRX7ZQogtwq0IhRenloTTlsbpezNgk6OCkt59V4ATEWSic9rbU92H/l7XsRvA==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.0.2.tgz",
+      "integrity": "sha512-b0jMEo566YdM2K+BurSed7bswjo3a6bcdw5ETqoIfSuxKuRLPfAiOjVbZyZBgx3J/TAM/QrvEQ/VN89A0ZAxSg==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.0.2.tgz",
+      "integrity": "sha512-zrBHaePwcv4cQXxzYgNj0+A8I1uVN97E7/3LmkRocYZ+rMwUsnPpp4RuTAHSRoKlTQV3nSdCQW4Qdt4MXw/iHw==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.0.2.tgz",
+      "integrity": "sha512-fpnI00dt+yO1cKx9qBXelKhPBdEgvc8ZPav1+0r09j0woYQU2N79w/jcGawSY5UGlgQ3vjaJsFHnGbGvvqdLzg==",
+      "dev": true,
+      "optional": true
+    },
     "@parcel/bundler-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.5.0.tgz",
-      "integrity": "sha512-7CJzE17SirCXjcRgBcnqWO/5EOA1raq/3OIKtT4cxbjpDQGHZpjpEEZiMNRpEpdNMxDSlsG8mAkXTYGL2VVWRw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.6.2.tgz",
+      "integrity": "sha512-XIa3had/MIaTGgRFkHApXwytYs77k4geaNcmlb6nzmAABcYjW1CLYh83Zt0AbzLFsDT9ZcRY3u2UjhNf6efSaw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.2.tgz",
+      "integrity": "sha512-hhJ6AsEGybeQZd9c/GYqfcKTgZKQXu3Xih6TlnP3gdR3KZoJOnb40ovHD1yYg4COvfcXThKP1cVJ18J6rcv3IA==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "lmdb": "2.2.4"
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "lmdb": "2.5.2"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
-      "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.2.tgz",
+      "integrity": "sha512-oFlHr6HCaYYsB4SHkU+gn9DKtbzvv3/4NdwMX0/6NAKyYVI7inEsXyPGw2Bbd2ZCFatW9QJZUETF0etvh5AEfQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/compressor-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.5.0.tgz",
-      "integrity": "sha512-I5Zs+2f1ue4sTPdfT8BNsLfTZl48sMWLk2Io3elUJjH/SS9kO7ut5ChkuJtt77ZS35m0OF+ZCt3ICTJdnDG8eA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.6.2.tgz",
+      "integrity": "sha512-P3c8jjV5HVs+fNDjhvq7PtHXNm687nit1iwTS5VAt+ScXKhKBhoIJ56q+9opcw0jnXVjAAgZqcRZ50oAJBGdKw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.2"
       }
     },
     "@parcel/config-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.5.0.tgz",
-      "integrity": "sha512-r30V61958SONvP9I8KV8s44ZOFq0H219VyFjPysraSabHjZ+KMaCTQOuqaDtUMa272sHUQkBcZxKYj5jYPJlZg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.6.2.tgz",
+      "integrity": "sha512-kuZFY0rhaioCRX2LqxaMM2ylui6ms/nmdVxuceP4/SAWi/9duc+y1lG2a1zGNShbc6OEgpdQr/W/jxdYM7NJDw==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.5.0",
-        "@parcel/compressor-raw": "2.5.0",
-        "@parcel/namer-default": "2.5.0",
-        "@parcel/optimizer-css": "2.5.0",
-        "@parcel/optimizer-htmlnano": "2.5.0",
-        "@parcel/optimizer-image": "2.5.0",
-        "@parcel/optimizer-svgo": "2.5.0",
-        "@parcel/optimizer-terser": "2.5.0",
-        "@parcel/packager-css": "2.5.0",
-        "@parcel/packager-html": "2.5.0",
-        "@parcel/packager-js": "2.5.0",
-        "@parcel/packager-raw": "2.5.0",
-        "@parcel/packager-svg": "2.5.0",
-        "@parcel/reporter-dev-server": "2.5.0",
-        "@parcel/resolver-default": "2.5.0",
-        "@parcel/runtime-browser-hmr": "2.5.0",
-        "@parcel/runtime-js": "2.5.0",
-        "@parcel/runtime-react-refresh": "2.5.0",
-        "@parcel/runtime-service-worker": "2.5.0",
-        "@parcel/transformer-babel": "2.5.0",
-        "@parcel/transformer-css": "2.5.0",
-        "@parcel/transformer-html": "2.5.0",
-        "@parcel/transformer-image": "2.5.0",
-        "@parcel/transformer-js": "2.5.0",
-        "@parcel/transformer-json": "2.5.0",
-        "@parcel/transformer-postcss": "2.5.0",
-        "@parcel/transformer-posthtml": "2.5.0",
-        "@parcel/transformer-raw": "2.5.0",
-        "@parcel/transformer-react-refresh-wrap": "2.5.0",
-        "@parcel/transformer-svg": "2.5.0"
+        "@parcel/bundler-default": "2.6.2",
+        "@parcel/compressor-raw": "2.6.2",
+        "@parcel/namer-default": "2.6.2",
+        "@parcel/optimizer-css": "2.6.2",
+        "@parcel/optimizer-htmlnano": "2.6.2",
+        "@parcel/optimizer-image": "2.6.2",
+        "@parcel/optimizer-svgo": "2.6.2",
+        "@parcel/optimizer-terser": "2.6.2",
+        "@parcel/packager-css": "2.6.2",
+        "@parcel/packager-html": "2.6.2",
+        "@parcel/packager-js": "2.6.2",
+        "@parcel/packager-raw": "2.6.2",
+        "@parcel/packager-svg": "2.6.2",
+        "@parcel/reporter-dev-server": "2.6.2",
+        "@parcel/resolver-default": "2.6.2",
+        "@parcel/runtime-browser-hmr": "2.6.2",
+        "@parcel/runtime-js": "2.6.2",
+        "@parcel/runtime-react-refresh": "2.6.2",
+        "@parcel/runtime-service-worker": "2.6.2",
+        "@parcel/transformer-babel": "2.6.2",
+        "@parcel/transformer-css": "2.6.2",
+        "@parcel/transformer-html": "2.6.2",
+        "@parcel/transformer-image": "2.6.2",
+        "@parcel/transformer-js": "2.6.2",
+        "@parcel/transformer-json": "2.6.2",
+        "@parcel/transformer-postcss": "2.6.2",
+        "@parcel/transformer-posthtml": "2.6.2",
+        "@parcel/transformer-raw": "2.6.2",
+        "@parcel/transformer-react-refresh-wrap": "2.6.2",
+        "@parcel/transformer-svg": "2.6.2"
       }
     },
     "@parcel/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-dygDmPsfAYJKTnUftcbEzjCik7AAaPbFvJW8ETYz8diyjkAG9y6hvCAZIrJE5pNOjFzg32en4v4UWv8Sqlzl9g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.2.tgz",
+      "integrity": "sha512-JlKS3Ux0ngmdooSBbzQLShHJdsapF9E7TGMo1hFaHRquZip/DaqzvysYrgMJlDuCoLArciq5ei7ZKzGeK9zexA==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/graph": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/cache": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/graph": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -3320,82 +3592,82 @@
       }
     },
     "@parcel/css": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.8.2.tgz",
-      "integrity": "sha512-3vTyKHy2LnZ3YJEut+UQPVIxsaY/mdGk7cDXtmvH4xR48Pd6rYzChHCMl4Ru2DUkCBpr0KCQRPZTdYcsJhUmIA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.12.0.tgz",
+      "integrity": "sha512-iDpbNOp5l6L7ZIX+rqutkdqvI01BBhUSJGXfDJFD5UfnG8VmDyQ2PYtVB+5+kJH4CICOI6oiO4JCi1O/fNpkJA==",
       "dev": true,
       "requires": {
-        "@parcel/css-darwin-arm64": "1.8.2",
-        "@parcel/css-darwin-x64": "1.8.2",
-        "@parcel/css-linux-arm-gnueabihf": "1.8.2",
-        "@parcel/css-linux-arm64-gnu": "1.8.2",
-        "@parcel/css-linux-arm64-musl": "1.8.2",
-        "@parcel/css-linux-x64-gnu": "1.8.2",
-        "@parcel/css-linux-x64-musl": "1.8.2",
-        "@parcel/css-win32-x64-msvc": "1.8.2",
+        "@parcel/css-darwin-arm64": "1.12.0",
+        "@parcel/css-darwin-x64": "1.12.0",
+        "@parcel/css-linux-arm-gnueabihf": "1.12.0",
+        "@parcel/css-linux-arm64-gnu": "1.12.0",
+        "@parcel/css-linux-arm64-musl": "1.12.0",
+        "@parcel/css-linux-x64-gnu": "1.12.0",
+        "@parcel/css-linux-x64-musl": "1.12.0",
+        "@parcel/css-win32-x64-msvc": "1.12.0",
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/css-darwin-arm64": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.8.2.tgz",
-      "integrity": "sha512-p5etxX3kPCuEQcipjqH9yc5j0x5/Yc++uB4MvG/sFbRgL2gI2zUuRo9sIgqA21boOP8lE4bQgz1ovPD/W1hj+Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.12.0.tgz",
+      "integrity": "sha512-zq2vdvIJNFetPFima2D/oytAlxlWP9Qy6WSri+l3TOMnxrvObqfMv71kmbwOFUApnaxmTMqdd/GQN6DvIL+gOQ==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-darwin-x64": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.8.2.tgz",
-      "integrity": "sha512-c3xi5DXRZYec5db4KPTxp69eHbomOuasgZNiuPPOi80k7jlOwfzCFQs0h6/KwWvTcJrKEFsLl8BKJU/aX7mETw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.12.0.tgz",
+      "integrity": "sha512-N3bvj68peUquzh/6mA50+EgnddjxFjil5sfDSfvvOEQoTQB0e0T/Q2J7O9RqRLcK5mKHJ/27ByQAhoEZZ8AT6g==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm-gnueabihf": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.8.2.tgz",
-      "integrity": "sha512-+ih3+mMpwbwtOjr/XW5pP0frsV1PMN+Qz7jCAM84h8xX+8UE/1IR0UVi3EPa8wQiIlcVcEwszQ1MV2UHacvo/A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.12.0.tgz",
+      "integrity": "sha512-Y2SQmYhUZllHFvv5BYRiZSFGoMOyLqhRcvRNrR6cgzIPBBUTLYgCTP1EKAXXaGqLZCjwPig/d1ZBvKI+cA75IA==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm64-gnu": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.8.2.tgz",
-      "integrity": "sha512-jIoyXbjJ1trUHXtyJhi3hlF1ck6xM4CDyaY5N6eN+3+ovkdw6wxog9IiheYJ1jf9ellYevLvTF5kiYE9MiP04A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.12.0.tgz",
+      "integrity": "sha512-FDaqmvB6Iuv64oen3XzKfimnlXARUZ+rkxu9ivgv69Iwp1OQKLUxwCRxMrhotg8sryONhyg/tHWft7G0t4S14w==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm64-musl": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.8.2.tgz",
-      "integrity": "sha512-QVTc5a+HatoywIei3djKYmp3s5dbI2Q3QaYZf3gqhyjOkeC7bm6j5eeNzFO+wa5xtga5jdHkIuTRrJ/wCojKKw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.12.0.tgz",
+      "integrity": "sha512-PxkjtWk5B5DA8dkBJqd59NSr55RnDkVwVRqH5nCXux7gWPdp9v+LRrRJBpSQgLJaiatFiY+CXZNlFRnBqrqFTQ==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-x64-gnu": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.8.2.tgz",
-      "integrity": "sha512-9r2tSfa6i3ZQ3a6C9XufJWuTv3LB7JYzxzEqsI35SSA8D/DrfAHMaIhqog5wSxKZRWmQxckh2wdT96eIIGHSGA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.12.0.tgz",
+      "integrity": "sha512-zxD1bS4BF79F+4DV7+kccAs6gNrcilzTOCJ3GvxrNjh1OJtXUVi7Ls0r+pVwuhF7kzOi0AUYvnwHBeybxoIhuA==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-x64-musl": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.8.2.tgz",
-      "integrity": "sha512-5SetLWkxXRQ3NU6QwwbGf9tOmGW2m1cGt07Moybbe4RCXOY6R5wAYUtauZUp7pD/fJlE9mHge4jnNHKpVO9pvw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.12.0.tgz",
+      "integrity": "sha512-oTHzmpTEkew/aoW4jyQ/sR+XJh+3Xl7J9dnJo4/FVvRjRSHdr/V8LEPx61Iv2Edx123WzrpNqpvUC1X6Q3M4fw==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-win32-x64-msvc": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.8.2.tgz",
-      "integrity": "sha512-/EdW5Ejlnkvc/AYrAi/FmLNvM6a6eAx+A4Y7oW+8JSMvk6bYa2zmXi7XLU/QOQuH2VQa/3gIIMA+sYjPndvDpw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.12.0.tgz",
+      "integrity": "sha512-FWlyrTezxfSvYdf9qX8XSbDimeF0+N8xyP2fIEMf1YFejxH6NJ5N4LSPfysBf4qqOVR0DYYTa+UHtZxN/g2B6A==",
       "dev": true,
       "optional": true
     },
     "@parcel/diagnostic": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
-      "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.2.tgz",
+      "integrity": "sha512-3ODSBkKVihENU763z1/1DhGAWFhYWRxOCOShC72KXp+GFnSgGiBsxclu8NBa/N948Rzp8lqQI8U1nLcKkh0O/w==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -3403,47 +3675,47 @@
       }
     },
     "@parcel/events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
-      "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.2.tgz",
+      "integrity": "sha512-IaCjOeA5ercdFVi1EZOmUHhGfIysmCUgc2Th9hMugSFO0I3GzRsBcAdP6XPfWm+TV6sQ/qZRfdk/drUxoAupnw==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
-      "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.2.tgz",
+      "integrity": "sha512-mIhqdF3tjgeoIGqW7Nc/xfM2ClID7o8livwUe5lpQEP+ZaIBiMigXs6ckv3WToCACK+3uylrSD2A/HmlhrxMqQ==",
       "dev": true,
       "requires": {
-        "@parcel/fs-search": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/fs-search": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.5.0"
+        "@parcel/workers": "2.6.2"
       }
     },
     "@parcel/fs-search": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
-      "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.2.tgz",
+      "integrity": "sha512-4STid1zqtGnmGjHD/2TG2g/zPDiCTtE3IAS24QYH3eiUAz2uoKGgEqd2tZbZ2yI96jtCuIhC1bzVu8Hbykls7w==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/graph": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.5.0.tgz",
-      "integrity": "sha512-qa2VtG08dJyTaWrxYAkMIlkoDRSPoiqLDNxxHKplkcxAjXBUw0/AkWaz82VO5r1G6jfOj+nM30ajH9uygZYwbw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.2.tgz",
+      "integrity": "sha512-DPH4G/RBFJWayIN2fnhDXqhUw75n7k15YsGzdDKiXuwwz4wMOjoL4cyrI6zOf1SIyh3guRmeTYJ4jjPzwrLYww==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/hash": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
-      "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.2.tgz",
+      "integrity": "sha512-tFB+cJU1Wqag6WyJgsmx3nx+xhmjcNZqtWh/MtK1lHNnZdDRk6bjr7SapnygBwruz+SmSt5bbdVThcpk2dRCcA==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -3451,68 +3723,69 @@
       }
     },
     "@parcel/logger": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
-      "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.2.tgz",
+      "integrity": "sha512-Sz5YGCj1DbEiX0/G8Uw97LLZ0uEK+qtWcRAkHNpJpeMiSqDiRNevxXltz42EcLo+oCh4d4wyiVzwi9mNwzhS/Q==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0"
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
-      "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.2.tgz",
+      "integrity": "sha512-N/h9J4eibhc+B+krzvPMzFUWL37GudBIZBa7XSLkcuH6MnYYfh6rrMvhIyyESwk6VkcZNVzAeZrGQqxEs0dHDQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/namer-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
-      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.2.tgz",
+      "integrity": "sha512-mp7bx/BQaIuohmZP0uE+gAmDBzzH0Yu8F4yCtE611lc6i0mou+nWRhzyKLNC/ieuI8DB3BFh2QQKeTxJn4W0qg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.5.0.tgz",
-      "integrity": "sha512-XQvpguiIwQcu75cscLDFOVhjsjuPzXbuMaaZ7XxxUEl0PscIgu/GfKYxTfTruN3cRl+CaQH6qBAMfjLaFng6lQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.6.2.tgz",
+      "integrity": "sha512-4b2L5QRYlTybvv3+TIRtwg4PPJXy+cRShCBa8eu1K0Fj297Afe8MOZrcVV+RIr2KPMIRXcIJoqDmOhyci/DynA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "nullthrows": "^1.1.1"
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
       }
     },
     "@parcel/optimizer-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.5.0.tgz",
-      "integrity": "sha512-J00bLF+4SsnKc+YbYrNuBr44/zz3cg++CoXteXhH27PxP1rScGQx36Rui8WORgil5mlX2VYN79DuqJC7V3Ynbg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.6.2.tgz",
+      "integrity": "sha512-rjTQ9bOokUzzKDYpwMQxDtPqRcMljcTVvod5GT5azGnw1EbwNv30vqnTu81+sEMyttHydzYrKAM15UGV/JYu1Q==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.8.1",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/css": "^1.10.1",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.5.0.tgz",
-      "integrity": "sha512-Fr0zPqgxoNaOVdROAjNGDWCts3+wByNQ82Mxhu8Tzc25A2cPjcr1H2sa/TE3hf79c92DxdKf2FaC1ZOgR5YPdg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.6.2.tgz",
+      "integrity": "sha512-Doi2hDmsQHLwuBo6w5gvw5u6GBDz8FhkzAlitfG3C96lZxEw2eu0vquY4Li8lbZT9MBNs8zuYiD1QW8sdlv9hA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.2",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -3520,236 +3793,237 @@
       }
     },
     "@parcel/optimizer-image": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.5.0.tgz",
-      "integrity": "sha512-nbo2pdnAt21WLGjzTpsE8ZEL0xNoP7c3wBj9y70Pysmasg1SrRVCbfE8jTy+lHBQwq2yjC6lV/Usv+9lfA7S/w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.6.2.tgz",
+      "integrity": "sha512-XwFk43s8Dar4N+wXOkpKkeXf1vtu3PSu4ic+M9J0EwNKElrktQ0+paLYmwwp7Xv0tZbRedLAROomUxdXqEMupg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/optimizer-svgo": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.5.0.tgz",
-      "integrity": "sha512-pgZqwU0RLc/wr4WcQY/W1GJmddnEANDEpz1mdppUOqBz1EfTQ7zh5NgUA3hV1i05Hbecp3mHSvXJPV0mhNOl5Q==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.6.2.tgz",
+      "integrity": "sha512-X2wPy1VeT2d9oUCue/vAXX907kmLf0o+w0LHghhbApuXjkvJNS2Vz182HIo1rtcS0RH5k3lXxUV0OPQjOC7BOw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "svgo": "^2.4.0"
       }
     },
     "@parcel/optimizer-terser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.5.0.tgz",
-      "integrity": "sha512-PZ3UHBGfjE49/Jloopsd38Hxg4qzsrdepWP53mCuVP7Aw605Y4QtYuB1ho3VV0oXfKQVq+uI7lVIBsuW4K6vqA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.2.tgz",
+      "integrity": "sha512-ZSEVQ3G3zOiVPeHvH+BrHegZybrQj9kWQAaAA92leSqbvf6UaX4xqXbGRg2OttNFtbGYBzIl28Zm4t2SLeUIuA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       }
     },
     "@parcel/package-manager": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
-      "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.2.tgz",
+      "integrity": "sha512-xGMqTgnwTE3rgzYwUZMKxR8fzmP5iSYz/gj2H8FR3pEmwh/8xCMtNjTSth+hPVGuqgRZ6JxwpfdY/fXdZ61ViQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
         "semver": "^5.7.1"
       }
     },
     "@parcel/packager-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.5.0.tgz",
-      "integrity": "sha512-c0mGBFdVSPhAxaX3+zN8KEIqOOUhkIPKbZex1pnGYfy03Qe2/Mb4nyt5DAGlw9gjka1UCHIN/wszLmKC8YyUeg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.6.2.tgz",
+      "integrity": "sha512-zifJqgNUtLZoJ2oeFeLz6OFOBy8FNlVGtGtOqTJZN1SeYd94xNYyeUTwnSsOh2OEDs6HJhggL3o4uEmpM1s9GA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.5.0.tgz",
-      "integrity": "sha512-ZFGUPRMWKrm8kQHdkEJ5S22C05qpSymx+o+57EfuNjCrGyj3M59WyGYYXYJ175bFYZ/jp5yy+VxMh6fZefe+Pw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.6.2.tgz",
+      "integrity": "sha512-NTJoKcqApMgFOpulok4Ru9QW3BD7d5931ymoow9/bmgDwvJNh2SOMHVx6lqzKRU5x+wlShpYfDur4zOipRev8g==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.5.0.tgz",
-      "integrity": "sha512-aJAKOTgXdxO3V9O7+2DCVOtne128WwXmUAOVThnMRo7f3zMVSAR7Mxc9pEsuTzPfj8UBXgFBRfdJUSCgsMxiSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.6.2.tgz",
+      "integrity": "sha512-fm5rKWtaExR0W+UEKWivXNPysRFxuBCdskdxDByb1J1JeGMvp7dJElbi8oXDAQM4MnM5EyG7cg47SlMZNTLm4A==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.5.0.tgz",
-      "integrity": "sha512-aHV0oogeiqxhxS1lsttw15EvG3DDWK3FV7+F+7hoaAy+xg89K56NTp6j43Jtw9iyU1/HnZRGBE2hF3C7N73oKw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.6.2.tgz",
+      "integrity": "sha512-Rl3ZkMtMjb+LEvRowijDD8fibUAS6rWK0/vZQMk9cDNYCP2gCpZayLk0HZIGxneeTbosf/0sbngHq4VeRQOnQA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.2"
       }
     },
     "@parcel/packager-svg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.5.0.tgz",
-      "integrity": "sha512-XSMFn30K/kpjcPpQqt88GmPJsNUSVL3RNeigXkIAcLpfO6Tb2eV4iOt4yVCagaDrRJ19alXut0TxjMm5bm41/g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.6.2.tgz",
+      "integrity": "sha512-FrGlwtiMs7YBWoVA3vCNHlBcghVYueKzimvufl4r287g1iEmq59pchCqpi6rW83O/mnpUQg9mpP+BmXxuvjLNg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "posthtml": "^0.16.4"
       }
     },
     "@parcel/packager-xml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-xml/-/packager-xml-2.5.0.tgz",
-      "integrity": "sha512-KFu3I7b2LAlnJxcJD0bufMCOmFEwZlvsNKrtOVooXUIbhe6Oe9yhQ4iw+FcosCdT0dI1U8jb808bkB6o+mhuAA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-xml/-/packager-xml-2.6.2.tgz",
+      "integrity": "sha512-p0pC5VHzW6WOeQHSSzmT0hvGqf78xlf/4BNDt6AlzanOJx9bgQQ0UuHWW5nN+Oma2AePdU4vs6tREydVFS3wwA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "@xmldom/xmldom": "^0.7.5"
       }
     },
     "@parcel/plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
-      "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.2.tgz",
+      "integrity": "sha512-wbbWsM23Pr+8xtLSvf+UopXdVYlpKCCx6PuuZaZcKo+9IcDCWoGXD4M8Kkz14qBmkFn5uM00mULUqmVdSibB2w==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.5.0"
+        "@parcel/types": "2.6.2"
       }
     },
     "@parcel/reporter-cli": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.5.0.tgz",
-      "integrity": "sha512-miJt2YbRJBmYSVeoUWUj8YL85Pwj1CmGQB0/btqhulGLH/Fvkbv6T4sJ4gl4l5xIt9mJQsZ70pOWwa8BId3rWw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.6.2.tgz",
+      "integrity": "sha512-5BWMtQRSXVXMlB/BOkCf8NVLh3qcQVMrj6owuekmqLi/GGC+kGZovzA6YrofVIdNHcoxOZwTIYwjoU3ibJ6yAA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.5.0.tgz",
-      "integrity": "sha512-wvxAiW42AxJ3B8jtvowJcP4/cTV8zY48SfKg61YKYu1yUO+TtyJIjHQzDW2XuT34cIGFY97Gr0i+AVu44RyUuQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.6.2.tgz",
+      "integrity": "sha512-5QtL3ETMFL161jehlIK6rjBM+Pqk5cMhr60s9yLYqE1GY4M4gMj+Act+FXViyM6gmMA38cPxDvUsxTKBYXpFCw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0"
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2"
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.5.0.tgz",
-      "integrity": "sha512-39PkZpVr/+iYS11u+lA84vIsKm/yisltTVmUjlYsDnExiuV1c8OSbSdYZ3JMx+7CYPE0bWbosX2AGilIwIMWpQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.6.2.tgz",
+      "integrity": "sha512-Lo5sWb5QkjWvdBr+TdmAF6Mszb/sMldBBatc1osQTkHXCy679VMH+lfyiWxHbwK+F1pmdMeBJpYcMxvrgT8EsA==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "2.5.0",
-        "@parcel/plugin": "2.5.0"
+        "@parcel/node-resolver-core": "2.6.2",
+        "@parcel/plugin": "2.6.2"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.5.0.tgz",
-      "integrity": "sha512-oPAo8Zf06gXCpt41nyvK7kv2HH1RrHAGgOqttyjStwAFlm5MZKs7BgtJzO58LfJN8g3sMY0cNdG17fB/4f8q6Q==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.6.2.tgz",
+      "integrity": "sha512-M4X0+7dyfdI6smwGUGjGXb8Ns3HX7ZrTemyq4Gc7zp7P/5gWjR8i9eISz46sXmF9bf01a/4dKZpoCC9un1pH1g==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0"
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.5.0.tgz",
-      "integrity": "sha512-gPC2PbNAiooULP71wF5twe4raekuXsR1Hw/ahITDoqsZdXHzG3CkoCjYL3CkmBGiKQgMMocCyN1E2oBzAH8Kyw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.6.2.tgz",
+      "integrity": "sha512-0S3JFwgvs6FmEx2dHta9R0Sfu8vCnFAm4i7Y4efGHtAcTrF2CHjyiz4/hG+RQGJ70eoWW463Q+8qt6EKbkaOBQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.5.0.tgz",
-      "integrity": "sha512-+8RuDKFdFYIQTrXG4MRhG9XqkkYEHn0zxKyOJ/IkDDfSEhY0na+EyhrneFUwIvDX63gLPkxceXAg0gwBqXPK/Q==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.6.2.tgz",
+      "integrity": "sha512-DJTm5D/tUAGZm0o3ndDOPbKwdYrobuvm4jvkPq31LdEUqVvyuzBAMlqQFHc1yJEJDRRWOIQwQP9Y0NQbJmXFfg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/runtime-service-worker": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.5.0.tgz",
-      "integrity": "sha512-STuDlU0fPXeWpAmbayY7o04F0eHy6FTOFeT5KQ0PTxtdEa3Ey8QInP/NVE52Yv0aVQtesWukGrNEFCERlkbFRw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.6.2.tgz",
+      "integrity": "sha512-9jV+RwVEeDUI5+eLy8j1tapTNoHHGOY2+JUprcObQkQ8fux7KltQBJWFhpkUdGtz5LTCNXtj9tdycFtS5lmSzg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/source-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.2.tgz",
-      "integrity": "sha512-NnUrPYLpYB6qyx2v6bcRPn/gVigmGG6M6xL8wIg/i0dP1GLkuY1nf+Hqdf63FzPTqqT7K3k6eE5yHPQVMO5jcA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.0.tgz",
+      "integrity": "sha512-E7UOEIof2o89LrKk1agSLmwakjigmEdDp1ZaEdsLVEvq63R/bul4Ij5CT+0ZDcijGpl5tnTbQADY9EyYGtjYgQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.5.0.tgz",
-      "integrity": "sha512-EFb866C9jCoBHIcebWF7goAcYj1wkObx0GDxshlazFtvym1RM27xSWWjRYyqb5+HNOxB3voaNvQOVjcD+DXjCA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.6.2.tgz",
+      "integrity": "sha512-R3qdfhnZhVhsDB8+0wC3CU86dmqx5DwxcTo10Wd1VbA6fiLRSGd4+ZrxJRg491mFTedgtTrUeO6LNYAmMFpCbQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -3757,29 +4031,29 @@
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.5.0.tgz",
-      "integrity": "sha512-p8FOvKWWSbS6H8PbD9a0KZqyaKNpSD2BUTzSRYnNj3TBUv7/ZXaP6Om295XTQ/MPht1o7XTQzvfpF/7yEhr02Q==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.6.2.tgz",
+      "integrity": "sha512-6lsMdwBUgAyTcd7OIz2lG56jobptGkaRogDmbGFDhmuq/tQ/ZrNElUFmDVeh5cELQlByvj/Qh32cUMnsiMsk3g==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.8.1",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/css": "^1.10.1",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.2",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.5.0.tgz",
-      "integrity": "sha512-iEjNyAF0wQmY3DMw7FS+UzoOMng76UsSngh+WWA1E5lv5XyqrP8Mk2QLTJp1nWetUhSLhZr58LGmPYBTB4l9ZQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.6.2.tgz",
+      "integrity": "sha512-DEGv0Gd8BVAO/QZuXRg+A6YieVpIub7YT8xTNA/6vCIAl++y2hYyo9NF2j2xnooYbzW7zd7uDEFawOSd40lxig==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3788,28 +4062,28 @@
       }
     },
     "@parcel/transformer-image": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.5.0.tgz",
-      "integrity": "sha512-vVEXTHZl8m/9yopgK0dWHLOQX2zOnghq6pZnWdWVG6fsvXZln7kP1YN5iwWDoADQYkiKzP+Ymn6UwP9pZpHFzA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.6.2.tgz",
+      "integrity": "sha512-i2Ug6exFaX64M10Qsq4vza5NP0iRW+aIcao4uGvPHP6d36a0oUfT6tJsOLHh3sDj2ihT8RVJL2TRavSX17TjUA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/workers": "2.6.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.5.0.tgz",
-      "integrity": "sha512-Cp8Ic+Au3OcskCRZszmo47z3bqcZ7rfPv2xZYXpXY2TzEc3IV0bKje57bZektoY8LW9LkYM9iBO/WhkVoT6LIg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.6.2.tgz",
+      "integrity": "sha512-uhXAMTjE/Q61amflV8qVpb73mj+mIdXIMH0cSks1/gDIAxcgIvWvrE14P4TvY6zJ1q1iRJRIRUN6cFSXqjjLSA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
-        "@swc/helpers": "^0.3.6",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
+        "@swc/helpers": "^0.4.2",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
@@ -3818,25 +4092,25 @@
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.5.0.tgz",
-      "integrity": "sha512-661sByA7TkR6Lmxt+hqV4h2SAt+7lgc58DzmUYArpEl1fQnMuQuaB0kQeHzi6fDD2+2G6o7EC+DuwBZKa479TA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.6.2.tgz",
+      "integrity": "sha512-QGcIIvbPF/u10ihYvQhxXqb2QMXWSzcBxJrOSIXIl74TUGrWX05D5LmjDA/rzm/n/kvRnBkFNP60R/smYb8x+Q==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.2",
         "json5": "^2.2.0"
       }
     },
     "@parcel/transformer-postcss": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.5.0.tgz",
-      "integrity": "sha512-IPNlWElekdQHMTBqhdwJNBCQomuYyo7xgNBdnTrt9VJ+R5ihy6n7ZJSWIAJXAH9VZxETTtunfrzRtgkmtjTeZQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.6.2.tgz",
+      "integrity": "sha512-yauLUofKnb09tzgg8FE33aDrbqgOgQtGyWfyiKWnoV1j8XTRu/t6R7e2qRysgNsm9Ghzxe1G83iJSli1MGTErA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -3844,13 +4118,13 @@
       }
     },
     "@parcel/transformer-posthtml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.5.0.tgz",
-      "integrity": "sha512-AZxg1XD8OXOS4bEGEmBBR+X9T9qoFdVsbVUg498zzejYSka1ZQHF7TgLI/+pUnE+ZVYNIp7/G0xXqsRVKMKmdQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.6.2.tgz",
+      "integrity": "sha512-Ly9znYdBnGLDmlyhKQJOekrs35w7fKTSxZ60B3nTtpwSFC/AMr3nv9kPTVi8KDRp2Kh1ahxQlfBIYHCa0RfkXA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3859,34 +4133,34 @@
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.5.0.tgz",
-      "integrity": "sha512-I3zjE1u9+Wj90Qqs1V2FTm6iC6SAyOVUthwVZkZey+qbQG/ok682Ez2XjLu7MyQCo9BJNwF/nfOa1hHr3MaJEQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.6.2.tgz",
+      "integrity": "sha512-CsofYq5g9Zj/FNmhya2R7Xp3WHlzz34mEdN69bds3azRYHCrl/TS33xXcp/9J+74SEIY1Ufh552o1cM3fnSrDQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.2"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.5.0.tgz",
-      "integrity": "sha512-VPqVBxhTN4OQwcjsdyxrv+smjAm4s6dbSWAplgPwdOITMv+a0tjhhJU37WnRC+xxTrbEqRcOt96JvGOkPb8i7g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.6.2.tgz",
+      "integrity": "sha512-7EE68ebISz+oAHm64ZJbz6uJQT4aOoB8QiK3PvuY6+RsP7aK4/FEHGM1afW49KrZbP4lWjloEkcJm/88DfBiGw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/transformer-svg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.5.0.tgz",
-      "integrity": "sha512-zCGJcrCpICFe0Q/dgjQZfW7sYFkbJEC7NGT4zEJnMo8Cm/kq8Qh6+2ApX6c+vv5Q0WZn5Ic+N0OvxIMkvgdC/w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.6.2.tgz",
+      "integrity": "sha512-s7e/DVte2OT+jUL10+g2+l/y/MqxAb8Avw1asRH0683iEVj6GGS/K4KnHN8WagLwnS6Fb3/InVrzxtb0YKUt2w==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/plugin": "2.6.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3895,41 +4169,41 @@
       }
     },
     "@parcel/transformer-xml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-xml/-/transformer-xml-2.5.0.tgz",
-      "integrity": "sha512-ndkAcE1ESFOIYtTx5BacDH45AfkHWyjolVh/JlIq3WxKTMxi1cN3gv0Hd3lL2oSgJGv9YmHnpsLIhVk2QlGFrA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-xml/-/transformer-xml-2.6.2.tgz",
+      "integrity": "sha512-07mpNqjGGT8RzXPly99ClFhuKJWY/fqJsNsZ0EpLSqIdKX6YcAHQucTRpuwHQRFmXJyHewDIk7P3zAF9BVvqKQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.2",
         "@xmldom/xmldom": "^0.7.5"
       }
     },
     "@parcel/types": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
-      "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.2.tgz",
+      "integrity": "sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
+        "@parcel/cache": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/workers": "2.6.2",
         "utility-types": "^3.10.0"
       }
     },
     "@parcel/utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
-      "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.2.tgz",
+      "integrity": "sha512-Ug7hpRxjgbY5AopW55nY7MmGMVmwmN+ihfCmxJkBUoESTG/3iq8uME7GjyOgW5DkQc2K7q62i8y8N0wCJT1u4Q==",
       "dev": true,
       "requires": {
-        "@parcel/codeframe": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/markdown-ansi": "2.5.0",
+        "@parcel/codeframe": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/markdown-ansi": "2.6.2",
         "@parcel/source-map": "^2.0.0",
         "chalk": "^4.1.0"
       }
@@ -3945,23 +4219,23 @@
       }
     },
     "@parcel/workers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
-      "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.2.tgz",
+      "integrity": "sha512-wBgUjJQm+lDd12fPRUmk09+ujTA9DgwPdqylSFK0OtI/yT6A+2kArUqjp8IwWo2tCJXoMzXBne2XQIWKqMiN4Q==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@swc/helpers": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.13.tgz",
-      "integrity": "sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
+      "integrity": "sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==",
       "dev": true,
       "requires": {
         "tslib": "^2.4.0"
@@ -4010,9 +4284,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "ansi-styles": {
@@ -4060,7 +4334,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
     "brace-expansion": {
@@ -4074,16 +4348,15 @@
       }
     },
     "browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.4"
       }
     },
     "buffer-from": {
@@ -4099,9 +4372,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001338",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
-      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true
     },
     "chalk": {
@@ -4128,7 +4401,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true
     },
     "color-convert": {
@@ -4155,7 +4428,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "cosmiconfig": {
@@ -4228,7 +4501,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true
     },
     "dom-serializer": {
@@ -4291,12 +4564,12 @@
     "elasticlunr": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/elasticlunr/-/elasticlunr-0.9.5.tgz",
-      "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU="
+      "integrity": "sha512-5YM9LFQgVYfuLNEoqMqVWIBuF2UNCA+xu/jz1TyryLN/wmBcQSb+GNAwvLKvEpGESwgGN8XA1nbLAt6rKlyHYQ=="
     },
     "electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
+      "version": "1.4.196",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
       "dev": true
     },
     "end-of-stream": {
@@ -4332,7 +4605,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "execa": {
@@ -4363,9 +4636,9 @@
       }
     },
     "fuzzysort": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.9.0.tgz",
-      "integrity": "sha512-MOxCT0qLTwLqmEwc7UtU045RKef7mc8Qz8eR4r2bLNEq9dy/c3ZKMEFp6IEst69otkQdFZ4FfgH2dmZD+ddX1g=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-2.0.1.tgz",
+      "integrity": "sha512-SlgbPAq0eQ6JQ1h3l4MNeGH/t9DHKH8GGM0RD/6RhmJrNnSoWt3oIVaiQm9g9BPB+wAhRMeMqlUTbhbd7+Ufcg=="
     },
     "get-port": {
       "version": "4.2.0",
@@ -4383,9 +4656,9 @@
       }
     },
     "globals": {
-      "version": "13.14.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.14.0.tgz",
-      "integrity": "sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -4427,9 +4700,9 @@
       "dev": true
     },
     "idb": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
-      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.2.tgz",
+      "integrity": "sha512-jjKrT1EnyZewQ/gCBb/eyiYrhGzws2FeY92Yx8qT9S9GeQAmo4JFVIiWRIfKW/6Ob9A+UDAOW9j9jn58fy2HIg=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -4450,13 +4723,13 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "is-json": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=",
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
       "dev": true
     },
     "is-stream": {
@@ -4468,7 +4741,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "js-tokens": {
@@ -4496,16 +4769,30 @@
       "dev": true
     },
     "lmdb": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-      "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
       "dev": true,
       "requires": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2",
         "msgpackr": "^1.5.4",
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
         "ordered-binary": "^1.2.4",
         "weak-lru-cache": "^1.2.2"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "dev": true
+        }
       }
     },
     "locate-path": {
@@ -4516,12 +4803,6 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
     },
     "mdn-data": {
       "version": "2.0.14",
@@ -4557,71 +4838,38 @@
       "dev": true
     },
     "msgpackr": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.7.tgz",
-      "integrity": "sha512-Hsa80i8W4BiObSMHslfnwC+CC1CYHZzoXJZn0+3EvoCEOgt3c5QlXhdcjgFk2aZxMgpV8aUFZqJyQUCIp4UrzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.6.1.tgz",
+      "integrity": "sha512-Je+xBEfdjtvA4bKaOv8iRhjC8qX2oJwpYH4f7JrG4uMVJVmnmkAT4pjKdbztKprGj3iwjcxPzb5umVZ02Qq3tA==",
       "dev": true,
       "requires": {
-        "msgpackr-extract": "^1.1.4"
+        "msgpackr-extract": "^2.0.2"
       }
     },
     "msgpackr-extract": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.1.4.tgz",
-      "integrity": "sha512-WQbHvsThprXh+EqZYy+SQFEs7z6bNM7a0vgirwUfwUcphWGT2mdPcpyLCNiRsN6w5q5VKJUMblHY+tNEyceb9Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.0.2.tgz",
+      "integrity": "sha512-coskCeJG2KDny23zWeu+6tNy7BLnAiOGgiwzlgdm4oeSsTpqEJJPguHIuKZcCdB7tzhZbXNYSg6jZAXkZErkJA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "msgpackr-extract-darwin-arm64": "1.1.0",
-        "msgpackr-extract-darwin-x64": "1.1.0",
-        "msgpackr-extract-linux-arm": "1.1.0",
-        "msgpackr-extract-linux-arm64": "1.1.0",
-        "msgpackr-extract-linux-x64": "1.1.0",
-        "msgpackr-extract-win32-x64": "1.1.0",
-        "node-gyp-build-optional-packages": "^4.3.2"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.0.2",
+        "node-gyp-build-optional-packages": "5.0.2"
+      },
+      "dependencies": {
+        "node-gyp-build-optional-packages": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.2.tgz",
+          "integrity": "sha512-PiN4NWmlQPqvbEFcH/omQsswWQbe5Z9YK/zdB23irp5j2XibaA2IrGvpSWmVVG4qMZdmPdwPctSy4a86rOMn6g==",
+          "dev": true,
+          "optional": true
+        }
       }
-    },
-    "msgpackr-extract-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-s1kHoT12tS2cCQOv+Wl3I+/cYNJXBPtwQqGA+dPYoXmchhXiE0Nso+BIfvQ5PxbmAyjj54Q5o7PnLTqVquNfZA==",
-      "dev": true,
-      "optional": true
-    },
-    "msgpackr-extract-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-yx/H/i12IKg4eWGu/eKdKzJD4jaYvvujQSaVmeOMCesbSQnWo5X6YR9TFjoiNoU9Aexk1KufzL9gW+1DozG1yw==",
-      "dev": true,
-      "optional": true
-    },
-    "msgpackr-extract-linux-arm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-1.1.0.tgz",
-      "integrity": "sha512-0VvSCqi12xpavxl14gMrauwIzHqHbmSChUijy/uo3mpjB1Pk4vlisKpZsaOZvNJyNKj0ACi5jYtbWnnOd7hYGw==",
-      "dev": true,
-      "optional": true
-    },
-    "msgpackr-extract-linux-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-1.1.0.tgz",
-      "integrity": "sha512-AxFle3fHNwz2V4CYDIGFxI6o/ZuI0lBKg0uHI8EcCMUmDE5mVAUWYge5WXmORVvb8sVWyVgFlmi3MTu4Ve6tNQ==",
-      "dev": true,
-      "optional": true
-    },
-    "msgpackr-extract-linux-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-1.1.0.tgz",
-      "integrity": "sha512-O+XoyNFWpdB8oQL6O/YyzffPpmG5rTNrr1nKLW70HD2ENJUhcITzbV7eZimHPzkn8LAGls1tBaMTHQezTBpFOw==",
-      "dev": true,
-      "optional": true
-    },
-    "msgpackr-extract-win32-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-1.1.0.tgz",
-      "integrity": "sha512-6AJdM5rNsL4yrskRfhujVSPEd6IBpgvsnIT/TPowKNLQ62iIdryizPY2PJNFiW3AJcY249AHEiDBXS1cTDPxzA==",
-      "dev": true,
-      "optional": true
     },
     "multimatch": {
       "version": "4.0.0",
@@ -4636,12 +4884,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true
-    },
     "node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -4649,22 +4891,21 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true
     },
     "node-gyp-build-optional-packages": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.2.tgz",
-      "integrity": "sha512-P5Ep3ISdmwcCkZIaBaQamQtWAG0facC89phWZgi5Z3hBU//J6S48OIvyZWSPPf6yQMklLZiqoosWAZUj7N+esA==",
-      "dev": true,
-      "optional": true
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "dev": true
     },
     "node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
     "npm-run-path": {
@@ -4677,9 +4918,9 @@
       }
     },
     "nth-check": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
-      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
@@ -4694,7 +4935,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -4710,9 +4951,9 @@
       }
     },
     "ordered-binary": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.5.tgz",
-      "integrity": "sha512-djRmZoEpOGvIRW7ufsCDHtvcUa18UC9TxnPbHhSVFZHsoyg0dtut1bWtBZ/fmxdPN62oWXrV6adM7NoWU+CneA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.3.0.tgz",
+      "integrity": "sha512-knIeYepTI6BDAzGxqFEDGtI/iGqs57H32CInAIxEvAHG46vk1Di0CEpyc1A7iY39B1mfik3g3KLYwOTNnnMHLA==",
       "dev": true
     },
     "p-limit": {
@@ -4740,21 +4981,21 @@
       "dev": true
     },
     "parcel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.5.0.tgz",
-      "integrity": "sha512-er0mj/BaMjWyzQ/jedLUi/LNAuQcFT8lCvoNqANF+jTaX9rohaBwxIvKVJVAZgyCnmyfbbldp496wPMW0R0+CA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.6.2.tgz",
+      "integrity": "sha512-q6hrD3rm9M4S/VBVTcOs3pl55cnRwWfco7n8hZoAqnInWjWB+Khu92LRBMerMBTdE15Y+lJhWrXNdimDYstfhQ==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.5.0",
-        "@parcel/core": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/reporter-cli": "2.5.0",
-        "@parcel/reporter-dev-server": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/config-default": "2.6.2",
+        "@parcel/core": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
+        "@parcel/reporter-cli": "2.6.2",
+        "@parcel/reporter-dev-server": "2.6.2",
+        "@parcel/utils": "2.6.2",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0",
@@ -4771,10 +5012,11 @@
       }
     },
     "parcel-resolver-ignore": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parcel-resolver-ignore/-/parcel-resolver-ignore-2.0.0.tgz",
-      "integrity": "sha512-68ZxMKFTMHJsK4dE2MNIuDthWMql8gpQ2mDxr9yx6Q7xa29h7H9REi0bb17juuYwzAt6pOk3xl2YG3NFQzoGiA==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/parcel-resolver-ignore/-/parcel-resolver-ignore-2.1.3.tgz",
+      "integrity": "sha512-C8uLvR4o7SPRSsQ/Nylm1/PdsLwn/Z9bzCs66qT3XIebJC7ojaFFF3MDl/mie5audngjcFF8wzU0AoEQkZq2pA==",
+      "dev": true,
+      "requires": {}
     },
     "parent-module": {
       "version": "1.0.1",
@@ -4867,14 +5109,14 @@
       }
     },
     "preact": {
-      "version": "10.7.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.2.tgz",
-      "integrity": "sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ=="
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.10.0.tgz",
+      "integrity": "sha512-fszkg1iJJjq68I4lI8ZsmBiaoQiQHbxf1lNq+72EmC/mZOsFF5zn3k1yv9QGoFgIXzgsdSKtYymLJsrJPoamjQ=="
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "pretty-quick": {
@@ -4913,10 +5155,10 @@
         "once": "^1.3.1"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+    "react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
     "react-refresh": {
@@ -5029,14 +5271,14 @@
       "dev": true
     },
     "terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
@@ -5045,32 +5287,14 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
         }
       }
     },
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
       "dev": true
-    },
-    "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
     },
     "tslib": {
       "version": "2.4.0",
@@ -5085,10 +5309,20 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
+    },
+    "update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
     },
     "utility-types": {
       "version": "3.10.0",
@@ -5108,23 +5342,6 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
     },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5137,7 +5354,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -11,22 +11,22 @@
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "elasticlunr": "^0.9.5",
-    "fuzzysort": "^1.2.1",
-    "idb": "^7.0.1",
-    "preact": "^10.6.6"
+    "fuzzysort": "^2.0.1",
+    "idb": "^7.0.2",
+    "preact": "^10.10.0"
   },
   "devDependencies": {
-    "@parcel/packager-xml": "^2.4.0",
-    "@parcel/transformer-image": "^2.4.0",
-    "@parcel/transformer-xml": "^2.4.0",
+    "@parcel/packager-xml": "^2.6.2",
+    "@parcel/transformer-image": "^2.6.2",
+    "@parcel/transformer-xml": "^2.6.2",
     "@types/elasticlunr": "^0.9.4",
     "@types/lunr": "^2.3.4",
-    "parcel": "^2.4.0",
+    "parcel": "^2.6.2",
     "parcel-reporter-static-files-copy": "^1.3.4",
-    "parcel-resolver-ignore": "^2.0.0",
-    "prettier": "^2.6.0",
+    "parcel-resolver-ignore": "^2.1.3",
+    "prettier": "^2.7.1",
     "pretty-quick": "^3.1.3",
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.4"
   },
   "staticFiles": {
     "staticPath": "resources/public/static"


### PR DESCRIPTION
Of note:
- fuzzysort removed allowType option (we are unaffected, but were
explicitly setting it to false)
- resolves security issue with terser package