### PR TITLE
Refine zprint usage to avoid throws

### DIFF
--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -1,6 +1,7 @@
 (ns cljdoc.render.api
   "Functions related to rendering API documenation"
   (:require [cljdoc.render.rich-text :as rich-text]
+            [cljdoc.render.code-fmt :as code-fmt]
             [cljdoc.util.fixref :as fixref]
             [cljdoc.util.ns-tree :as ns-tree]
             [cljdoc.bundle :as bundle]
@@ -8,15 +9,14 @@
             [cljdoc.spec]
             [cljdoc.server.routes :as routes]
             [clojure.string :as string]
-            [hiccup2.core :as hiccup]
-            [zprint.core :as zp]))
+            [hiccup2.core :as hiccup]))
 
-(defn def-code-block
+(defn def-fn-call-example
   [args-str]
   {:pre [(string? args-str)]}
   [:pre.ma0.pa0.pb3
    [:code.db {:class "language-clojure"}
-    (zp/zprint-str args-str {:parse-string? true :width 70})]])
+    (code-fmt/snippet args-str)]])
 
 (defn parse-wiki-link [m]
   (if (string/includes? m "/")
@@ -113,7 +113,7 @@
 
 (defn render-arglists [def-name arglists]
   (for [argv (sort-by count arglists)]
-    (def-code-block
+    (def-fn-call-example
       (str "(" def-name (when (seq argv) " ") (string/join " " argv) ")"))))
 
 (defn render-var-args-and-docs

--- a/src/cljdoc/render/build_log.clj
+++ b/src/cljdoc/render/build_log.clj
@@ -1,11 +1,11 @@
 (ns cljdoc.render.build-log
   (:require [clojure.string :as string]
+            [cljdoc.render.code-fmt :as code-fmt]
             [cljdoc.render.layout :as layout]
             [cljdoc.render.links :as links]
             [cljdoc.util.datetime :as dt]
             [cljdoc.server.routes :as routes]
-            [taoensso.nippy :as nippy]
-            [zprint.core :as zp])
+            [taoensso.nippy :as nippy])
   (:import [java.time Instant Duration]
            [java.time.temporal ChronoUnit]))
 
@@ -200,7 +200,7 @@
              [:p.bg-washed-red.pa3.br2 (:error build-info)]
              (when-some [ex-data (some-> build-info :error_info_map nippy/thaw)]
                [:pre.lh-copy.bg-near-white.code.pa3.br2.f6.overflow-x-scroll.nohighlight
-                (zp/zprint-str ex-data)])
+                (code-fmt/snippet (str ex-data))])
              (when (:analysis_job_uri build-info)
                [:p.lh-copy "Please see the "
                 [:a.link.blue {:href (:analysis_job_uri build-info)} "build job"]

--- a/src/cljdoc/render/code_fmt.clj
+++ b/src/cljdoc/render/code_fmt.clj
@@ -1,0 +1,26 @@
+(ns cljdoc.render.code-fmt
+  "Isolate code formatting to its own namespace.
+  We are using zprint for its widths support.
+  It has many dials and knobs, so it is worthy of its own namespace to support testing."
+  (:require [clojure.string :as string]
+            [zprint.core :as zp]
+            [zprint.config :as zpc]))
+
+;; tell zprint not to look for external default configs
+(zp/set-options! {:configured? true})
+
+;; zprint applies special styling to particular function calls,
+;; this is problematic for our use case, and can cause throws.
+(def ^:private all-fnstyles-disabled (reduce-kv (fn [m k _v] (assoc m k :none))
+                                                {}
+                                                zpc/zfnstyle))
+
+(defn snippet
+  "Return formatted version of clojure code snippet in string `s`."
+  [s]
+  (if (string/blank? s)
+    ""
+    (zp/zprint-str s {:parse-string? true
+                      :width 80
+                      :map {:comma? false}
+                      :fn-map all-fnstyles-disabled})))

--- a/test/cljdoc/render/code_fmt_test.clj
+++ b/test/cljdoc/render/code_fmt_test.clj
@@ -1,0 +1,124 @@
+(ns cljdoc.render.code-fmt-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [cljdoc.render.code-fmt :as subject]
+   [clojure.string :as string]))
+
+(deftest snippet-blanks
+  (is (= "" (subject/snippet nil)))
+  (is (= "" (subject/snippet "")))
+  (is (= "" (subject/snippet "  ")))
+  (is (= "" (subject/snippet " \r\t\n  "))))
+
+(deftest snippet-basics
+  (is (= "a" (subject/snippet "  a"))))
+
+(deftest snippet-call-examples
+  (is (= "(are we good)" (subject/snippet "(are we good)")))
+
+  (is (= (string/join "\n" ["(are just-wondering-if-we"
+                            "     {:keys [wrap long things properly]}"
+                            "     {:keys [hoping that we do]})"])
+         (subject/snippet "(are just-wondering-if-we {:keys [wrap long things properly]} {:keys [hoping that we do]})")))
+
+  (is (= (string/join "\n" ["(so-do-we {:keys [handle the case where keyword destructuring is crazy long and"
+                            "                  in itself would cause a wrap]})"])
+         (subject/snippet "(so-do-we {:keys [handle the case where keyword destructuring is crazy long and in itself would cause a wrap]})"))))
+
+(deftest snippet-error-map-example
+  (is (= ["{:cause \"clj-http: status 500\""
+          " :data {:body \"{\\\"message\\\":\\\"An internal server error occurred.\\\"}\""
+          "        :headers {\"connection\" \"keep-alive\""
+          "                  \"content-length\" \"48\""
+          "                  \"content-type\" \"application/json\""
+          "                  \"date\" \"Mon, 27 Sep 2021 08:42:51 GMT\""
+          "                  \"server\" \"nginx\""
+          "                  \"strict-transport-security\" \"max-age=15724800\""
+          "                  \"x-request-id\" \"e4c31bab-ac17-4a80-a311-4a5d72e282f7\"}"
+          "        :status 500}"
+          " :trace"
+          "   [[slingshot.support$stack_trace invoke \"support.clj\" 201]"
+          "    [clj_http.lite.client$wrap_exceptions$fn__407 invoke \"client.clj\" 36]"
+          "    [clj_http.lite.client$wrap_basic_auth$fn__475 invoke \"client.clj\" 177]"
+          "    [clj_http.lite.client$wrap_accept$fn__448 invoke \"client.clj\" 131]"
+          "    [clj_http.lite.client$wrap_accept_encoding$fn__454 invoke \"client.clj\" 145]"
+          "    [clj_http.lite.client$wrap_content_type$fn__443 invoke \"client.clj\" 124]"
+          "    [clj_http.lite.client$wrap_form_params$fn__492 invoke \"client.clj\" 202]"
+          "    [clj_http.lite.client$wrap_method$fn__487 invoke \"client.clj\" 195]"
+          "    [clj_http.lite.client$wrap_unknown_host$fn__502 invoke \"client.clj\" 218]"
+          "    [clj_http.lite.client$post invokeStatic \"client.clj\" 281]"
+          "    [clj_http.lite.client$post doInvoke \"client.clj\" 278]"
+          "    [clojure.lang.RestFn invoke \"RestFn.java\" 423]"
+          "    [cljdoc.analysis.service.CircleCI trigger_build \"service.clj\" 56]"
+          "    [cljdoc.server.api$analyze_and_import_api_BANG_ invokeStatic \"api.clj\" 17]"
+          "    [cljdoc.server.api$analyze_and_import_api_BANG_ invoke \"api.clj\" 10]"
+          "    [cljdoc.server.api$kick_off_build_BANG_$fn__28064 invoke \"api.clj\" 78]"
+          "    [clojure.core$binding_conveyor_fn$fn__5772 invoke \"core.clj\" 2034]"
+          "    [clojure.lang.AFn call \"AFn.java\" 18]"
+          "    [java.util.concurrent.FutureTask run \"FutureTask.java\" 266]"
+          "    [java.util.concurrent.ThreadPoolExecutor runWorker \"ThreadPoolExecutor.java\""
+          "     1149]"
+          "    [java.util.concurrent.ThreadPoolExecutor$Worker run"
+          "     \"ThreadPoolExecutor.java\" 624] [java.lang.Thread run \"Thread.java\" 748]]"
+          " :via [{:at [slingshot.support$stack_trace invoke \"support.clj\" 201]"
+          "        :data {:body \"{\\\"message\\\":\\\"An internal server error occurred.\\\"}\""
+          "               :headers {\"connection\" \"keep-alive\""
+          "                         \"content-length\" \"48\""
+          "                         \"content-type\" \"application/json\""
+          "                         \"date\" \"Mon, 27 Sep 2021 08:42:51 GMT\""
+          "                         \"server\" \"nginx\""
+          "                         \"strict-transport-security\" \"max-age=15724800\""
+          "                         \"x-request-id\" \"e4c31bab-ac17-4a80-a311-4a5d72e282f7\"}"
+          "               :status 500}"
+          "        :message \"clj-http: status 500\""
+          "        :type clojure.lang.ExceptionInfo}]}"]
+         ;; split lines for better diffs on failure
+         (string/split-lines
+          (subject/snippet (str ;; grabbed from a sample error_map_info from production
+                              ;; TODO: consistent ordering of maps?
+                            '{:cause "clj-http: status 500"
+                              :data {:body "{\"message\":\"An internal server error occurred.\"}",
+                                     :headers {"connection" "keep-alive",
+                                               "content-length" "48",
+                                               "content-type" "application/json",
+                                               "date" "Mon, 27 Sep 2021 08:42:51 GMT",
+                                               "server" "nginx",
+                                               "strict-transport-security" "max-age=15724800",
+                                               "x-request-id" "e4c31bab-ac17-4a80-a311-4a5d72e282f7"},
+                                     :status 500},
+                              :trace
+                              [[slingshot.support$stack_trace invoke "support.clj" 201]
+                               [clj_http.lite.client$wrap_exceptions$fn__407 invoke "client.clj" 36]
+                               [clj_http.lite.client$wrap_basic_auth$fn__475 invoke "client.clj" 177]
+                               [clj_http.lite.client$wrap_accept$fn__448 invoke "client.clj" 131]
+                               [clj_http.lite.client$wrap_accept_encoding$fn__454 invoke "client.clj" 145]
+                               [clj_http.lite.client$wrap_content_type$fn__443 invoke "client.clj" 124]
+                               [clj_http.lite.client$wrap_form_params$fn__492 invoke "client.clj" 202]
+                               [clj_http.lite.client$wrap_method$fn__487 invoke "client.clj" 195]
+                               [clj_http.lite.client$wrap_unknown_host$fn__502 invoke "client.clj" 218]
+                               [clj_http.lite.client$post invokeStatic "client.clj" 281]
+                               [clj_http.lite.client$post doInvoke "client.clj" 278]
+                               [clojure.lang.RestFn invoke "RestFn.java" 423]
+                               [cljdoc.analysis.service.CircleCI trigger_build "service.clj" 56]
+                               [cljdoc.server.api$analyze_and_import_api_BANG_ invokeStatic "api.clj" 17]
+                               [cljdoc.server.api$analyze_and_import_api_BANG_ invoke "api.clj" 10]
+                               [cljdoc.server.api$kick_off_build_BANG_$fn__28064 invoke "api.clj" 78]
+                               [clojure.core$binding_conveyor_fn$fn__5772 invoke "core.clj" 2034]
+                               [clojure.lang.AFn call "AFn.java" 18]
+                               [java.util.concurrent.FutureTask run "FutureTask.java" 266]
+                               [java.util.concurrent.ThreadPoolExecutor runWorker "ThreadPoolExecutor.java"
+                                1149]
+                               [java.util.concurrent.ThreadPoolExecutor$Worker run
+                                "ThreadPoolExecutor.java" 624] [java.lang.Thread run "Thread.java" 748]],
+                              :via [{:at [slingshot.support$stack_trace invoke "support.clj" 201],
+                                     :data {:body "{\"message\":\"An internal server error occurred.\"}",
+                                            :headers {"connection" "keep-alive",
+                                                      "content-length" "48",
+                                                      "content-type" "application/json",
+                                                      "date" "Mon, 27 Sep 2021 08:42:51 GMT",
+                                                      "server" "nginx",
+                                                      "strict-transport-security" "max-age=15724800",
+                                                      "x-request-id" "e4c31bab-ac17-4a80-a311-4a5d72e282f7"},
+                                            :status 500},
+                                     :message "clj-http: status 500",
+                                     :type clojure.lang.ExceptionInfo}]}))))))


### PR DESCRIPTION
Moved all zprint usage to new cljdoc.render.code-fmt namespace. Added tests for this new namespace to be clear as to what we expect and to protect against breakages should zprint behaviour change in the future.

Told zprint to not employ any of its special fn call formatting. This means that `(are x y z)` will no longer throw and probably fixes other scenarios.

Asking zprint to not load any default config from default locations. We don't need this feature and should avoid confusion for any cljdoc developers that might have a default zprint config lying around.

Other minor changes:
- now wrapping at 80 chars for both error maps and api call examples. was formerly wrapping at 70 for call examples.
- no longer rendering a comma after key value pairs in maps.

Close #714