### PR TITLE
Indicate when a var has diffs across platforms

### DIFF
--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -105,7 +105,7 @@
             {:top-bar top-bar-component
              :main-sidebar-contents (sidebar/sidebar-contents route-params cache-bundle last-build)
              :vars-sidebar-contents (when (seq ns-defs)
-                                      [(api/platform-support-note platf-stats)
+                                      [(api/platforms-supported-note platf-stats)
                                        (api/definitions-list ns-emap ns-defs {:indicate-platforms-other-than dominant-platf})])
              :content (api/namespace-page {:ns-entity ns-emap
                                            :ns-data ns-data


### PR DESCRIPTION
Existing var annotations are `cljs`, `cljs` and `clj/s`.

A new `clj/s≠` annotation is used for vars where there are differences in docstring, arglists and/or protocol members across platforms.

When differences exist, this new annotation is always shown in the var index regardless of dominant platforms.

Var annotations now always shown for all vars in var detail view, including protocol members.

There is no var index for offline docs, but var detail is affected. Will verify macOS Dash app is ok with this after deploy and adjust as necessary.

Closes #702