### PR TITLE
ci: deploy: retry check for cljdoc docker tag

### DIFF
--- a/modules/deploy/src/cljdoc/deploy.clj
+++ b/modules/deploy/src/cljdoc/deploy.clj
@@ -183,6 +183,4 @@
     (deploy!
      (or "0.0.1160-blue-green-8b4cdad" "0.0.1151-blue-green-c329ed1")))
 
-  (wait-until "docker tag foo exists" #(tag-exists? "0.0.2101-05f1c27") 1000 3)
-
-  )
+  (wait-until "docker tag foo exists" #(tag-exists? "0.0.2101-05f1c27") 1000 3))


### PR DESCRIPTION
It can take a while for a pushed docker image to become visible on docker hub. I have noticed sporadic failures in the past.

On 2022-10-17 I was seeing repeated failures, one case taking 20m for a pushed tag to appear. I assume this was just a bad day for docker hub.

Start with what seems to be reasonable retry timeout of 3m with 2s interval.

includes: rework of wait-until fn to do more logging