### PR TITLE
build log: don't attempt to truncate to short sha

### DIFF
--- a/src/cljdoc/render/build_log.clj
+++ b/src/cljdoc/render/build_log.clj
@@ -115,9 +115,7 @@
          (string/replace (:scm_url build-info) #"^https://github\.com/" "")]
         " @ "
         [:a.link.blue {:href (str (:scm_url build-info) "/commit/" (:commit_sha build-info))}
-         (if (< (count (:commit_sha build-info)) 8)
-           (:commit_sha build-info)
-           (subs (:commit_sha build-info) 0 8))]]))
+         (:commit_sha build-info)]]))
 
     (:git_problem build-info)
     (section


### PR DESCRIPTION
The build log was trying to distinguish a version tag vs a sha based on length only and then truncating a sha to a short-sha.

This is too naive and is truncating version tags longer than 8 chars.

For now we'll just blurp out the whole version/sha. To me this looks fine and is acceptable for a low traffic web page.

If we ever want to revisit, we'll have cljdoc store the necessary info in the build log so the render code does not have to make naive guesses.

Closes #757