### PR TITLE
remove superflouos segments from http uris

### DIFF
--- a/src/cljdoc/util/scm.clj
+++ b/src/cljdoc/util/scm.clj
@@ -55,7 +55,7 @@
   [scm-url]
   (cond
     (string/starts-with? scm-url "http")
-    scm-url
+    (re-find #"http.*//[^/]*/[^/]*/[^/]*" scm-url)
 
     (or (string/starts-with? scm-url "git@")
         (string/starts-with? scm-url "ssh://"))

--- a/test/cljdoc/util/scm_test.clj
+++ b/test/cljdoc/util/scm_test.clj
@@ -95,6 +95,10 @@
   (t/is (= "http://gitea.heevyis.ninja/josha/formulare" (scm/http-uri "git@gitea.heevyis.ninja:josha/formulare.git")))
   (t/is (= "http://unknown-scm.com/circleci/clj-yaml" (scm/http-uri "git@unknown-scm.com:circleci/clj-yaml"))))
 
+(t/deftest http-uri-remove-extra-segments
+  (t/is (= "http://github.com/circleci/clj-yaml" (scm/http-uri "http://github.com/circleci/clj-yaml/some/extra/stuff")))
+  (t/is (= "https://github.com/circleci/clj-yaml" (scm/http-uri "https://github.com/circleci/clj-yaml/some/extra/stuff"))))
+
 (t/deftest scm-view-uri-test
   (t/is (= "https://github.com/circleci/clj-yaml/blob/master/README.md" (scm/branch-url {:url "https://github.com/circleci/clj-yaml", :branch "master"} "README.md")))
   (t/is (= "https://git.sr.ht/~miikka/clj-branca/tree/master/README.md" (scm/branch-url {:url "https://git.sr.ht/~miikka/clj-branca", :branch "master"} "README.md")))


### PR DESCRIPTION
This fixes an issue with extra segments in the SCM URL field:

    <scm>
      <url>https://github.com/pitch-io/uix/tree/master/core</url>
      <tag>33de62e1f0425aaeb5249a589f0cc5c98a848f0f</tag>
      <connection></connection>
      <developerConnection></developerConnection>
    </scm>

Would previously attempt to clone from `git@github.com:pitch-io/uix/tree/master/core.git`

Leading to a `clone-failed` error in [builds like this one](https://cljdoc.org/builds/65965).

With this change we do not allow more than 2 segments after the domain which I think should work with all SCM services we integrate with.