### PR TITLE
css: restrict doc set search input width

### DIFF
--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -499,7 +499,7 @@ const SingleDocsetSearch = (props: { url: string }) => {
             name="single-docset-search-term"
             type="text"
             aria-describedby="single-docset-search-term-description"
-            className="input-reset ba b--black-20 pa2 pl4 db br1"
+            className="input-reset ba b--black-20 pa2 pl4 db br1 w-100"
             value={inputValue}
             disabled={!searchIndex}
             placeholder={searchIndex ? "Search..." : "Loading..."}


### PR DESCRIPTION
Doc set search input width was overflowing and getting clipped on Linux and Windows platforms.

(For whatever reason, this was not happening on macOS).

Setting the input element width to 100 ensures it will be sized to its parent width.

Closes #698