### PR TITLE
maint: bump antq

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,12 +10,12 @@
         ;; web server/services
         io.pedestal/pedestal.jetty {:mvn/version "0.5.11-beta-1"}   ;; web site/service with jetty engine
         ;; override pedestal jetty 9.4.48 deps to overcome CVEs (delete/recheck after bumping pedetal.jetty)
-        org.eclipse.jetty/jetty-servlet {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.http2/http2-server {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-api {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty/jetty-alpn-server {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty/jetty-servlet ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty.http2/http2-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty.websocket/websocket-api ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty.websocket/websocket-servlet ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty.websocket/websocket-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty/jetty-alpn-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
 
         co.deps/ring-etag-middleware {:mvn/version "0.2.1"}  ;; fast checksum based ETags for http responses
         ;; override pedestal dep on old dep that generate warning noise for clojure 1.11,
@@ -120,7 +120,7 @@
             :main-opts [ "-m" "cljfmt.main"  "--indents" "./.cljfmt/indentation.edn"]}
 
            :outdated
-           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.3.1043"}
+           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.4.1062"}
                            org.slf4j/slf4j-simple {:mvn/version "2.0.7"}} ;; to rid ourselves of logger warnings
             :main-opts ["-m" "antq.core"
                         "--exclude=com.layerware/hugsql@0.5.2" ;; Not sure of effect of https://github.com/layerware/hugsql/issues/138


### PR DESCRIPTION
Take advantage of cool new antq feature to ignore jetty 10.x and 11.x release streams.