### PR TITLE
maint: bump deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,20 +8,12 @@
         integrant/repl {:mvn/version "0.3.2"}                ;;  with reload support
 
         ;; web server/services
-        io.pedestal/pedestal.jetty {:mvn/version "0.5.10"}   ;; web site/service with jetty engine
-        io.pedestal/pedestal.service {:mvn/version "0.5.10"} ;; web site/service
+        io.pedestal/pedestal.jetty {:mvn/version "0.5.11-beta-1"}   ;; web site/service with jetty engine
+        io.pedestal/pedestal.service {:mvn/version "0.5.11-beta-1"} ;; web site/service
         co.deps/ring-etag-middleware {:mvn/version "0.2.1"}  ;; fast checksum based ETags for http responses
         ;; override pedestal dep on old dep that generate warning noise for clojure 1.11,
         ;; delete override when pedestal updates:
         org.clojure/tools.analyzer.jvm {:mvn/version "1.2.3"}
-        ;; override pedestal jetty deps for CVEs (delete all when pedestal addresses)
-        org.eclipse.jetty/jetty-server {:mvn/version "9.4.48.v20220622"}
-        org.eclipse.jetty/jetty-servlet {:mvn/version "9.4.48.v20220622"}
-        org.eclipse.jetty/jetty-alpn-server {:mvn/version "9.4.48.v20220622"}
-        org.eclipse.jetty.http2/http2-server {:mvn/version "9.4.48.v20220622"}
-        org.eclipse.jetty.websocket/websocket-api {:mvn/version "9.4.48.v20220622"}
-        org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.48.v20220622"}
-        org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.48.v20220622"}
         ;; pedestal -> ring dep override to address CVE (delete when pedestals addresses)
         commons-fileupload/commons-fileupload {:mvn/version "1.5"}
 
@@ -80,7 +72,7 @@
         cheshire/cheshire {:mvn/version "5.11.0"}            ;; json
         clj-commons/fs {:mvn/version "1.6.310"}              ;; file system utilities
         com.taoensso/tufte {:mvn/version "2.4.5"}            ;; profile/perf monitoring
-        lambdaisland/uri {:mvn/version "1.13.95"}            ;; URI/URLs
+        lambdaisland/uri {:mvn/version "1.14.120"}           ;; URI/URLs
         org.clj-commons/digest {:mvn/version "1.4.100"}      ;; digest algs (md5, sha1, etc)
         org.clojure/core.cache {:mvn/version "1.0.225"}      ;; general caching library
         org.clojure/core.memoize {:mvn/version "1.0.257"}    ;; function caching library
@@ -100,7 +92,7 @@
            {:extra-paths ["test"]
             :extra-deps {lambdaisland/kaocha {:mvn/version "1.80.1274"}
                          org.clojure/test.check {:mvn/version "1.1.1"}
-                         nubank/matcher-combinators {:mvn/version "3.8.4" :exclusions [midje/midje]}}
+                         nubank/matcher-combinators {:mvn/version "3.8.5" :exclusions [midje/midje]}}
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo

--- a/ops/nvd-suppressions.xml
+++ b/ops/nvd-suppressions.xml
@@ -54,4 +54,12 @@
    <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority\-map@.*$</packageUrl>
    <cpe>cpe:/a:priority-software:priority</cpe>
   </suppress>
+  <suppress>
+   <notes><![CDATA[
+   Google has marked the risky Guava function as deprecated and, at the time of this writing, will do no more.
+   https://github.com/google/guava/issues/4011
+   Guava is brought in by by owasp-java-html-sanitizer.
+   ]]></notes>
+   <cve>CVE-2020-8908</cve>
+  </suppress>
 </suppressions>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1658,9 +1658,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001469",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
-      "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "dev": true,
       "funding": [
         {
@@ -1670,6 +1670,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -1937,9 +1941,9 @@
       "integrity": "sha512-5YM9LFQgVYfuLNEoqMqVWIBuF2UNCA+xu/jz1TyryLN/wmBcQSb+GNAwvLKvEpGESwgGN8XA1nbLAt6rKlyHYQ=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.339",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.339.tgz",
-      "integrity": "sha512-MSXHBJGcbBydq/DQDlpBeUKnJ6C7aTiNCTRpfDV5Iz0sNr/Ng6RJFloq82AAicp/SrmDq4zF6XsKG0B8Xwn1UQ==",
+      "version": "1.4.341",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.341.tgz",
+      "integrity": "sha512-R4A8VfUBQY9WmAhuqY5tjHRf5fH2AAf6vqitBOE0y6u2PgHgqHSrhZmu78dIX3fVZtjqlwJNX1i2zwC3VpHtQQ==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -2946,9 +2950,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.1.tgz",
-      "integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==",
+      "version": "10.13.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.2.tgz",
+      "integrity": "sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"


### PR DESCRIPTION
Of note:
- decided to bump pedestal to the 0.5.11 beta 1 release, it has been out for over 4 months, so... good? This gets rid of a bunch of jetty CVE overrides.
- the database our CVE scanner uses corrected a rule for Guava which is brought in by owasp html sanitizer. Google has addressed the CVE by deprecating the offending code. Suppressed the warning for this CVE for nvd scanner.
- bump for lambdaisland/uri addresses CVE