### PR TITLE
When library not found present 404 page

### DIFF
--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -23,25 +23,36 @@ function parseCljdocURI(uri: string): Library | void {
   }
 }
 
+function isErrorPage() {
+  return Boolean(document.querySelector("head > title[data-error]"));
+}
+
 function trackProjectOpened() {
-  const maxTrackedCount = 15;
-  const project = parseCljdocURI(window.location.pathname) as VisitedLibrary;
-  if (project) {
-    var previouslyOpened: VisitedLibrary[] = JSON.parse(
-      localStorage.getItem("previouslyOpened") || "[]"
-    );
-    // remove identical values
-    previouslyOpened = previouslyOpened.filter(p => !isSameProject(p, project));
-    project.last_viewed = new Date().toUTCString();
-    previouslyOpened.push(project);
-    // truncate from the front to not have localstorage grow too large
-    if (previouslyOpened.length > maxTrackedCount) {
-      previouslyOpened = previouslyOpened.slice(
-        previouslyOpened.length - maxTrackedCount,
-        previouslyOpened.length
+  if (!isErrorPage()) {
+    const maxTrackedCount = 15;
+    const project = parseCljdocURI(window.location.pathname) as VisitedLibrary;
+    if (project) {
+      var previouslyOpened: VisitedLibrary[] = JSON.parse(
+        localStorage.getItem("previouslyOpened") || "[]"
+      );
+      // remove identical values
+      previouslyOpened = previouslyOpened.filter(
+        p => !isSameProject(p, project)
+      );
+      project.last_viewed = new Date().toUTCString();
+      previouslyOpened.push(project);
+      // truncate from the front to not have localstorage grow too large
+      if (previouslyOpened.length > maxTrackedCount) {
+        previouslyOpened = previouslyOpened.slice(
+          previouslyOpened.length - maxTrackedCount,
+          previouslyOpened.length
+        );
+      }
+      localStorage.setItem(
+        "previouslyOpened",
+        JSON.stringify(previouslyOpened)
       );
     }
-    localStorage.setItem("previouslyOpened", JSON.stringify(previouslyOpened));
   }
 }
 

--- a/src/cljdoc/render/error.clj
+++ b/src/cljdoc/render/error.clj
@@ -2,12 +2,32 @@
   (:require [cljdoc.render.layout :as layout]
             [cljdoc.render.search :as search]))
 
-(defn not-found-404 [static-resources]
-  (->> [:div.pt4
-        [:div.mt5-ns.mt6-l.mw7.center.pa4.pa0-l
-         [:h1.f2.f1-ns.b ":("]
-         [:h2.f3.f2-ns.ttu "404 - Page Not Found"]
-         [:p.lh-copy.i "What library are you looking for? Find it here 👇"]
-         (search/search-form)]]
-       (layout/page {:static-resources static-resources})
+(defn- not-found-404 [static-resources {:keys [title detail]}]
+  (->> [:div
+        (layout/top-bar-generic)
+        [:div.pt4
+         [:div.mt5-ns.mt6-l.mw7.center.pa4.pa0-l
+          [:h1.f2.f1-ns.b ":("]
+          [:h2.f3.f2-ns.ttu (str  "404 - " title)]
+          (when detail
+            [:f4.f3-ns detail])
+          [:p.lh-copy.i "What library are you looking for? Find it here 👇"]
+          (search/search-form)]]]
+       (layout/page {:static-resources static-resources
+                     :title (str "cljdoc - " title)
+                     :title-attributes {:data-error "404"}})
        (str)))
+
+(defn not-found-page [static-resources]
+  (not-found-404 static-resources {:title "Page not found"}))
+
+(defn not-found-release [static-resources {:keys [project]}]
+  (not-found-404 static-resources {:title "Library not found"
+                                   :detail [:span "Could not find release " [:code project]]}))
+
+(defn not-found-artifact [static-resources {:keys [group-id artifact-id version]}]
+  (not-found-404 static-resources {:title "Library not found"
+                                   :detail [:span
+                                            "Could not find " [:code (str group-id "/" artifact-id)]
+                                            " version " [:code version]
+                                            " in any maven repository"]}))

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -89,7 +89,7 @@
                (hiccup.page/doctype :html5)
                [:html {}
                 [:head
-                 [:title (:title opts)]
+                 [:title (:title-attributes opts) (:title opts)]
                  [:meta {:charset "utf-8"}]
                  [:meta {:content (:description opts) :name "description"}]
 

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -50,7 +50,9 @@
   [{:keys [storage build-tracker analysis-service] :as deps}
    {:keys [project version jar pom scm-url scm-rev] :as coords}]
   (let [a-uris    (when-not (and jar pom)
-                    (repositories/artifact-uris project version))
+                    (or (repositories/artifact-uris project version)
+                        (throw (ex-info (format "Requested version cannot be found in configured repositories: [%s %s]" project version)
+                                        {:project project :version version}))))
         v-entity  (storage/version-entity project version)
         build-id  (build-log/analysis-requested!
                    build-tracker (:group-id v-entity) (:artifact-id v-entity) version)

--- a/src/cljdoc/util/repositories.clj
+++ b/src/cljdoc/util/repositories.clj
@@ -111,10 +111,8 @@
            (config/maven-repositories))))
 
 (defn artifact-uris [project version]
-  (if-let [repository (find-artifact-repository project version)]
-    (artifact-uris* repository project version)
-    (throw (ex-info (format "Requested version cannot be found in configured repositories: [%s %s]" project version)
-                    {:project project :version version}))))
+  (when-let [repository (find-artifact-repository project version)]
+    (artifact-uris* repository project version)))
 
 (defn assert-first [[x & rest :as xs]]
   (if (empty? rest)
@@ -147,7 +145,7 @@
   [project version]
   (if-let [local-pom (:pom (local-uris project version))]
     (slurp local-pom)
-    (-> (artifact-uris project version) :pom http/get :body)))
+    (some-> (artifact-uris project version) :pom http/get :body)))
 
 (comment
   (config/maven-repositories)

--- a/test/cljdoc/util/repositories_test.clj
+++ b/test/cljdoc/util/repositories_test.clj
@@ -1,7 +1,6 @@
 (ns cljdoc.util.repositories-test
   (:require [cljdoc.util.repositories :as repositories]
-            [clojure.test :as t])
-  (:import (clojure.lang ExceptionInfo)))
+            [clojure.test :as t]))
 
 (t/deftest find-artifact-repository-test
   (let [central "https://repo.maven.apache.org/maven2/"
@@ -15,8 +14,7 @@
     (t/is (true? (repositories/exists? clojars 'bidi)))
     (t/is (true? (repositories/exists? clojars 'org.clojure/clojure)))
     (t/is (true? (repositories/exists? central 'org.clojure/clojure))))
-  (t/is (thrown-with-msg? ExceptionInfo #"Requested version cannot be found in configured repositories"
-                          (repositories/artifact-uris 'bidi "2.1.3-SNAPSHOT")))
+  (t/is (= nil (repositories/artifact-uris 'bidi "2.1.3-SNAPSHOT")))
   (t/is (= (repositories/artifact-uris 'bidi "2.0.9-SNAPSHOT")
            {:pom "https://repo.clojars.org/bidi/bidi/2.0.9-SNAPSHOT/bidi-2.0.9-20160426.224252-1.pom",
             :jar "https://repo.clojars.org/bidi/bidi/2.0.9-SNAPSHOT/bidi-2.0.9-20160426.224252-1.jar"})))

--- a/test/cljdoc/util/sqlite_cache_test.clj
+++ b/test/cljdoc/util/sqlite_cache_test.clj
@@ -3,7 +3,8 @@
             [clojure.java.io :as io]
             [clojure.core.memoize :as memo]
             [cljdoc.util.sqlite-cache :as c])
-  (:import (java.time Instant)))
+  (:import [clojure.lang ExceptionInfo]
+           [java.time Instant]))
 
 (def database-filename "data/unit-test-cache.db")
 
@@ -21,11 +22,24 @@
                         :subname database-filename}})
 
 (defn get-memoed-for-test
-  "returns memoized fn and an underlying atom that will, if changed, change fn return value"
+  "returns memoized fn and
+  - atom `v` that will, if changed, change fn return value
+  - atom `c` that counts calls to to underlying raw function"
   [cache-config]
   (let [v (atom "original")
-        raw-fn (fn [a b] (str a "-" b "!" @v))]
-    [(c/memo-sqlite raw-fn cache-config) v]))
+        c (atom 0)
+        raw-fn (fn [a b]
+                 (swap! c inc)
+                 (cond
+                   (= "throw" a)
+                   (throw (ex-info "some unfixable problem, sorry" {}))
+
+                   (= "return-nil" a)
+                   nil
+
+                   :else
+                   (str a "-" b "!" @v)))]
+    [(c/memo-sqlite raw-fn cache-config) v c]))
 
 (defn wrap-delete-db-before [f]
   (when (.exists (io/file database-filename))
@@ -35,49 +49,76 @@
 (t/use-fixtures :once wrap-delete-db-before)
 
 (t/deftest caches
-  (let [[memoed-fn v] (get-memoed-for-test cache-config)]
+  (let [[memoed-fn v c] (get-memoed-for-test cache-config)]
     (with-redefs [c/instant-now (fn [] (Instant/parse "2019-07-25T10:15:30.00Z"))]
       (t/is (= 'cache-me!original (memoed-fn "cache" "me")))
+      (t/is (= 1 @c))
       (reset! v "new")
-      (t/is (= 'cache-me!original (memoed-fn "cache" "me"))))))
+      (t/is (= 'cache-me!original (memoed-fn "cache" "me")))
+      (t/is (= 1 @c)))))
+
+(t/deftest does-not-cache-nil-returns
+  (let [[memoed-fn _v c] (get-memoed-for-test cache-config)]
+    (with-redefs [c/instant-now (fn [] (Instant/parse "2019-07-25T10:15:30.00Z"))]
+      (t/is (= nil (memoed-fn "return-nil" "blarg")))
+      (t/is (= 1 @c))
+      (t/is (= nil (memoed-fn "return-nil" "blarg")))
+      (t/is (= 2 @c)))))
+
+(t/deftest handles-throw-from-raw-fn
+  (let [[memoed-fn _v c] (get-memoed-for-test cache-config)]
+    (with-redefs [c/instant-now (fn [] (Instant/parse "2019-07-25T10:15:30.00Z"))]
+      (t/is (thrown? ExceptionInfo (memoed-fn "throw" "blarg")))
+      (t/is (= 1 @c))
+      (t/is (thrown? ExceptionInfo (memoed-fn "throw" "blarg")))
+      (t/is (= 2 @c)))))
 
 (t/deftest refreshes_after_ttl
-  (let [[memoed-fn v] (get-memoed-for-test cache-config)
+  (let [[memoed-fn v c] (get-memoed-for-test cache-config)
         fake-time (atom "2019-07-25T10:30:45.00Z")]
     (with-redefs [c/instant-now (fn [] (Instant/parse @fake-time))]
       (t/is (= 'refresh-me!original (memoed-fn "refresh" "me")))
+      (t/is (= 1 @c))
       (reset! v "new")
       (reset! fake-time "2019-07-25T10:30:47.00Z")
       (t/is (= 'refresh-me!original (memoed-fn "refresh" "me")))
+      (t/is (= 1 @c))
       (reset! fake-time "2019-07-25T10:30:47.01Z")
-      (t/is (= 'refresh-me!new (memoed-fn "refresh" "me"))))))
+      (t/is (= 'refresh-me!new (memoed-fn "refresh" "me")))
+      (t/is (= 2 @c)))))
 
 (t/deftest can-explicitly-clear-an-item
-  (let [[memoed-fn v] (get-memoed-for-test cache-config)]
+  (let [[memoed-fn v c] (get-memoed-for-test cache-config)]
     (with-redefs [c/instant-now (fn [] (Instant/parse "2019-07-25T10:15:30.00Z"))]
       (t/is (= 'explicit-clear!original (memoed-fn "explicit" "clear")))
+      (t/is (= 1 @c))
       (reset! v "new")
       (memo/memo-clear! memoed-fn '("explicit" "clear"))
-      (t/is (= 'explicit-clear!new (memoed-fn "explicit" "clear"))))))
+      (t/is (= 'explicit-clear!new (memoed-fn "explicit" "clear")))
+      (t/is (= 2 @c)))))
 
 (t/deftest config-without-ttl-does-not-auto-refresh
-  (let [[memoed-fn v] (get-memoed-for-test (dissoc cache-config :ttl))
+  (let [[memoed-fn v c] (get-memoed-for-test (dissoc cache-config :ttl))
         fake-time (atom "2019-07-25T10:30:45.00Z")]
     (with-redefs [c/instant-now (fn [] (Instant/parse @fake-time))]
       (t/is (= 'never-refresh!original (memoed-fn "never" "refresh")))
+      (t/is (= 1 @c))
       (reset! v "new")
       (reset! fake-time "2030-07-25T10:30:47.01Z")
-      (t/is (= 'never-refresh!original (memoed-fn "never" "refresh"))))))
+      (t/is (= 'never-refresh!original (memoed-fn "never" "refresh")))
+      (t/is (= 1 @c)))))
 
 (t/deftest can-explicitly-clear-all-items
-  (let [[memoed-fn v] (get-memoed-for-test cache-config)]
+  (let [[memoed-fn v c] (get-memoed-for-test cache-config)]
     (with-redefs [c/instant-now (fn [] (Instant/parse "2019-07-25T10:15:30.00Z"))]
       (t/is (= 'clear-all!original (memoed-fn "clear" "all")))
       (t/is (= 'the-things!original (memoed-fn "the" "things")))
+      (t/is (= 2 @c))
       (reset! v "new")
       (memo/memo-clear! memoed-fn)
       (t/is (= 'clear-all!new (memoed-fn "clear" "all")))
-      (t/is (= 'the-things!new (memoed-fn "the" "things"))))))
+      (t/is (= 'the-things!new (memoed-fn "the" "things")))
+      (t/is (= 4 @c)))))
 
 (t/deftest preserves-cache-on-new-memoize
   (let [[memoed-fn _v] (get-memoed-for-test cache-config)]


### PR DESCRIPTION
Previously we only presented a page not found 404 page when a route was not found.

When a library was not we'd throw and generate a 500 error.

A library not found error happens when a user directly manipulates or scripts a cljdoc URL. You'd think this would be rare, but our logs tells us it happens enough to be worthy of addressing.

This change adjusts our existing 404 page to:
- provide a link back to the cljdoc home page (was missing)
- include some details of the library that was not found

Impacts:
- adjusted client side visit history/switcher to ignore library 404 errors
- adjusted pom db caching (in cache.db) to never cache pom that is not found (we were previously throwing on pom not found). Adjusted tests accordingly.

Closes #720