### PR TITLE
Sitemap now includes only latest official releases

### DIFF
--- a/src/cljdoc/server/sitemap.clj
+++ b/src/cljdoc/server/sitemap.clj
@@ -2,7 +2,8 @@
   (:require [clojure.spec.alpha :as spec]
             [sitemap.core :as sitemap]
             [cljdoc.storage.api :as storage]
-            [cljdoc.server.routes :as routes]))
+            [cljdoc.server.routes :as routes]
+            [version-clj.core :as version-clj]))
 
 (spec/fdef query->url-entries
   :args (spec/cat :version :cljdoc.spec/version-entity)
@@ -18,20 +19,40 @@
     (throw (ex-info "Invalide sitemap generated" {}))
     sitemap))
 
+(defn- latest-release-version [docs]
+  (->> docs
+       (map :version)
+       (remove #(.endsWith % "-SNAPSHOT"))
+       (version-clj/version-sort)
+       last))
+
+(defn- all-latest-release-docs [db-spec]
+  (->> (storage/all-distinct-docs db-spec)
+       (group-by (juxt :group-id :artifact-id))
+       (keep (fn [[grp docs]]
+               (when-let [version (latest-release-version docs)]
+                 (conj grp version))))
+       sort
+       (map #(zipmap [:group-id :artifact-id :version] %))))
+
 (defn build [db-spec]
-  (->>
-   (storage/all-distinct-docs db-spec)
-   (map query->url-entries)
-   (sitemap/generate-sitemap)
-   (assert-valid-sitemap)))
+  (->> (all-latest-release-docs db-spec)
+       (map query->url-entries)
+       (sitemap/generate-sitemap)
+       (assert-valid-sitemap)))
 
 (comment
-  (require '[clojure.spec.test.alpha :as st])
+  (require '[clojure.spec.test.alpha :as st]
+           '[cljdoc.config :as cfg])
 
   (def db-spec
     (-> (cfg/config)
         (cfg/db)
         (storage/->SQLiteStorage)))
+
+  (all-latest-release-docs db-spec)
+
+  (build db-spec)
 
   (routes/url-for :artifact/version :path-params {:group-id "a" :artifact-id "b" :version "c"})
 


### PR DESCRIPTION
We exclude SNAPSHOT versions.
Libraries with only SNAPSHOT releases are excluded.

Although the order of URLs is not important to Google, we do now sort
our sitemap for a consistent result.

Closes #397
Closes #651