### PR TITLE
Expose cache-bundle via the API

### DIFF
--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -595,11 +595,11 @@
                      :body (json/generate-string {:error "Could not find data, please request a build first"})})
                   (assoc ctx :response)))}))
 
-(def api-cache-bundle
-  "Creates an API response with a JSON representation of a cache bundle."
+(def api-docsets
+  "Creates an API response with a JSON representation of a cache bundle as a `docset`."
   (interceptor/interceptor
-   {:name ::api/cache-bundle
-    :enter (fn api-cache-bundle [{:keys [cache-bundle] :as ctx}]
+   {:name ::api/docsets
+    :enter (fn api-docsets [{:keys [cache-bundle] :as ctx}]
              (->> (if cache-bundle
                     {:status 200
                      :headers {"Content-Type" "application/json"}
@@ -639,9 +639,9 @@
                          (artifact-data-loader storage)
                          api-searchset]
 
-         :api/cache-bundle [(pom-loader cache)
-                            (artifact-data-loader storage)
-                            api-cache-bundle]
+         :api/docsets [(pom-loader cache)
+                       (artifact-data-loader storage)
+                       api-docsets]
 
          :ping          [(interceptor/interceptor {:name ::pong :enter #(pu/ok-html % "pong")})]
          :request-build [(body/body-params) request-build-validate (request-build deps)]

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -595,6 +595,20 @@
                      :body (json/generate-string {:error "Could not find data, please request a build first"})})
                   (assoc ctx :response)))}))
 
+(def api-cache-bundle
+  "Creates an API response with a JSON representation of a cache bundle."
+  (interceptor/interceptor
+   {:name ::api/cache-bundle
+    :enter (fn api-cache-bundle [{:keys [cache-bundle] :as ctx}]
+             (->> (if cache-bundle
+                    {:status 200
+                     :headers {"Content-Type" "application/json"}
+                     :body (json/generate-string cache-bundle)}
+                    {:status 404
+                     :headers {"Content-Type" "application/json"}
+                     :body (json/generate-string {:error "Could not find data, please request a build first"})})
+                  (assoc ctx :response)))}))
+
 (defn route-resolver
   "Given a route name return a list of interceptors to handle requests
   to that route.
@@ -624,6 +638,10 @@
          :api/searchset [(pom-loader cache)
                          (artifact-data-loader storage)
                          api-searchset]
+
+         :api/cache-bundle [(pom-loader cache)
+                            (artifact-data-loader storage)
+                            api-cache-bundle]
 
          :ping          [(interceptor/interceptor {:name ::pong :enter #(pu/ok-html % "pong")})]
          :request-build [(body/body-params) request-build-validate (request-build deps)]

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -25,7 +25,7 @@
     ["/api/search" :get nop :route-name :api/search]
     ["/api/search-suggest" :get nop :route-name :api/search-suggest]
     ["/api/searchset/:group-id/:artifact-id/:version" :get nop :route-name :api/searchset]
-    ["/api/cache-bundle/:group-id/:artifact-id/:version" :get nop :route-name :api/cache-bundle]})
+    ["/api/docsets/:group-id/:artifact-id/:version" :get nop :route-name :api/cache-bundle]})
 
 (defn build-log-routes []
   #{["/builds/:id" :get nop :route-name :show-build]

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -24,7 +24,8 @@
     ["/api/request-build2" :post nop :route-name :request-build]
     ["/api/search" :get nop :route-name :api/search]
     ["/api/search-suggest" :get nop :route-name :api/search-suggest]
-    ["/api/searchset/:group-id/:artifact-id/:version" :get nop :route-name :api/searchset]})
+    ["/api/searchset/:group-id/:artifact-id/:version" :get nop :route-name :api/searchset]
+    ["/api/cache-bundle/:group-id/:artifact-id/:version" :get nop :route-name :api/cache-bundle]})
 
 (defn build-log-routes []
   #{["/builds/:id" :get nop :route-name :show-build]

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -25,7 +25,7 @@
     ["/api/search" :get nop :route-name :api/search]
     ["/api/search-suggest" :get nop :route-name :api/search-suggest]
     ["/api/searchset/:group-id/:artifact-id/:version" :get nop :route-name :api/searchset]
-    ["/api/docsets/:group-id/:artifact-id/:version" :get nop :route-name :api/docsets]})
+    ["/experiments/cora/api/docsets/:group-id/:artifact-id/:version" :get nop :route-name :api/docsets]})
 
 (defn build-log-routes []
   #{["/builds/:id" :get nop :route-name :show-build]

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -25,7 +25,7 @@
     ["/api/search" :get nop :route-name :api/search]
     ["/api/search-suggest" :get nop :route-name :api/search-suggest]
     ["/api/searchset/:group-id/:artifact-id/:version" :get nop :route-name :api/searchset]
-    ["/api/docsets/:group-id/:artifact-id/:version" :get nop :route-name :api/cache-bundle]})
+    ["/api/docsets/:group-id/:artifact-id/:version" :get nop :route-name :api/docsets]})
 
 (defn build-log-routes []
   #{["/builds/:id" :get nop :route-name :show-build]


### PR DESCRIPTION
I'm spiking on an experiment to expose the cache-bundle via the API in order decouple the frontend and the backend. This should enable me (and others) to experiment with different frontends a little more. I'm not sure on the naming here or if there's any formatting we'd like to apply to this data before sending it back but this is the raw, simple version.

```
❯ curl 'http://localhost:8000/api/docsets/babashka/fs/0.1.6' | gron | head -10
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 30610    0 30610    0     0  1386k      0 --:--:-- --:--:-- --:--:-- 1992k
json = {};
json.defs = [];
json.defs[0] = {};
json.defs[0].arglists = [];
json.defs[0].arglists[0] = [];
json.defs[0].arglists[0][0] = "joined-paths";
json.defs[0].doc = "Splits a string joined by the OS-specific path-seperator into a vec of paths.\n";
json.defs[0].file = "babashka/fs.cljc";
json.defs[0].line = 754;
json.defs[0].name = "split-paths";
```


