### PR TITLE
maint: bump deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,14 +8,7 @@
         integrant/repl {:mvn/version "0.3.2"}                ;;  with reload support
 
         ;; web server/services
-        io.pedestal/pedestal.jetty {:mvn/version "0.5.11-beta-1"}   ;; web site/service with jetty engine
-        ;; override pedestal jetty 9.4.48 deps to overcome CVEs (delete/recheck after bumping pedetal.jetty)
-        org.eclipse.jetty/jetty-servlet ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.http2/http2-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-api ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-servlet ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty/jetty-alpn-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
+        io.pedestal/pedestal.jetty {:mvn/version "0.6.0-beta-2"}   ;; web site/service with jetty engine
 
         co.deps/ring-etag-middleware {:mvn/version "0.2.1"}  ;; fast checksum based ETags for http responses
         ;; override pedestal dep on old dep that generate warning noise for clojure 1.11,
@@ -60,13 +53,15 @@
         sitemap/sitemap {:mvn/version "0.4.0"}               ;; web sitemap generation
         com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer
         {:mvn/version "20220608.1"}                          ;; sanitize html converted from user markdown
+        ;; to overcome CVE in owasp-java-html-sanitizer deps, delete when addressed in sanitizer lib
+        com.google.guava/guava {:mvn/version "32.0.0-jre"}
 
         ;; logging
         spootnik/unilog {:mvn/version "0.7.31"}              ;; easy log setup
         org.clojure/tools.logging {:mvn/version "1.2.4"}     ;; logging facade
 
         ;; sentry service support
-        io.sentry/sentry-logback {:mvn/version "6.20.0"}     ;; logback appendery to Sentry service
+        io.sentry/sentry-logback {:mvn/version "6.21.0"}     ;; logback appendery to Sentry service
         raven-clj/raven-clj {:mvn/version "1.7.0"}           ;; Sentry service interface
 
         ;; reaching out to other services

--- a/ops/docker/Dockerfile
+++ b/ops/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-alpine
 
-ENV CLOJURE_VERSION=1.11.1.1155
+ENV CLOJURE_VERSION=1.11.1.1347
 
 WORKDIR /tmp
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,10 @@
         "@types/lunr": "^2.3.4",
         "parcel": "^2.9.1",
         "parcel-reporter-static-files-copy": "^1.5.0",
-        "parcel-resolver-ignore": "^2.1.3",
+        "parcel-resolver-ignore": "^2.1.5",
         "prettier": "^2.8.8",
         "pretty-quick": "^3.1.3",
-        "typescript": "^5.0.4"
+        "typescript": "^5.1.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1589,9 +1589,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.60.tgz",
-      "integrity": "sha512-dWfic7sVjnrStzGcMWakHd2XPau8UXGPmFUTkx6xGX+DOVtfAQVzG6ZW7ohw/yNcTqI05w6Ser26XMTMGBgXdA==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.62.tgz",
+      "integrity": "sha512-J58hWY+/G8vOr4J6ZH9hLg0lMSijZtqIIf4HofZezGog/pVX6sJyBJ40dZ1ploFkDIlWTWvJyqtpesBKS73gkQ==",
       "dev": true,
       "hasInstallScript": true,
       "engines": {
@@ -1602,16 +1602,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.60",
-        "@swc/core-darwin-x64": "1.3.60",
-        "@swc/core-linux-arm-gnueabihf": "1.3.60",
-        "@swc/core-linux-arm64-gnu": "1.3.60",
-        "@swc/core-linux-arm64-musl": "1.3.60",
-        "@swc/core-linux-x64-gnu": "1.3.60",
-        "@swc/core-linux-x64-musl": "1.3.60",
-        "@swc/core-win32-arm64-msvc": "1.3.60",
-        "@swc/core-win32-ia32-msvc": "1.3.60",
-        "@swc/core-win32-x64-msvc": "1.3.60"
+        "@swc/core-darwin-arm64": "1.3.62",
+        "@swc/core-darwin-x64": "1.3.62",
+        "@swc/core-linux-arm-gnueabihf": "1.3.62",
+        "@swc/core-linux-arm64-gnu": "1.3.62",
+        "@swc/core-linux-arm64-musl": "1.3.62",
+        "@swc/core-linux-x64-gnu": "1.3.62",
+        "@swc/core-linux-x64-musl": "1.3.62",
+        "@swc/core-win32-arm64-msvc": "1.3.62",
+        "@swc/core-win32-ia32-msvc": "1.3.62",
+        "@swc/core-win32-x64-msvc": "1.3.62"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -1623,9 +1623,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.60.tgz",
-      "integrity": "sha512-oCDKWGdSO1WyErduGfiITRDoq7ZBt9PXETlhi8BGKH/wCc/3mfSNI9wXAg3Stn8mrT0lUJtdsnwMI/eZp6dK+A==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.62.tgz",
+      "integrity": "sha512-MmGilibITz68LEje6vJlKzc2gUUSgzvB3wGLSjEORikTNeM7P8jXVxE4A8fgZqDeudJUm9HVWrxCV+pHDSwXhA==",
       "cpu": [
         "arm64"
       ],
@@ -1639,9 +1639,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.60.tgz",
-      "integrity": "sha512-pcE/1oUlmN/BkKndOPtViqTkaM5pomagXATo+Muqn4QNMnkSOEVcmF9T3Lr3nB1A7O/fwCew3/aHwZ5B2TZ1tA==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.62.tgz",
+      "integrity": "sha512-Xl93MMB3sCWVlYWuQIB+v6EQgzoiuQYK5tNt9lsHoIEVu2zLdkQjae+5FUHZb1VYqCXIiWcULFfVz0R4Sjb7JQ==",
       "cpu": [
         "x64"
       ],
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.60.tgz",
-      "integrity": "sha512-Moc+86SWcbPr06PaQYUb0Iwli425F7QgjwTCNEPYA6OYUsjaJhXMaHViW2WdGIXue2+eaQbg31BHQd14jXcoBg==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.62.tgz",
+      "integrity": "sha512-nJsp6O7kCtAjTTMcIjVB0g5y1JNiYAa5q630eiwrnaHUusEFoANDdORI3Z9vXeikMkng+6yIv9/V8Rb093xLjQ==",
       "cpu": [
         "arm"
       ],
@@ -1671,9 +1671,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.60.tgz",
-      "integrity": "sha512-pPGZrTgSXBvp6IrXPXz8UJr82AElf8hMuK4rNHmLGDCqrWnRIFLUpiAsc2WCFIgdwqitZNQoM+F2vbceA/bkKg==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.62.tgz",
+      "integrity": "sha512-XGsV93vpUAopDt5y6vPwbK1Nc/MlL55L77bAZUPIiosWD1cWWPHNtNSpriE6+I+JiMHe0pqtfS/SSTk6ZkFQVw==",
       "cpu": [
         "arm64"
       ],
@@ -1687,9 +1687,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.60.tgz",
-      "integrity": "sha512-HSFQaVUkjWYNsQeymAQ3IPX3csRQvHe6MFyqPfvCCQ4dFlxPvlS7VvNaLnGG+ZW1ek7Lc+hEX+4NGzZKsxDIHA==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.62.tgz",
+      "integrity": "sha512-ESUmJjSlTTkoBy9dMG49opcNn8BmviqStMhwyeD1G8XRnmRVCZZgoBOKdvCXmJhw8bQXDhZumeaTUB+OFUKVXg==",
       "cpu": [
         "arm64"
       ],
@@ -1703,9 +1703,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.60.tgz",
-      "integrity": "sha512-WJt/X6HHM3/TszckRA7UKMXec3FHYsB9xswQbIYxN4bfTQodu3Rc8bmpHYtFO7ScMLrhY+RljHLK6wclPvaEXw==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.62.tgz",
+      "integrity": "sha512-wnHJkt3ZBrax3SFnUHDcncG6mrSg9ZZjMhQV9Mc3JL1x1s1Gy9rGZCoBNnV/BUZWTemxIBcQbANRSDut/WO+9A==",
       "cpu": [
         "x64"
       ],
@@ -1719,9 +1719,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.60.tgz",
-      "integrity": "sha512-DGGBqAPUXy/aPMBKokL3osZC9kM97HchiDPuprzwgTMP40YQ3hGCzNJ5jK7sOk9Tc4PEdZ2Igfr9sBHmCrxxQw==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.62.tgz",
+      "integrity": "sha512-9oRbuTC/VshB66Rgwi3pTq3sPxSTIb8k9L1vJjES+dDMKa29DAjPtWCXG/pyZ00ufpFZgkGEuAHH5uqUcr1JQg==",
       "cpu": [
         "x64"
       ],
@@ -1735,9 +1735,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.60.tgz",
-      "integrity": "sha512-wQg/BZPJvp5WpUbsBp7VHjhUh0DfYOPhP6dH67WO9QQ07+DvOk2DR2Bfh0z0ts1k7H/FsAqExWtTDCWMCRJiRQ==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.62.tgz",
+      "integrity": "sha512-zv14vlF2VRrxS061XkfzGjCYnOrEo5glKJjLK5PwUKysIoVrx/L8nAbFxjkX5cObdlyoqo+ekelyBPAO+4bS0w==",
       "cpu": [
         "arm64"
       ],
@@ -1751,9 +1751,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.60.tgz",
-      "integrity": "sha512-nqkd0XIVyGbnBwAxP4GIfx6n45/hAPETpmQYpDSGnucOKFJfvGdFGL81GDG1acPCq/oFtR3tIyTbPpKmJ0N6xQ==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.62.tgz",
+      "integrity": "sha512-8MC/PZQSsOP2iA/81tAfNRqMWyEqTS/8zKUI67vPuLvpx6NAjRn3E9qBv7iFqH79iqZNzqSMo3awnLrKZyFbcw==",
       "cpu": [
         "ia32"
       ],
@@ -1767,9 +1767,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.60",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.60.tgz",
-      "integrity": "sha512-ouw+s22i9PYQpSE7Xc+ZittEyA87jElXABesviSpP+jgHt10sM5KFUpVAeV8DRlxJCXMJJ5AhOdCf4TAtFr+6A==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.62.tgz",
+      "integrity": "sha512-GJSmUJ95HKHZXAxiuPUmrcm/S3ivQvEzXhOZaIqYBIwUsm02vFZkClsV7eIKzWjso1t0+I/8MjrnUNaSWqh1rQ==",
       "cpu": [
         "x64"
       ],
@@ -1819,9 +1819,9 @@
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.10.tgz",
-      "integrity": "sha512-hb9QhOg5MGmpVkFcoZ9XJMe1em5gd0e2eqqjK87O1dwULedXsnY/Zg/Ju6lcohA+t6jVkmKpe7I1etqhvdRdrQ==",
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.11.tgz",
+      "integrity": "sha512-UDi3g6Jss/W5FnSzO9jCtQwEpfymt0M+sPPlmLhDH6h2TJ8j4ESE/LpmNPBij15J5NKkk4/cg/qoVMdWI3vnlQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -1925,9 +1925,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.6.tgz",
-      "integrity": "sha512-PF07dKGXKR+/bljJzCB6rAYtHEu21TthLxmJagtQizx+rwiqdRDBO5971Xu1N7MgcMLi4+mr4Cnl76x7O3DHtA==",
+      "version": "4.21.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
+      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
       "dev": true,
       "funding": [
         {
@@ -1966,9 +1966,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001489",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
-      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
+      "version": "1.0.30001494",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz",
+      "integrity": "sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==",
       "dev": true,
       "funding": [
         {
@@ -2058,9 +2058,9 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
       "dev": true,
       "dependencies": {
         "import-fresh": "^3.2.1",
@@ -2348,9 +2348,9 @@
       "integrity": "sha512-5YM9LFQgVYfuLNEoqMqVWIBuF2UNCA+xu/jz1TyryLN/wmBcQSb+GNAwvLKvEpGESwgGN8XA1nbLAt6rKlyHYQ=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.411",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.411.tgz",
-      "integrity": "sha512-5VXLW4Qw89vM2WTICHua/y8v7fKGDRVa2VPOtBB9IpLvW316B+xd8yD1wTmLPY2ot/00P/qt87xdolj4aG/Lzg==",
+      "version": "1.4.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.419.tgz",
+      "integrity": "sha512-jdie3RiEgygvDTyS2sgjq71B36q2cDSBfPlwzUyuOrfYTNoYWyBxxjGJV/HAu3A2hB0Y+HesvCVkVAFoCKwCSw==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -3005,9 +3005,9 @@
       }
     },
     "node_modules/msgpackr": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.2.tgz",
-      "integrity": "sha512-xtDgI3Xv0AAiZWLRGDchyzBwU6aq0rwJ+W+5Y4CZhEWtkl/hJtFFLc+3JtGTw7nz1yquxs7nL8q/yA2aqpflIQ==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.4.tgz",
+      "integrity": "sha512-MihliU9Wgi5rVHmXYjXeB969jDBogwMVUn9CjrL8T2Na5+n5gsTJVGdeUHBplNtqEqgnm/nFnQYK8Bdzry5ahQ==",
       "dev": true,
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
@@ -3238,9 +3238,9 @@
       }
     },
     "node_modules/parcel-resolver-ignore": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/parcel-resolver-ignore/-/parcel-resolver-ignore-2.1.3.tgz",
-      "integrity": "sha512-C8uLvR4o7SPRSsQ/Nylm1/PdsLwn/Z9bzCs66qT3XIebJC7ojaFFF3MDl/mie5audngjcFF8wzU0AoEQkZq2pA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/parcel-resolver-ignore/-/parcel-resolver-ignore-2.1.5.tgz",
+      "integrity": "sha512-/2zgQw3J/2YA7L6JXg4XKBWT/SXDZx+PfweWcCsllchNVwFvK7jDJhG6h+puy+e15Rm9A/ubuuHYwANQHVXp2A==",
       "dev": true,
       "engines": {
         "parcel": ">=2.0.0"
@@ -3654,9 +3654,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
       "dev": true
     },
     "node_modules/type-fest": {
@@ -3672,16 +3672,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "@types/lunr": "^2.3.4",
     "parcel": "^2.9.1",
     "parcel-reporter-static-files-copy": "^1.5.0",
-    "parcel-resolver-ignore": "^2.1.3",
+    "parcel-resolver-ignore": "^2.1.5",
     "prettier": "^2.8.8",
     "pretty-quick": "^3.1.3",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.3"
   },
   "staticFiles": {
     "staticPath": "resources/public/static"


### PR DESCRIPTION
Bumping pedestal got rid of a bunch of jetty CVE overrides.

Added a guava override to address a CVE.

Held off on bumping asciidoctorj, asciidoctor 2.0.20 is rendering docs a bit differently than 2.0.18 and causing some test failures. I've pinged the asciidoctor team on their chat forum to ask if they consider this a bug.