### PR TITLE
maint: bump deploy module deps

### DIFF
--- a/modules/deploy/deps.edn
+++ b/modules/deploy/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src" "resources"]
- :deps {clj-http/clj-http {:mvn/version "3.9.1"}
-        cli-matic/cli-matic {:mvn/version "0.2.10"}
-        aero/aero {:mvn/version "1.1.3"}
-        cheshire/cheshire {:mvn/version "5.8.1"}
-        org.clojure/tools.logging {:mvn/version "0.4.1"}
-        spootnik/unilog {:mvn/version "0.7.22"},
+ :deps {org.clj-commons/clj-http-lite {:mvn/version "1.0.13"}
+        cli-matic/cli-matic {:mvn/version "0.5.4"}
+        aero/aero {:mvn/version "1.1.6"}
+        cheshire/cheshire {:mvn/version "5.11.0"}
+        org.clojure/tools.logging {:mvn/version "1.2.4"}
+        spootnik/unilog {:mvn/version "0.7.31"},
         com.jcraft/jsch {:mvn/version "0.1.55"}}}

--- a/modules/deploy/src/cljdoc/deploy.clj
+++ b/modules/deploy/src/cljdoc/deploy.clj
@@ -14,7 +14,7 @@
             [clojure.pprint :as pp]
             [clojure.java.shell :as sh]
             [clojure.string :as string]
-            [clj-http.client :as http]
+            [clj-http.lite.client :as http]
             [cheshire.core :as json]
             [clojure.tools.logging :as log]
             [cli-matic.core :as cli-matic]
@@ -101,7 +101,7 @@
   "Return true if given `tag` exists in the DockerHub cljdoc/cljdoc repository."
   [tag]
   (let [status (:status (http/head (format "https://hub.docker.com/v2/repositories/cljdoc/cljdoc/tags/%s/" tag)
-                                   {:throw-exceptions? false}))]
+                                   {:throw-exceptions false}))]
     (log/info "check for existence of docker tag" tag "returned" status)
     (= 200 status)))
 
@@ -177,10 +177,12 @@
   (cli-matic/run-cmd args CONFIGURATION))
 
 (comment
-
   (with-nomad ip
     (nomad-get "/v1/deployments")
     (deploy!
      (or "0.0.1160-blue-green-8b4cdad" "0.0.1151-blue-green-c329ed1")))
 
+  ;; exists
+  (wait-until "docker tag foo exists" #(tag-exists? "0.0.2101-05f1c28") 1000 3)
+  ;; does not exist
   (wait-until "docker tag foo exists" #(tag-exists? "0.0.2101-05f1c27") 1000 3))

--- a/script/outdated.clj
+++ b/script/outdated.clj
@@ -12,7 +12,7 @@
 (defn check-clojure []
   (status/line :head "Checking Clojure deps")
   ;; antq will return 1 when there are outdated deps, so don't fail on non-zero exit
-  (shell/command {:continue true} "clojure -M:outdated"))
+  (shell/command {:continue true} "clojure -M:outdated" "--directory=.:modules/deploy"))
 
 (defn check-npm-js []
   (when (not (fs/exists? "node_modules"))


### PR DESCRIPTION
While diagnosing a deploy issue, I stumbled on some ancient deps for our deploy module. I switched from clj-http to clj-http-lite (because we use that in cljdoc itself, and we have not need for the beefier clj-http).

It all seems good, but will tweak based on success (or lack thereof) of next deploy.

Also added the deploy module to our `bb outdated` check.