### PR TITLE
Search lucene directly for Dash versions api calls

### DIFF
--- a/src/cljdoc/server/search/api.clj
+++ b/src/cljdoc/server/search/api.clj
@@ -30,15 +30,15 @@
   ;; wrap the required configuration in it, passing the type instead of the raw config
   ;; to each of the functions that need it.
   "Index and search artifacts."
-  (all-docs [_] "Return all the documents, with all the version")
+  (artifact-versions [_ refined-by] "Return all artifact versions, optionally refined-by a group-id or a group-id and artifact-id.")
   (index-artifact [_ artifact])
   (search [_ query] "Supports web app libraries search")
   (suggest [_ query] "Supports OpenSearch libraries suggest search."))
 
 (defrecord Searcher [clojars-stats ^Directory index]
   ISearcher
-  (all-docs [_]
-    (search/all-docs index))
+  (artifact-versions [_ refined-by]
+    (search/versions index refined-by))
   (index-artifact [_ artifact]
     (search/index! clojars-stats index [artifact]))
   (search [_ query]


### PR DESCRIPTION
There was an old todo that I meant to address when updating Lucene
support. Finally got to it.

When listing versions of an artifact, the cljdoc website shows built
versions. A while ago, to support the Dash offline reader, cljdoc added in
support for returning all known versions from maven and clojars.

Before this change, we cached available artifacts and their versions in
memory. The old @holyjak todo was to not bother with the cache and just
hit our Lucene index directly.

My tests indicate that this works out fine when searching for a specific
artifact or artifact group. When returning all known artifacts, the request is
heavy but most time is spent in processing the result, so seems fine too.

Although Dash will request these versions as json, our website has
support to display them as HTML. To be kinder to developers I changed
the wording in these HTML pages to describe built vs available more
clearly.

I also changed artefact to artifact in our website text. Both are
correct, but I think the US spelling is more commonly used when
describing maven/clojars artifacts.

Out of scope:
- Does Dash still need to request ALL versions? It is a heavy request,
and if we don't need it anymore, we should consider turfing it.
- While working on this I thought it might be helpful to list (and
denote) available unbuilt versions to the cljdoc website users.
But not for this PR.
- Related to prev point: we offer to goto the latest version of the
current artifact, but this can result in a 500 error if there is none.

Closes #369