### PR TITLE
Fix: not all vars have arglists

### DIFF
--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -142,10 +142,11 @@
       (catch Throwable _ex))))
 
 (defn render-arglists [def-name arglists]
-  (if-let [calls (to-call-examples def-name arglists)]
-    (for [c calls]
-      (render-call-example c))
-    (render-call-example-bad-arglists def-name arglists)))
+  (when arglists
+    (if-let [calls (to-call-examples def-name arglists)]
+      (for [c calls]
+        (render-call-example c))
+      (render-call-example-bad-arglists def-name arglists))))
 
 (defn render-var-args-and-docs
   "Render arglists and docstring for var `d` distinguishing platform differences, if any."


### PR DESCRIPTION
Was reporting invalid arglists for vars with nil arglists, but that's silly, not all vars have arglists.

Addendum to #728