### PR TITLE
Handle case: listed artifact does not resolve

### DIFF
--- a/resources/migrations/012-add-retry-count-to-releases.down.sql
+++ b/resources/migrations/012-add-retry-count-to-releases.down.sql
@@ -1,0 +1,1 @@
+-- column removal not supported in older versions of sqlite

--- a/resources/migrations/012-add-retry-count-to-releases.up.sql
+++ b/resources/migrations/012-add-retry-count-to-releases.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE releases ADD retry_count INTEGER DEFAULT 0 NOT NULL;

--- a/src/cljdoc/render/build_log.clj
+++ b/src/cljdoc/render/build_log.clj
@@ -244,7 +244,7 @@
                               count)]
     {:date (-> builds
                first
-               :analysis_triggered_ts
+               :analysis_requested_ts
                dt/->analytics-format)
      :total build-cnt
      :failed failed-build-cnt
@@ -330,7 +330,7 @@
        (into [:div.mw8.center.pv3.ph2
               [:h1 "Recent cljdoc builds"]
               (->> builds
-                   (partition-by #(-> % :analysis_triggered_ts Instant/parse
+                   (partition-by #(-> % :analysis_requested_ts Instant/parse
                                       (.truncatedTo  ChronoUnit/DAYS)))
                    (map build-aggregates)
                    (build-analytics))])

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -71,9 +71,9 @@
     (first (sql/query db-spec ["SELECT * FROM builds WHERE id = ?" build-id])))
   (recent-builds [_ days]
     (sql/query db-spec [(str "SELECT * FROM builds "
-                             "WHERE analysis_triggered_ts "
-                             "BETWEEN DATETIME('now', 'localtime', ?) "
-                             "AND DATETIME('now', 'localtime', '+1 days') "
+                             "WHERE analysis_requested_ts "
+                             "BETWEEN DATETIME('now', ?) "
+                             "AND DATETIME('now', '+1 days') "
                              "ORDER BY id DESC")
                         (str "-" days " days")]))
   (running-build [_ group-id artifact-id version]

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -73,6 +73,8 @@
 
      (when (cfg/enable-release-monitor? env-config)
        {:cljdoc/release-monitor {:db-spec  (ig/ref :cljdoc/sqlite)
+                                 :build-tracker (ig/ref :cljdoc/build-tracker)
+                                 :max-retries 10
                                  :dry-run? (not (cfg/autobuild-clojars-releases? env-config))
                                  :searcher (ig/ref :cljdoc/searcher)
                                  :tea-time (ig/ref :cljdoc/tea-time)}}))))


### PR DESCRIPTION
I have learned that that artifacts listed by clojars sometimes do not resolve. One example is an artifact with a version of just "SNAPSHOT".

The cljdoc release monitor pings clojars for new releases and will endlessly retry these unresolvable, but listed, artifacts.

There are not many cases of these, but they do generate exceptions which is confusing noise for the cljdoc devops team.

There are other flows that trigger doc builds, this change is limited to the release monitor flow. This is the one generating the logging noise.

The release monitor now does a pre-check.
The pre-check tries to resolve the artifact, if resolve returns
- 200 - good to attempt a build
- 404 - create and immediately fail build with listed-artifact-not-found
- else - requeue release, if after 10 tries, still no go, create and immediately fail build with listed-artifact-resolve-failed.

Once a build is created it is effectively no longer in the queue. Queued builds with fewer retries are favored.

Related changes of note:
- build log adjusted to key off analysis_requested_ts instead of analysis_triggered_ts, not sure why this was not already the case. It allows for our new pre-check failures where analysis_triggered_ts is not populated.
- recent builds query was having sqlite convert 'now' to a localdate. Our dates are in utc so we don't want to do that. Was harmless on prod where localdate is utc, but not great for dev where localdate is dev box specific.
- release monitor checks to clojars refined slightly. Was previously adding 1 second to last known release timestamp, now simply excluding the first release (because it was in the last release fetch).

Closes #716, closes #717