### PR TITLE
Rework library articles tips

### DIFF
--- a/doc/userguide/for-library-authors.adoc
+++ b/doc/userguide/for-library-authors.adoc
@@ -18,7 +18,7 @@ If you publish your library to https://clojars.org[Clojars], its docs should alr
 Default handling:
 
 * link:#api[API] automatically documented
-* link:#articles[Articles] include `README`, `CHANGELOG` and articles under `doc/` (else `docs/`), see link:#auto-inferred-articles[auto-inferred articles]
+* link:#articles[Articles] include `README`, `CHANGELOG` and articles under `doc/` (else `docs/`), see link:#auto-discovered-articles[auto-discovered articles]
 
 == Mechanics
 
@@ -138,7 +138,7 @@ When building your docs, cljdoc will look under the `doc` (else `docs`) director
 You can use this configuration file to tell cljdoc more about your documentation.
 
 * `:cljdoc.doc/tree` - Tells cljdoc what link:#articles[articles] to present and in what hierarchy. +
-By default, cljdoc will link:#auto-inferred-articles[automatically infer articles].
+By default, cljdoc will link:#auto-discovered-articles[automatically discover articles].
 * `:cljdoc/languages` - Tells cljdoc which link:#languages[languages] your API uses. +
 By default, cljdoc will automatically detect languages based on the sources it finds in your jar.
 * `:cljdoc/include-namespaces-from-dependencies` - Tells cljdoc to amalgamate API docs from multiple link:#modules[modules]. +
@@ -307,8 +307,8 @@ This allows cljdoc to retrieve article files at the revision/commit of the relea
 Cljdoc hosted articles will have their links link:#link-articles[rewritten to link back to cljdoc].
 All links that work on GitHub should also work on cljdoc.
 
-[[auto-inferred-articles]]
-=== Auto-inferred Articles
+[[auto-discovered-articles]]
+=== Auto-discovered Articles
 
 If your git repository does not contain a link:#article-config[doc tree configuration], cljdoc will automatically include:
 
@@ -317,7 +317,7 @@ If your git repository does not contain a link:#article-config[doc tree configur
 * `CHANGELOG.md` else `CHANGELOG.adoc`- filename search is case insensitive
 ** Title is `Changelog`
 * link:#markup[Markup] articles from your `doc/` else `docs/` folder
-** The title is read from the file's first heading. There will be no nesting and articles will be ordered alphabetically by filename. 
+** The title is read from the file's first heading. There will be no nesting and articles will be ordered alphabetically by filename.
 
 TIP: Use filenames prefixed with digits like `01-intro.md` to define the order of articles.
 
@@ -354,6 +354,8 @@ Your articles will be presented with the following hierarchy and titles:
 └── Configuration
 ----
 
+TIP: Cljdoc will always present the readme and changelog articles first.
+
 IMPORTANT: The resulting URLs for those articles will be based on the title provided in the `cljdoc.edn` file and _not_ on the filename or title within the article file.
 
 See also: link:#verifying-articles[verifying articles]
@@ -362,7 +364,7 @@ See also: link:#verifying-articles[verifying articles]
 === Article Slugs
 
 Slugs for articles are currently based on the article title.
-Titles can be link:#article-config[explicitly configured] or link:#auto-inferred-articles[inferred].
+Titles can be link:#article-config[explicitly configured] or link:#auto-discovered-articles[discovered].
 
 === AsciiDoc Environment
 

--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -134,6 +134,20 @@ function toggleMetaDialog() {
   }
 }
 
+function toggleArticlesTip() {
+  const tipToggler = document.getElementById("js--articles-tip-toggler");
+  const tip = document.getElementById("js--articles-tip");
+  if (tipToggler && tip) {
+    tipToggler.onclick = () => {
+      if (tip.classList.contains("dn")) {
+        tip.classList.remove("dn");
+      } else {
+        tip.classList.add("dn");
+      }
+    };
+  }
+}
+
 function addPrevNextPageKeyHandlers() {
   const prevLink: HTMLAnchorElement | null = document.querySelector(
     "a#prev-article-page-link"
@@ -159,6 +173,7 @@ export {
   restoreSidebarScrollPos,
   saveSidebarScrollPos,
   toggleMetaDialog,
+  toggleArticlesTip,
   isNSPage,
   isNSOfflinePage,
   isProjectDocumentationPage,

--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -139,11 +139,7 @@ function toggleArticlesTip() {
   const tip = document.getElementById("js--articles-tip");
   if (tipToggler && tip) {
     tipToggler.onclick = () => {
-      if (tip.classList.contains("dn")) {
-        tip.classList.remove("dn");
-      } else {
-        tip.classList.add("dn");
-      }
+      tip.classList.toggle("dn");
     };
   }
 }

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -11,6 +11,7 @@ import {
   initToggleRaw,
   restoreSidebarScrollPos,
   toggleMetaDialog,
+  toggleArticlesTip,
   addPrevNextPageKeyHandlers,
   saveSidebarScrollPos
 } from "./cljdoc";
@@ -66,6 +67,7 @@ if (isProjectDocumentationPage()) {
   const mobileNav = document.querySelector("#js--mobile-nav");
   mobileNav && render(<MobileNav />, mobileNav);
   toggleMetaDialog();
+  toggleArticlesTip();
   addPrevNextPageKeyHandlers();
 }
 

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -35,7 +35,7 @@
           (map (fn [doc-page]
                  (let [slug-path (-> doc-page :attrs :slug-path)]
                    [:li
-                    {:class (when (seq (:children doc-page)) "mv2")}
+                    {:class (when (seq (:children doc-page)) "mv0")}
                     [:a.link.blue.hover-dark-blue.dib.pv1
                      {:style {:word-wrap "break-word"}
                       :href  (doc-link version-entity slug-path)


### PR DESCRIPTION
Formerly we were suggesting to the reader that they might want
to glance at our Articles docs. This messaging always appeared when a
library did not have more than readme and/or changelog articles.

This did not make a ton of sense and was a bit noisy/wordy.
As raised in the issue, we now assume the library author does not need
a tip if we have found their project's cljdoc.edn config.

We instead now offer a click-able "tip" in the articles header.
It is noticeable but also subtle.
When clicked, the tip shows tip content to the user.

The tip appears when:
- there is no cljdoc.edn and we've auto-discovered articles
- there are no articles because scm cannot be found
- there are no articles in a found scm

To make this work, we've move all articles under the articles header.
Formerly readme and changelog appeared above the articles header.

The new tip more effectively serves our 2 audiences:
- the library author who might want to make a change/fix
- the doc reader who will usually ignore our tip, but if curious, can
learn more.

Also: fixed vertical spacing on article toc for tocs with hierarchy.

Closes #270