### PR TITLE
Correct build log reporting

### DIFF
--- a/src/cljdoc/server/ingest.clj
+++ b/src/cljdoc/server/ingest.clj
@@ -67,7 +67,8 @@
                   :doc-tree     doc-tree}
            scm-articles (assoc :scm-articles scm-articles)))
         {:scm-url scm-url
-         :config config}))))
+         :config config
+         :commit (:rev scm)}))))
 
 (comment
 


### PR DESCRIPTION
It relies on :commit in git analysis result which I erroneously turfed thinking it was unused.

Addendum to #31