### PR TITLE
Give doc links a nice hover underline

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -36,6 +36,11 @@ pre {
   color: #357edd;
 }
 
+.cljdoc-markup a:hover {
+  text-decoration: underline;
+  color: #00449e;
+}
+
 .cljdoc-markup hr {
   height: 0.25em;
   padding: 0;

--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -38,7 +38,6 @@ pre {
 
 .cljdoc-markup a:hover {
   text-decoration: underline;
-  color: #00449e;
 }
 
 .cljdoc-markup hr {


### PR DESCRIPTION
Adds an underline to links within docs.

![Screen Shot 2022-09-02 at 2 54 01 PM](https://user-images.githubusercontent.com/130/188227028-785537b2-6a70-4af4-9da8-1fa757bdf019.png)


The link on the left is being hovered over.