### PR TITLE
maint: bump deps + auto lucene dir

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,26 +33,25 @@
         com.taoensso/nippy {:mvn/version "3.2.0"}            ;; fast compact serializer that we use for blobs
 
         ;; full text search database
-        ;; when upgrading also a good idea to change cljdoc.server.system/index-dir
-        org.apache.lucene/lucene-core {:mvn/version "9.5.0"} ;; search engine
-        org.apache.lucene/lucene-analysis-common {:mvn/version "9.5.0"}
-        org.apache.lucene/lucene-analysis-icu {:mvn/version "9.5.0"}
-        org.apache.lucene/lucene-queryparser {:mvn/version "9.5.0"}
+        org.apache.lucene/lucene-core {:mvn/version "9.6.0"} ;; search engine
+        org.apache.lucene/lucene-analysis-common {:mvn/version "9.6.0"}
+        org.apache.lucene/lucene-analysis-icu {:mvn/version "9.6.0"}
+        org.apache.lucene/lucene-queryparser {:mvn/version "9.6.0"}
 
         ;; markdown
         org.asciidoctor/asciidoctorj {:mvn/version "2.5.8"}  ;; render adoc to html
         ;; temporarily override jruby used by asciidoctorj to overcome CVE (delete/recheck after bumping asciidoctorj)
         org.jruby/jruby {:mvn/version "9.4.2.0"}
         com.vladsch.flexmark/flexmark                        ;; render github markdown to html
-        {:mvn/version "0.64.0"}
+        {:mvn/version "0.64.4"}
         com.vladsch.flexmark/flexmark-ext-autolink           ;; converts raw links in text to clickable links
-        {:mvn/version "0.64.0"}
+        {:mvn/version "0.64.4"}
         com.vladsch.flexmark/flexmark-ext-tables             ;; support for tables
-        {:mvn/version "0.64.0"}
+        {:mvn/version "0.64.4"}
         com.vladsch.flexmark/flexmark-ext-anchorlink         ;; adds github id style anchor links to headings
-        {:mvn/version "0.64.0"}
+        {:mvn/version "0.64.4"}
         com.vladsch.flexmark/flexmark-ext-wikilink           ;; support for our docstring [[my-ns/var]] link feature
-        {:mvn/version "0.64.0"}
+        {:mvn/version "0.64.4"}
 
         ;; html
         hiccup/hiccup {:mvn/version "2.0.0-alpha2"}          ;; html abstraction
@@ -75,7 +74,7 @@
         org.clj-commons/clj-http-lite {:mvn/version "1.0.13"} ;; a lite version of clj-http client
 
         ;; misc utils
-        babashka/fs {:mvn/version "0.3.17"}                  ;; file system utilities (a modern version of clj-commons/fs)
+        babashka/fs {:mvn/version "0.4.18"}                  ;; file system utilities (a modern version of clj-commons/fs)
         cheshire/cheshire {:mvn/version "5.11.0"}            ;; json
         clj-commons/fs {:mvn/version "1.6.310"}              ;; file system utilities
         com.taoensso/tufte {:mvn/version "2.4.5"}            ;; profile/perf monitoring
@@ -97,7 +96,7 @@
  :paths ["src" "resources" "resources-compiled"]
  :aliases {:test
            {:extra-paths ["test"]
-            :extra-deps {lambdaisland/kaocha {:mvn/version "1.82.1306"}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.83.1314"}
                          org.clojure/test.check {:mvn/version "1.1.1"}
                          nubank/matcher-combinators {:mvn/version "3.8.5" :exclusions [midje/midje]}}
             :main-opts ["-m" "kaocha.runner"]}
@@ -120,7 +119,7 @@
             :main-opts [ "-m" "cljfmt.main"  "--indents" "./.cljfmt/indentation.edn"]}
 
            :outdated
-           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.4.1062"}
+           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.4.1070"}
                            org.slf4j/slf4j-simple {:mvn/version "2.0.7"}} ;; to rid ourselves of logger warnings
             :main-opts ["-m" "antq.core"
                         "--exclude=com.layerware/hugsql@0.5.2" ;; Not sure of effect of https://github.com/layerware/hugsql/issues/138

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "elasticlunr": "^0.9.5",
         "fuzzysort": "^2.0.4",
         "idb": "^7.1.1",
-        "preact": "^10.13.1"
+        "preact": "^10.14.0"
       },
       "devDependencies": {
         "@parcel/packager-xml": "^2.8.3",
@@ -1811,9 +1811,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001481",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
-      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
       "dev": true,
       "funding": [
         {
@@ -2193,9 +2193,9 @@
       "integrity": "sha512-5YM9LFQgVYfuLNEoqMqVWIBuF2UNCA+xu/jz1TyryLN/wmBcQSb+GNAwvLKvEpGESwgGN8XA1nbLAt6rKlyHYQ=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.377",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.377.tgz",
-      "integrity": "sha512-H3BYG6DW5Z+l0xcfXaicJGxrpA4kMlCxnN71+iNX+dBLkRMOdVJqFJiAmbNZZKA1zISpRg17JR03qGifXNsJtw==",
+      "version": "1.4.394",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.394.tgz",
+      "integrity": "sha512-0IbC2cfr8w5LxTz+nmn2cJTGafsK9iauV2r5A5scfzyovqLrxuLoxOHE5OBobP3oVIggJT+0JfKnw9sm87c8Hw==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -2838,12 +2838,12 @@
       }
     },
     "node_modules/msgpackr": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
-      "integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.1.tgz",
+      "integrity": "sha512-jJdrNH8tzfCtT0rjPFryBXjRDQE7rqfLkah4/8B4gYa7NNZYFBcGxqWBtfQpGC+oYyBwlkj3fARk4aooKNPHxg==",
       "dev": true,
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.1"
+        "msgpackr-extract": "^3.0.2"
       }
     },
     "node_modules/msgpackr-extract": {
@@ -3216,9 +3216,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.13.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.2.tgz",
-      "integrity": "sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==",
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.14.0.tgz",
+      "integrity": "sha512-4oh2sf208mKAdL5AQtzXxE387iSGNWMX/YjwMjH6m/XROILKAmx5Pbs2FsXrW7ixoVGGjpfYSBB833vOwYxNxw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -3479,9 +3479,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
-      "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
+      "version": "5.17.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.3.tgz",
+      "integrity": "sha512-AudpAZKmZHkG9jueayypz4duuCFJMMNGRMwaPvQKWfxKedh8Z2x3OCoDqIIi1xx5+iwx1u6Au8XQcc9Lke65Yg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "elasticlunr": "^0.9.5",
     "fuzzysort": "^2.0.4",
     "idb": "^7.1.1",
-    "preact": "^10.13.1"
+    "preact": "^10.14.0"
   },
   "devDependencies": {
     "@parcel/packager-xml": "^2.8.3",

--- a/src/cljdoc/server/system.clj
+++ b/src/cljdoc/server/system.clj
@@ -9,6 +9,7 @@
             [cljdoc.util.sentry]
             [cljdoc.util.repositories :as repos]
             [cljdoc.util.sqlite-cache :as sqlite-cache]
+            [clojure.string :as string]
             [clojure.tools.logging :as log]
             [clojure.java.io :as io]
             [integrant.core :as ig]
@@ -30,10 +31,12 @@
                [{:appender :sentry}])})
 
 (defn index-dir [env-config]
-  ;; change the index name when making incompatible changes, this will
-  ;; - create a new index from scratch
-  ;; - leave the old index around should we want to revert and
-  (str (fs/file (cfg/data-dir env-config) "index-lucene950")))
+  (let [lucene-version (-> (org.apache.lucene.util.Version/LATEST)
+                           str
+                           (string/replace "." "_"))
+
+        dir-name (str "index-lucene-" lucene-version)]
+    (str (fs/file (cfg/data-dir env-config) dir-name))))
 
 (defn system-config [env-config]
   (let [ana-service (cfg/analysis-service env-config)]


### PR DESCRIPTION
Now automatically including current lucene version in lucene index dir name. This avoids me forgetting to do this manually when bumping lucene.

Bumping flexmark, as expected (but checked anyway), did not fix https://github.com/vsch/flexmark-java/issues/551