### PR TITLE
maint: bump clojure deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -26,22 +26,22 @@
         ;; relational database
         org.clojure/java.jdbc {:mvn/version "0.7.12"}        ;; jdbc abstraction
         org.xerial/sqlite-jdbc {:mvn/version "3.39.3.0"}     ;; jdbc driver needed to talk to our SQLite db
-        dev.weavejester/ragtime {:mvn/version "0.9.2"}       ;; database migrations
+        dev.weavejester/ragtime {:mvn/version "0.9.3"}       ;; database migrations
         com.mjachimowicz/ragtime-clj {:mvn/version "0.1.2"}  ;; database migration support for Clojure code migrations
         com.layerware/hugsql {:mvn/version "0.5.1"}          ;; SQL abstraction
         com.taoensso/nippy {:mvn/version "3.2.0"}            ;; fast compact serializer that we use for blobs
 
         ;; full text search database
         ;; when upgrading also a good idea to change cljdoc.server.system/index-dir
-        org.apache.lucene/lucene-core {:mvn/version "9.4.1"} ;; search engine
-        org.apache.lucene/lucene-analysis-common {:mvn/version "9.4.1"}
-        org.apache.lucene/lucene-analysis-icu {:mvn/version "9.4.1"}
-        org.apache.lucene/lucene-queryparser {:mvn/version "9.4.1"}
+        org.apache.lucene/lucene-core {:mvn/version "9.4.2"} ;; search engine
+        org.apache.lucene/lucene-analysis-common {:mvn/version "9.4.2"}
+        org.apache.lucene/lucene-analysis-icu {:mvn/version "9.4.2"}
+        org.apache.lucene/lucene-queryparser {:mvn/version "9.4.2"}
 
         ;; markdown
         org.asciidoctor/asciidoctorj {:mvn/version "2.5.7"}  ;; render adoc to html
         ;; temporarily override jruby used by asciidoctorj to overcome CVE
-        org.jruby/jruby {:mvn/version "9.3.9.0"}
+        org.jruby/jruby {:mvn/version "9.4.0.0"}
         com.vladsch.flexmark/flexmark                        ;; render github markdown to html
         {:mvn/version "0.64.0"}
         com.vladsch.flexmark/flexmark-ext-autolink           ;; converts raw links in text to clickable links
@@ -66,18 +66,18 @@
         org.clojure/tools.logging {:mvn/version "1.2.4"}     ;; logging facade
 
         ;; sentry service support
-        io.sentry/sentry-logback {:mvn/version "6.6.0"}      ;; logback appendery to Sentry service
-        raven-clj/raven-clj {:mvn/version "1.6.0"}           ;; Sentry service interface
+        io.sentry/sentry-logback {:mvn/version "6.8.0"}      ;; logback appendery to Sentry service
+        raven-clj/raven-clj {:mvn/version "1.7.0"}           ;; Sentry service interface
 
         ;; reaching out to other services
         org.eclipse.jgit/org.eclipse.jgit.ssh.jsch {:mvn/version "6.3.0.202209071007-r"} ;; git with jsch
         org.clj-commons/clj-http-lite {:mvn/version "1.0.13"} ;; a lite version of clj-http client
 
         ;; misc utils
-        babashka/fs {:mvn/version "0.1.11"}                  ;; file system utilities (a modern version of clj-commons/fs)
+        babashka/fs {:mvn/version "0.2.12"}                  ;; file system utilities (a modern version of clj-commons/fs)
         cheshire/cheshire {:mvn/version "5.11.0"}            ;; json
         clj-commons/fs {:mvn/version "1.6.310"}              ;; file system utilities
-        com.taoensso/tufte {:mvn/version "2.4.3"}            ;; profile/perf monitoring
+        com.taoensso/tufte {:mvn/version "2.4.5"}            ;; profile/perf monitoring
         lambdaisland/uri {:mvn/version "1.13.95"}            ;; URI/URLs
         org.clj-commons/digest {:mvn/version "1.4.100"}      ;; digest algs (md5, sha1, etc)
         org.clojure/core.cache {:mvn/version "1.0.225"}      ;; general caching library
@@ -98,11 +98,11 @@
            {:extra-paths ["test"]
             :extra-deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}
                          org.clojure/test.check {:mvn/version "1.1.1"}
-                         nubank/matcher-combinators {:mvn/version "3.5.1" :exclusions [midje/midje]}}
+                         nubank/matcher-combinators {:mvn/version "3.7.0" :exclusions [midje/midje]}}
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.10.14"}}
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.11.02"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :eastwood
@@ -119,8 +119,8 @@
             :main-opts [ "-m" "cljfmt.main"  "--indents" "./.cljfmt/indentation.edn"]}
 
            :outdated
-           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.1.939"}
-                           org.slf4j/slf4j-simple {:mvn/version "2.0.3"}} ;; to rid ourselves of logger warnings
+           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.2.962"}
+                           org.slf4j/slf4j-simple {:mvn/version "2.0.4"}} ;; to rid ourselves of logger warnings
             :main-opts ["-m" "antq.core"
                         "--exclude=com.layerware/hugsql@0.5.2" ;; Not sure of effect of https://github.com/layerware/hugsql/issues/138
                         "--exclude=com.layerware/hugsql@0.5.3"

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -30,7 +30,7 @@
   ;; change the index name when making incompatible changes, this will
   ;; - create a new index from scratch
   ;; - leave the old index around should we want to revert and
-  (str (cfg/data-dir env-config) "index-lucene941"))
+  (str (cfg/data-dir env-config) "index-lucene942"))
 
 (defn system-config [env-config]
   (let [ana-service (cfg/analysis-service env-config)]


### PR DESCRIPTION
Of note:
- bumped lucene, so also renamed index dir for index recreation
- there is a new version of pedestal, but it is beta, so maybe wait a bit?
- left sqlite driver unbumped for now because one db (lucene) is enough for one bump run