### PR TITLE
maint: bump asciidoctorj

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,9 +32,7 @@
         org.apache.lucene/lucene-queryparser {:mvn/version "9.6.0"}
 
         ;; markdown
-        org.asciidoctor/asciidoctorj {:mvn/version "2.5.8"}  ;; render adoc to html
-        ;; temporarily override jruby used by asciidoctorj to overcome CVE (delete/recheck after bumping asciidoctorj)
-        org.jruby/jruby {:mvn/version "9.4.2.0"}
+        org.asciidoctor/asciidoctorj {:mvn/version "2.5.10"} ;; render adoc to html
         com.vladsch.flexmark/flexmark                        ;; render github markdown to html
         {:mvn/version "0.64.8"}
         com.vladsch.flexmark/flexmark-ext-autolink           ;; converts raw links in text to clickable links

--- a/resources/test_data/cache_bundle.edn
+++ b/resources/test_data/cache_bundle.edn
@@ -3241,7 +3241,7 @@
     :namespace "rewrite-clj.zip",
     :platform "cljs",
     :type :var}},
- :latest "1.0.767-alpha",
+ :latest "1.1.47",
  :namespaces
  #{{:doc
     "APIs to navigate and update Clojure/ClojureScript/EDN source code.\n\nUse [[rewrite-clj.zip]] to ingest your source code into a zipper of nodes and then again to navigate and/or change it.\n\nOptionally use [[rewrite-clj.parser]] to instead work with raw nodes.\n\n[[rewrite-clj.node]] will help you to inspect and create nodes.\n\n[[rewrite-clj.paredit]] first appeared in the ClojureScript only version of rewrite-clj and supports structured editing of the zipper tree.",

--- a/resources/test_data/searchset.edn
+++ b/resources/test_data/searchset.edn
@@ -4858,11 +4858,13 @@
    :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.node.coercer",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_coercer"}
-  {:doc "arglists attributes + [ n value ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n value ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +node-with-meta",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_node_with_meta"}
-  {:doc "arglists attributes + [ f sq ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f sq ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +seq-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_seq_node"}
@@ -5046,19 +5048,23 @@
    :name "rwt-clj v0 vs rwt-cljs - =vector-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_vector_node_2"}
-  {:doc "arglists attributes + [ s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +wrap-list",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_list"}
-  {:doc "arglists attributes + [ s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +wrap-map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_map"}
-  {:doc "arglists attributes + [ s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +wrap-set",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_set"}
-  {:doc "arglists attributes + [ s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +wrap-vec",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_vec"}
@@ -5078,11 +5084,12 @@
    :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.node.stringz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_stringz"}
-  {:doc "arglists attributes + [ lines ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+lines ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +string-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_string_node_3"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +StringNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_stringnode_2"}
@@ -5091,7 +5098,7 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_node_token"}
   {:doc
-   "arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+value ] **` [green]#[# [green]`+value string-value ] - [ value & [string-value] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-cljs - ≠token-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_token_node_2"}
@@ -5183,84 +5190,102 @@
    :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.paredit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_paredit"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +barf-backward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_barf_backward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +barf-forward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_barf_forward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +join",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_join"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +kill",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_kill"}
-  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +kill-at-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_kill_at_pos"}
-  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +kill-one-at-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_kill_one_at_pos"}
   {:doc
-   "arglists attributes + [ loc f n ] :type + :var :no-doc + true ",
+   "arglists attributes **` [green]#[# [green]`+loc f n ] :type **` [green]`:var+ :no-doc **` [green]`+true ",
    :name "rwt-clj v0 vs rwt-cljs - +move-n",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_move_n"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +move-to-prev",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_move_to_prev"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +raise",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_raise"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +slurp-backward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_slurp_backward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +slurp-backward-fully",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_slurp_backward_fully"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +slurp-forward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_slurp_forward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +slurp-forward-fully",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_slurp_forward_fully"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +splice",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +splice-killing-backward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice_killing_backward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +splice-killing-forward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice_killing_forward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +split",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_split"}
-  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +split-at-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_split_at_pos"}
-  {:doc "arglists attributes + [ zloc t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +wrap-around",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_around"}
-  {:doc "arglists attributes + [ zloc t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +wrap-fully-forward-slurp",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_wrap_fully_forward_slurp"}
@@ -5384,7 +5409,7 @@
    :name "rwt-clj v0 vs rwt-cljs - =boundary?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_boundary"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +buf",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_buf"}
@@ -5396,11 +5421,11 @@
    :name "rwt-clj v0 vs rwt-cljs - -file-reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_file_reader"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +get-column-number",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_get_column_number"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +get-line-number",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_get_line_number"}
@@ -5408,7 +5433,7 @@
    :name "rwt-clj v0 vs rwt-cljs - =ignore",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_ignore_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +indexing-push-back-reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_indexing_push_back_reader"}
@@ -5424,7 +5449,7 @@
    :name "rwt-clj v0 vs rwt-cljs - =peek",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_peek"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +peek-char",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_peek_char"}
@@ -5432,7 +5457,7 @@
    :name "rwt-clj v0 vs rwt-cljs - -position",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_position_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +read-char",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_char"}
@@ -5440,7 +5465,8 @@
    :name "rwt-clj v0 vs rwt-cljs - =read-include-linebreak",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_include_linebreak"}
-  {:doc "arglists attributes + [ reader initch ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+reader initch ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +read-keyword",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_keyword"}
@@ -5453,7 +5479,7 @@
    :name "rwt-clj v0 vs rwt-cljs - =read-repeatedly",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_repeatedly"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +read-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_string"}
@@ -5462,7 +5488,7 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_until"}
   {:doc
-   "arglists attributes + [ reader p? ] + [ reader p? eof? ] - [ reader p? & [eof?] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+reader p? ] **` [green]#[# [green]`+reader p? eof? ] - [ reader p? & [eof?] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-cljs - ≠read-while",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_read_while"}
@@ -5583,7 +5609,7 @@
    :name "rwt-clj v0 vs rwt-cljs - ≠find-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_depth_first"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-last-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_last_by_pos"}
@@ -5616,7 +5642,7 @@
    :name "rwt-clj v0 vs rwt-cljs - ≠find-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-tag-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag_by_pos"}
@@ -5774,7 +5800,7 @@
    :name "rwt-clj v0 vs rwt-cljs - -remove*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_3"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-preserve-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_preserve_newline"}
@@ -5976,23 +6002,28 @@
    :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.editz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_editz"}
-  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f & args ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +edit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_edit_7"}
-  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc s ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +prefix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prefix_3"}
-  {:doc "arglists attributes + [ zloc value ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc value ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +replace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_replace_5"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +splice",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_splice_4"}
-  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc s ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +suffix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_suffix_3"}
@@ -6053,63 +6084,67 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_findz"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_3"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_depth_first_3"}
   {:doc
-   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] **` [green]#[# [green]`+zloc pos p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-last-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_last_by_pos_2"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-next",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_3"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-next-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_depth_first_3"}
   {:doc
-   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc t ] **` [green]#[# [green]`+zloc f t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-next-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_tag_3"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-next-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_token_3"}
   {:doc
-   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc v ] **` [green]#[# [green]`+zloc f v ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-next-value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_next_value_3"}
   {:doc
-   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc t ] **` [green]#[# [green]`+zloc f t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag_3"}
-  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-tag-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_tag_by_pos_2"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_token_3"}
   {:doc
-   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc v ] **` [green]#[# [green]`+zloc f v ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +find-value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_find_value_3"}
-  {:doc "arglists attributes + [ {} {} ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`{}` [green]`{}+ ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +in-range?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_in_range"}
@@ -6173,11 +6208,13 @@
    :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.removez",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_removez"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_5"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-preserve-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_preserve_newline_2"}
@@ -6229,43 +6266,53 @@
    :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.seqz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_seqz"}
-  {:doc "arglists attributes + [ zloc k v ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc k v ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +assoc",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_assoc_3"}
-  {:doc "arglists attributes + [ zloc k ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc k ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +get",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_get_3"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +list?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_list_3"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_5"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +map-keys",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_keys_3"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +map-vals",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_vals_3"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_map_6"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +seq?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_seq_3"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +set?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_set_3"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +vector?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_vector_3"}
@@ -6305,35 +6352,43 @@
    :name "rwt-clj v0 vs rwt-cljs - + rewrite-clj.zip.utils",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_utils"}
-  {:doc "arglists attributes + [ [_ {} :as loc] ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`[_ {} :as loc]+ ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-and-move-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_and_move_left_2"}
-  {:doc "arglists attributes + [ [_ {} :as loc] ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`[_ {} :as loc]+ ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-and-move-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_and_move_right_2"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-and-move-up",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_and_move_up"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_left_2"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-left-while",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_left_while_2"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_right_2"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-right-while",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_right_while_2"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +remove-while",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_remove_while"}
@@ -6360,16 +6415,17 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_rewrite_clj_zip_whitespace"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
    :name "rwt-clj v0 vs rwt-cljs - ≠append-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_append_newline_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
    :name "rwt-clj v0 vs rwt-cljs - ≠append-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_append_space_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +comment?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_comment_3"}
@@ -6394,12 +6450,12 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_linebreak_6"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
    :name "rwt-clj v0 vs rwt-cljs - ≠prepend-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prepend_newline_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated - 0.5.0 ",
    :name "rwt-clj v0 vs rwt-cljs - ≠prepend-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_prepend_space_2"}
@@ -6415,7 +6471,8 @@
    :name "rwt-clj v0 vs rwt-cljs - =skip-whitespace-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_skip_whitespace_left_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-cljs - +whitespace-not-linebreak?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-cljs#_whitespace_not_linebreak"}
@@ -6432,7 +6489,7 @@
    :name "rwt-clj v0 vs rwt-clj v1",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.custom-zipper.core",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_custom_zipper_core"}
@@ -6509,7 +6566,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - =position",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_position"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +position-span",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_position_span"}
@@ -6550,7 +6608,8 @@
    "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.custom-zipper.utils",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_custom_zipper_utils"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +remove-and-move-up",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_and_move_up"}
@@ -6558,7 +6617,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node"}
-  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+  {:doc
+   "arglists attributes = [ node ] **` [green]#[# [green]`+node opts ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠child-sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_child_sexprs"}
@@ -6567,50 +6627,57 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_concat_strings"}
   {:doc
-   "arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+k ] **` [green]#[# [green]`+k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠keyword-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_node"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +keyword-node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_node_2"}
-  {:doc "arglists attributes + [ node map-qualifier ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node map-qualifier ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +map-context-apply",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_context_apply"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +map-context-clear",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_context_clear"}
   {:doc
-   "arglists attributes + [ auto-resolved? prefix ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+auto-resolved? prefix ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +map-qualifier-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_qualifier_node"}
-  {:doc "arglists attributes + [ x ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+x ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node_2"}
-  {:doc "arglists attributes = [ _ ] + [ node opts ] :type = :var ",
+  {:doc
+   "arglists attributes = [ _ ] **` [green]#[# [green]`+node opts ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +sexpr-able?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_able"}
   {:doc
-   "arglists attributes = [ nodes ] + [ nodes opts ] :type = :var ",
+   "arglists attributes = [ nodes ] **` [green]#[# [green]`+nodes opts ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexprs"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +symbol-node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_symbol_node"}
   {:doc
-   "arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+value ] **` [green]#[# [green]`+value string-value ] - [ value & [string-value] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠token-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_token_node"}
@@ -6622,7 +6689,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.node.coercer",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_coercer"}
-  {:doc "arglists attributes + [ n value ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n value ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +node-with-meta",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node_with_meta"}
@@ -6630,7 +6698,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.node.extras",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_extras"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +whitespace-or-comment?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_whitespace_or_comment"}
@@ -6659,20 +6728,22 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_keyword"}
   {:doc
-   "arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+k ] **` [green]#[# [green]`+k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠keyword-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_node_3"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +keyword-node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_node_4"}
   {:doc
-   "arglists attributes + [ kw kw-auto-resolved? map-qualifier {} ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+kw kw-auto-resolved? map-qualifier {} ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +keyword-sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_keyword_sexpr"}
-  {:doc "arglists attributes + [ k auto-resolved? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+k auto-resolved? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +kw-qualifier",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_kw_qualifier"}
@@ -6682,27 +6753,29 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_namespaced_map"}
   {:doc
-   "arglists attributes + [ auto-resolved? prefix ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+auto-resolved? prefix ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +map-qualifier-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_qualifier_node_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +MapQualifierNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_mapqualifiernode"}
-  {:doc "arglists attributes + [ children ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +namespaced-map-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespaced_map_node"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +NamespacedMapNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespacedmapnode"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +reapply-namespaced-map-context",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_reapply_namespaced_map_context"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.protocols",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_protocols"}
@@ -6720,7 +6793,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠assert-single-sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_assert_single_sexpr"}
-  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+  {:doc
+   "arglists attributes = [ node ] **` [green]#[# [green]`+node opts ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠child-sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_child_sexprs_2"}
@@ -6728,7 +6802,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠concat-strings",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_concat_strings_2"}
-  {:doc "arglists attributes + [ alias ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+alias ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +default-auto-resolve",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_default_auto_resolve"}
@@ -6746,25 +6821,28 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠make-printable!",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_make_printable"}
-  {:doc "arglists attributes + [ class ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+class ] :type **` [green]`:macro+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +make-printable-clj!",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_make_printable_clj"}
   {:doc
-   "attributes members name arglists attributes :type + :protocol + map-context-apply + [ node map-qualifier ] :type + :var + map-context-clear + [ node ] :type + :var ",
+   "attributes members name arglists attributes :type **` [green]`:protocol+ **` [green]`+map-context-apply **` [green]#[# [green]`+node map-qualifier ] :type **` [green]`:var+ **` [green]`+map-context-clear **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +MapQualifiable",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_mapqualifiable"}
-  {:doc "arglists attributes + [ form ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+form ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +meta-elided",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_meta_elided"}
   {:doc
-   "attributes members name arglists attributes :type = :protocol = length = [ _ ] :type = :var + node-type + [ node ] :type + :var = printable-only? = [ _ ] :type = :var - sexpr - [ _ ] :type - :var + sexpr* + [ node opts ] :type + :var = string = [ _ ] :type = :var = tag = [ _ ] :type = :var ",
+   "attributes members name arglists attributes :type = :protocol = length = [ _ ] :type = :var **` [green]`+node-type **` [green]#[# [green]`+node ] :type **` [green]`:var+ = printable-only? = [ _ ] :type = :var - sexpr - [ _ ] :type - :var **` [green]`+sexpr* **` [green]#[# [green]`+node opts ] :type **` [green]`:var+ = string = [ _ ] :type = :var = tag = [ _ ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠Node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node_3"}
-  {:doc "arglists attributes + [ x ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+x ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_node_4"}
@@ -6773,16 +6851,18 @@
    :name "rwt-clj v0 vs rwt-clj v1 - =NodeCoerceable",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_nodecoerceable"}
-  {:doc "arglists attributes + [ node ] + [ node opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] **` [green]#[# [green]`+node opts ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_2"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +sexpr-able?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_able_2"}
   {:doc
-   "arglists attributes = [ nodes ] + [ nodes opts ] :type = :var ",
+   "arglists attributes = [ nodes ] **` [green]#[# [green]`+nodes opts ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexprs_2"}
@@ -6791,11 +6871,12 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sum_lengths"}
   {:doc
-   "arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - +value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_value"}
-  {:doc "arglists attributes + [ nodes ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+nodes ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +without-whitespace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_without_whitespace"}
@@ -6808,7 +6889,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.regex",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_regex"}
-  {:doc "arglists attributes + [ regex ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+regex ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +pattern-string-for-regex",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_pattern_string_for_regex"}
@@ -6836,11 +6918,12 @@
    :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.node.stringz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_stringz"}
-  {:doc "arglists attributes + [ lines ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+lines ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +string-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_string_node"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +StringNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_stringnode_2"}
@@ -6848,16 +6931,17 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.node.token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_node_token"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +symbol-node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_symbol_node_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +SymbolNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_symbolnode"}
   {:doc
-   "arglists attributes + [ value ] + [ value string-value ] - [ value & [string-value] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+value ] **` [green]#[# [green]`+value string-value ] - [ value & [string-value] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠token-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_token_node_2"}
@@ -6865,79 +6949,97 @@
    :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.paredit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_paredit"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +barf-backward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_barf_backward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +barf-forward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_barf_forward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +join",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_join"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +kill",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_kill"}
-  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +kill-at-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_kill_at_pos"}
-  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +kill-one-at-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_kill_one_at_pos"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +move-to-prev",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_move_to_prev"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +raise",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_raise"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +slurp-backward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_slurp_backward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +slurp-backward-fully",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_slurp_backward_fully"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +slurp-forward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_slurp_forward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +slurp-forward-fully",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_slurp_forward_fully"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +splice",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_splice"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +splice-killing-backward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_splice_killing_backward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +splice-killing-forward",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_splice_killing_forward"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +split",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_split"}
-  {:doc "arglists attributes + [ zloc pos ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +split-at-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_split_at_pos"}
-  {:doc "arglists attributes + [ zloc t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +wrap-around",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_wrap_around"}
-  {:doc "arglists attributes + [ zloc t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +wrap-fully-forward-slurp",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_wrap_fully_forward_slurp"}
@@ -6946,12 +7048,12 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_parser"}
   {:doc
-   "arglists attributes = [ reader ] :type = :var :no-doc + true ",
+   "arglists attributes = [ reader ] :type = :var :no-doc **` [green]`+true ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠parse",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_parse"}
   {:doc
-   "arglists attributes = [ reader ] :type = :var :no-doc + true ",
+   "arglists attributes = [ reader ] :type = :var :no-doc **` [green]`+true ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠parse-all",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_parse_all"}
@@ -6960,7 +7062,8 @@
    "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.parser.namespaced-map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_parser_namespaced_map"}
-  {:doc "arglists attributes + [ reader read-next ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+reader read-next ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +parse-namespaced-map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_parse_namespaced_map"}
@@ -6996,16 +7099,18 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_reader"}
-  {:doc "arglists attributes + [ rdr ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+rdr ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +newline-normalizing-reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_newline_normalizing_reader"}
-  {:doc "arglists attributes + [ reader ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+reader ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +read-keyword",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_read_keyword"}
   {:doc
-   "arglists attributes + [ reader p? ] + [ reader p? eof? ] - [ reader p? & [eof?] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+reader p? ] **` [green]#[# [green]`+reader p? eof? ] - [ reader p? & [eof?] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠read-while",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_read_while"}
@@ -7013,90 +7118,103 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.zip",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +append-child*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_child_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠append-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_newline"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠append-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_space"}
   {:doc
-   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] **` [green]#[# [green]`+zloc pos p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-last-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_last_by_pos"}
-  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-tag-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_tag_by_pos"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +insert-child*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_child_2"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +insert-newline-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_newline_left"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +insert-newline-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_newline_right"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +insert-space-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_space_left"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +insert-space-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_insert_space_right"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +namespaced-map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespaced_map"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +position-span",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_position_span_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠prepend-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prepend_newline"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠prepend-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prepend_space"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc writer ] - [ zloc & [writer] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠print",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_print"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc writer ] - [ zloc & [writer] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠print-root",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_print_root"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +reapply-context",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_reapply_context"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +remove-preserve-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_preserve_newline"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +sexpr-able?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_able_3"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +subzip",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_subzip"}
@@ -7105,34 +7223,37 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_base"}
   {:doc
-   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - +->root-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_root_string"}
   {:doc
-   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - +->string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_string"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +get-opts",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_get_opts"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc writer ] - [ zloc & [writer] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠print",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_print_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc writer ] - [ zloc & [writer] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc writer ] - [ zloc & [writer] ] :type = :var ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠print-root",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_print_root_2"}
-  {:doc "arglists attributes + [ zloc opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc opts ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +set-opts",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_set_opts"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +sexpr-able?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_sexpr_able_4"}
@@ -7140,7 +7261,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.context",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_context"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +reapply-context",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_reapply_context_2"}
@@ -7148,23 +7270,28 @@
    :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.editz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_editz"}
-  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f & args ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +edit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_edit_2"}
-  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc s ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +prefix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prefix"}
-  {:doc "arglists attributes + [ zloc value ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc value ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +replace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_replace_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +splice",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_splice_2"}
-  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc s ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +suffix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_suffix"}
@@ -7173,11 +7300,12 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_find"}
   {:doc
-   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] **` [green]#[# [green]`+zloc pos p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-last-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_last_by_pos_2"}
-  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-tag-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_tag_by_pos_2"}
@@ -7186,59 +7314,62 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_findz"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_depth_first"}
   {:doc
-   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] **` [green]#[# [green]`+zloc pos p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-last-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_last_by_pos_3"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-next",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-next-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next_depth_first"}
   {:doc
-   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc t ] **` [green]#[# [green]`+zloc f t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-next-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next_tag"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-next-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next_token"}
   {:doc
-   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc v ] **` [green]#[# [green]`+zloc f v ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-next-value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_next_value"}
   {:doc
-   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc t ] **` [green]#[# [green]`+zloc f t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_tag"}
-  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos t ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-tag-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_tag_by_pos_3"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_token"}
   {:doc
-   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc v ] **` [green]#[# [green]`+zloc f v ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +find-value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_find_value"}
@@ -7246,7 +7377,8 @@
    :name "rwt-clj v0 vs rwt-clj v1 - ≠ rewrite-clj.zip.remove",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_remove"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +remove-preserve-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_preserve_newline_2"}
@@ -7254,11 +7386,13 @@
    :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.removez",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_removez"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +remove",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +remove-preserve-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_remove_preserve_newline_3"}
@@ -7266,47 +7400,58 @@
    :name "rwt-clj v0 vs rwt-clj v1 - + rewrite-clj.zip.seqz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_seqz"}
-  {:doc "arglists attributes + [ zloc k v ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc k v ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +assoc",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_assoc"}
-  {:doc "arglists attributes + [ zloc k ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc k ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +get",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_get"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +list?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_list"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +map-keys",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_keys"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +map-vals",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_vals"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_map_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +namespaced-map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_namespaced_map_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +seq?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_seq"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +set?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_set"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +vector?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_vector"}
@@ -7315,30 +7460,32 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_rewrite_clj_zip_whitespace"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠append-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_newline_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠append-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_append_space_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +comment?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_comment"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠prepend-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prepend_newline_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] - [ zloc & [n] ] :type = :var :deprecated = 0.5.0 ",
    :name "rwt-clj v0 vs rwt-clj v1 - ≠prepend-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_prepend_space_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v0 vs rwt-clj v1 - +whitespace-not-linebreak?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v0-vs-rwt-clj-v1#_whitespace_not_linebreak"}
@@ -7351,111 +7498,138 @@
    :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.custom-zipper.core",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_custom_zipper_core"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +append-child",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_child"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +branch?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_branch"}
-  {:doc "arglists attributes + [ {} ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`{}+ ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +children",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_children"}
-  {:doc "arglists attributes + [ root ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+root ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +custom-zipper",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_custom_zipper"}
-  {:doc "arglists attributes + [ value ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+value ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +custom-zipper?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_custom_zipper_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +down",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_down"}
-  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f & args ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +end?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_end"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-child",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_child"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_left"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_right"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_left"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +leftmost",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +lefts",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_lefts"}
-  {:doc "arglists attributes + [ _zloc node children ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+_zloc node children ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +make-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_make_node"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +next",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_next"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +position",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +position-span",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position_span"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +prev",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prev"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove"}
-  {:doc "arglists attributes + [ zloc node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +replace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_right"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +rightmost",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +root",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +up",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_up"}
-  {:doc "arglists attributes + [ root ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+root ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +zipper",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_zipper"}
@@ -7463,31 +7637,38 @@
    :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.custom-zipper.utils",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_custom_zipper_utils"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove-and-move-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_left"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove-and-move-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_right"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove-and-move-up",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_and_move_up"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_left"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove-left-while",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_left_while"}
-  {:doc "arglists attributes + [ loc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+loc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_right"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove-right-while",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_right_while"}
@@ -7495,240 +7676,287 @@
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node"}
-  {:doc "arglists attributes + [ node ] + [ node opts ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] **` [green]#[# [green]`+node opts ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠child-sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_child_sexprs"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠children",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_children_2"}
-  {:doc "arglists attributes + [ form ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+form ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠coerce",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_coerce"}
-  {:doc "arglists attributes + [ s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +comma-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_node"}
-  {:doc "arglists attributes + [ nodes ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+nodes ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +comma-separated",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_separated"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +comma?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma"}
-  {:doc "arglists attributes + [ s ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠comment-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comment_node"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠comment?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comment"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠deref-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_deref_node"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠eval-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_eval_node"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠fn-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_fn_node"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠forms-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_forms_node"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠inner?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_inner"}
   {:doc
-   "arglists attributes + [ value ] + [ value base ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+value ] **` [green]#[# [green]`+value base ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +integer-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_integer_node"}
   {:doc
-   "arglists attributes + [ k ] + [ k auto-resolved? ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+k ] **` [green]#[# [green]`+k auto-resolved? ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠keyword-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_node"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +keyword-node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_node_2"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +leader-length",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leader_length"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠length",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_length"}
-  {:doc "arglists attributes + [ nodes ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+nodes ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +line-separated",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_line_separated"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠linebreak?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_linebreak"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠list-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_list_node"}
-  {:doc "arglists attributes + [ node map-qualifier ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node map-qualifier ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +map-context-apply",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_context_apply"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +map-context-clear",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_context_clear"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠map-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_node"}
   {:doc
-   "arglists attributes + [ auto-resolved? prefix ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+auto-resolved? prefix ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +map-qualifier-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_qualifier_node"}
   {:doc
-   "arglists attributes + [ children ] + [ metadata data ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+children ] **` [green]#[# [green]`+metadata data ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠meta-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_meta_node"}
-  {:doc "arglists attributes + [ children ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +namespaced-map-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespaced_map_node"}
-  {:doc "arglists attributes + [ s ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠newline-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newline_node"}
-  {:doc "arglists attributes + [ n ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠newlines",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newlines"}
-  {:doc "arglists attributes + [ x ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+x ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_2"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠printable-only?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_printable_only"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠quote-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_quote_node"}
   {:doc
-   "arglists attributes + [ children ] + [ metadata data ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+children ] **` [green]#[# [green]`+metadata data ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +raw-meta-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_raw_meta_node"}
   {:doc
-   "arglists attributes + [ children ] + [ macro-node form-node ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+children ] **` [green]#[# [green]`+macro-node form-node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠reader-macro-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_reader_macro_node"}
-  {:doc "arglists attributes + [ pattern-string ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+pattern-string ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +regex-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_regex_node"}
-  {:doc "arglists attributes + [ node children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠replace-children",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace_children"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠set-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_set_node"}
-  {:doc "arglists attributes + [ node ] + [ node opts ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] **` [green]#[# [green]`+node opts ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +sexpr-able?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_able"}
   {:doc
-   "arglists attributes + [ nodes ] + [ nodes opts ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+nodes ] **` [green]#[# [green]`+nodes opts ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexprs"}
-  {:doc "arglists attributes + [ n ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠spaces",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_spaces"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string"}
-  {:doc "arglists attributes + [ lines ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+lines ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠string-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_node"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +symbol-node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_symbol_node"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠syntax-quote-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_syntax_quote_node"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_tag"}
   {:doc
-   "arglists attributes + [ value ] + [ value string-value ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+value ] **` [green]#[# [green]`+value string-value ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠token-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_token_node"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠uneval-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_uneval_node"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠unquote-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_unquote_node"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠unquote-splicing-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_unquote_splicing_node"}
   {:doc
-   "arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_value"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠var-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_var_node"}
-  {:doc "arglists attributes + [ children ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠vector-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_vector_node"}
-  {:doc "arglists attributes + [ s ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠whitespace-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_node"}
-  {:doc "arglists attributes + [ s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +whitespace-nodes",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_nodes"}
-  {:doc "arglists attributes + [ node ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠whitespace?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.coercer",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_coercer"}
@@ -7740,7 +7968,7 @@
    :name "rwt-cljs vs rwt-clj v1 - -seq-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_seq_node"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.comment",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_comment"}
@@ -7760,11 +7988,12 @@
    :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.node.extras",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_extras"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +whitespace-or-comment?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_or_comment"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.forms",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_forms"}
@@ -7781,29 +8010,30 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_integer"}
   {:doc
-   "arglists attributes + [ value ] + [ value base ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+value ] **` [green]#[# [green]`+value base ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +integer-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_integer_node_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +IntNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_intnode"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.keyword",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_keyword"}
   {:doc
-   "arglists attributes + [ k ] + [ k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+k ] **` [green]#[# [green]`+k auto-resolved? ] - [ k & [namespaced?] ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠keyword-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_node_3"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +keyword-node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_node_4"}
   {:doc
-   "arglists attributes + [ kw kw-auto-resolved? map-qualifier {} ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+kw kw-auto-resolved? map-qualifier {} ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +keyword-sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keyword_sexpr"}
@@ -7811,11 +8041,12 @@
    :name "rwt-cljs vs rwt-clj v1 - =KeywordNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_keywordnode"}
-  {:doc "arglists attributes + [ k auto-resolved? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+k auto-resolved? ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +kw-qualifier",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_kw_qualifier"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.meta",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_meta"}
@@ -7838,32 +8069,34 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_namespaced_map"}
   {:doc
-   "arglists attributes + [ auto-resolved? prefix ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+auto-resolved? prefix ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +map-qualifier-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_qualifier_node_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +MapQualifierNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_mapqualifiernode"}
-  {:doc "arglists attributes + [ children ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+children ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +namespaced-map-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespaced_map_node_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +NamespacedMapNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespacedmapnode"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +reapply-namespaced-map-context",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_reapply_namespaced_map_context"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.protocols",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_protocols"}
   {:doc
-   "arglists attributes + [ [row col] [row-extent col-extent] ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`[row col]` [green]`[row-extent col-extent]+ ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - ++extent",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_extent"}
@@ -7875,7 +8108,8 @@
    :name "rwt-cljs vs rwt-clj v1 - =assert-single-sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_assert_single_sexpr"}
-  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+  {:doc
+   "arglists attributes = [ node ] **` [green]#[# [green]`+node opts ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠child-sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_child_sexprs_2"}
@@ -7883,42 +8117,48 @@
    :name "rwt-cljs vs rwt-clj v1 - =concat-strings",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_concat_strings"}
-  {:doc "arglists attributes + [ alias ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+alias ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +default-auto-resolve",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_default_auto_resolve"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +extent",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_extent_2"}
   {:doc
-   "attributes members name arglists attributes :type = :protocol = children = [ _ ] :type = :var = inner? = [ _ ] :type = :var + leader-length + [ node ] :type + :var = replace-children = [ _ children ] :type = :var ",
+   "attributes members name arglists attributes :type = :protocol = children = [ _ ] :type = :var = inner? = [ _ ] :type = :var **` [green]`+leader-length **` [green]#[# [green]`+node ] :type **` [green]`:var+ = replace-children = [ _ children ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠InnerNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_innernode"}
-  {:doc "arglists attributes + [ obj ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+obj ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +make-printable!",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_make_printable"}
-  {:doc "arglists attributes + [ obj ] :type + :var :no-doc + true ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+obj ] :type **` [green]`:var+ :no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - +make-printable-cljs!",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_make_printable_cljs"}
   {:doc
-   "attributes members name arglists attributes :type + :protocol + map-context-apply + [ node map-qualifier ] :type + :var + map-context-clear + [ node ] :type + :var ",
+   "attributes members name arglists attributes :type **` [green]`:protocol+ **` [green]`+map-context-apply **` [green]#[# [green]`+node map-qualifier ] :type **` [green]`:var+ **` [green]`+map-context-clear **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +MapQualifiable",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_mapqualifiable"}
-  {:doc "arglists attributes + [ form ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+form ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +meta-elided",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_meta_elided"}
   {:doc
-   "attributes members name arglists attributes :type = :protocol = length = [ _ ] :type = :var + node-type + [ node ] :type + :var = printable-only? = [ _ ] :type = :var - sexpr - [ _ ] :type - :var + sexpr* + [ node opts ] :type + :var = string = [ _ ] :type = :var = tag = [ _ ] :type = :var ",
+   "attributes members name arglists attributes :type = :protocol = length = [ _ ] :type = :var **` [green]`+node-type **` [green]#[# [green]`+node ] :type **` [green]`:var+ = printable-only? = [ _ ] :type = :var - sexpr - [ _ ] :type - :var **` [green]`+sexpr* **` [green]#[# [green]`+node opts ] :type **` [green]`:var+ = string = [ _ ] :type = :var = tag = [ _ ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠Node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_3"}
-  {:doc "arglists attributes + [ x ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+x ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_4"}
@@ -7927,16 +8167,18 @@
    :name "rwt-cljs vs rwt-clj v1 - =NodeCoerceable",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_nodecoerceable"}
-  {:doc "arglists attributes + [ node ] + [ node opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] **` [green]#[# [green]`+node opts ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_2"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +sexpr-able?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_able_2"}
   {:doc
-   "arglists attributes = [ nodes ] + [ nodes opts ] :type = :var ",
+   "arglists attributes = [ nodes ] **` [green]#[# [green]`+nodes opts ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexprs_2"}
@@ -7945,11 +8187,12 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sum_lengths"}
   {:doc
-   "arglists attributes + [ node ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_value_2"}
-  {:doc "arglists attributes + [ nodes ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+nodes ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +without-whitespace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_without_whitespace"}
@@ -7957,19 +8200,21 @@
    :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.node.regex",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_regex"}
-  {:doc "arglists attributes + [ regex ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+regex ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +pattern-string-for-regex",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_pattern_string_for_regex"}
-  {:doc "arglists attributes + [ pattern-string ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+pattern-string ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +regex-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_regex_node_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +RegexNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_regexnode"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.seq",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_seq"}
@@ -8009,7 +8254,7 @@
    :name "rwt-cljs vs rwt-clj v1 - -wrap-vec",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_wrap_vec"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.stringz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_stringz"}
@@ -8021,15 +8266,16 @@
    :name "rwt-cljs vs rwt-clj v1 - =StringNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_stringnode"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_token"}
-  {:doc "arglists attributes + [ n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +symbol-node?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_symbol_node_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +SymbolNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_symbolnode"}
@@ -8042,7 +8288,7 @@
    :name "rwt-cljs vs rwt-clj v1 - =TokenNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_tokennode"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.node.whitespace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_node_whitespace"}
@@ -8054,7 +8300,8 @@
    :name "rwt-cljs vs rwt-clj v1 - =*newline-fn*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_newline_fn"}
-  {:doc "arglists attributes + [ s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +comma-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_node_2"}
@@ -8062,11 +8309,12 @@
    :name "rwt-cljs vs rwt-clj v1 - =comma-separated",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_separated_2"}
-  {:doc "arglists attributes + [ node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +comma?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_2"}
-  {:doc "attributes :type + :var ",
+  {:doc "attributes :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +CommaNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_commanode"}
@@ -8114,11 +8362,13 @@
    :name "rwt-cljs vs rwt-clj v1 - =WhitespaceNode",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespacenode"}
-  {:doc "arglists attributes + [ f & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +with-count-fn",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_with_count_fn"}
-  {:doc "arglists attributes + [ f & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +with-newline-fn",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_with_newline_fn"}
@@ -8136,16 +8386,16 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser"}
   {:doc
-   "arglists attributes = [ reader ] :type = :var :no-doc + true ",
+   "arglists attributes = [ reader ] :type = :var :no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠parse",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse"}
   {:doc
-   "arglists attributes = [ reader ] :type = :var :no-doc + true ",
+   "arglists attributes = [ reader ] :type = :var :no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠parse-all",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_all"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.core",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_core"}
@@ -8153,7 +8403,7 @@
    :name "rwt-cljs vs rwt-clj v1 - =parse-next",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_next"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.keyword",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_keyword"}
@@ -8166,11 +8416,12 @@
    "rwt-cljs vs rwt-clj v1 - + rewrite-clj.parser.namespaced-map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_namespaced_map"}
-  {:doc "arglists attributes + [ reader read-next ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+reader read-next ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +parse-namespaced-map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_namespaced_map"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_string"}
@@ -8182,7 +8433,7 @@
    :name "rwt-cljs vs rwt-clj v1 - =parse-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_string"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_token"}
@@ -8190,7 +8441,7 @@
    :name "rwt-cljs vs rwt-clj v1 - =parse-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_token"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.parser.whitespace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_parser_whitespace"}
@@ -8198,7 +8449,7 @@
    :name "rwt-cljs vs rwt-clj v1 - =parse-whitespace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_parse_whitespace"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_reader"}
@@ -8210,7 +8461,8 @@
    :name "rwt-cljs vs rwt-clj v1 - -buf",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_buf"}
-  {:doc "arglists attributes + [ c ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+c ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +comma?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comma_3"}
@@ -8246,7 +8498,8 @@
    :name "rwt-cljs vs rwt-clj v1 - -peek-char",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_peek_char"}
-  {:doc "arglists attributes + [ reader row-k col-k ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+reader row-k col-k ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +position",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position_2"}
@@ -8259,7 +8512,7 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_include_linebreak"}
   {:doc
-   "arglists attributes + [ reader ] - [ reader initch ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+reader ] - [ reader initch ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠read-keyword",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_read_keyword"}
@@ -8297,7 +8550,8 @@
    :name "rwt-cljs vs rwt-clj v1 - =string->edn",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_edn"}
-  {:doc "arglists attributes + [ s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +string-reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_reader"}
@@ -8305,7 +8559,8 @@
    :name "rwt-cljs vs rwt-clj v1 - =throw-reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_throw_reader"}
-  {:doc "arglists attributes + [ reader ch ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+reader ch ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠unread",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_unread"}
@@ -8322,448 +8577,531 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip"}
   {:doc
-   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +->root-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_string"}
   {:doc
-   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +->string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_2"}
-  {:doc "arglists attributes + [ zloc item ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠append-child",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_child_2"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +append-child*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_child_3"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ :deprecated **` [green]`+0.5.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +append-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_newline"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ :deprecated **` [green]`+0.5.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +append-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_space"}
-  {:doc "arglists attributes + [ zloc k v ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc k v ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠assoc",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_assoc"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +child-sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_child_sexprs_3"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠down",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_down_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +down*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_down_3"}
-  {:doc "arglists attributes + [ zloc f & args ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f & args ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠edit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_2"}
-  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f & args ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edit*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_3"}
-  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edit->",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_4"}
-  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edit->>",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_5"}
-  {:doc "arglists attributes + [ zloc f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edit-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_node"}
-  {:doc "arglists attributes + [ node ] + [ node opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] **` [green]#[# [green]`+node opts ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edn",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edn"}
-  {:doc "arglists attributes + [ node ] + [ node opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+node ] **` [green]#[# [green]`+node opts ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edn*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edn_2"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠end?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_end_2"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find"}
-  {:doc "arglists attributes + [ zloc p? ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_depth_first"}
   {:doc
-   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] **` [green]#[# [green]`+zloc pos p? ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-last-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_last_by_pos"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-next",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next"}
-  {:doc "arglists attributes + [ zloc p? ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-next-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_depth_first"}
   {:doc
-   "arglists attributes + [ zloc t ] + [ zloc f t ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc t ] **` [green]#[# [green]`+zloc f t ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-next-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_tag"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-next-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_token"}
   {:doc
-   "arglists attributes + [ zloc v ] + [ zloc f v ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc v ] **` [green]#[# [green]`+zloc f v ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-next-value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_next_value"}
   {:doc
-   "arglists attributes + [ zloc t ] + [ zloc f t ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc t ] **` [green]#[# [green]`+zloc f t ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_tag"}
-  {:doc "arglists attributes + [ zloc pos t ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos t ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-tag-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_tag_by_pos"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_token"}
   {:doc
-   "arglists attributes + [ zloc v ] + [ zloc f v ] :type = :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc v ] **` [green]#[# [green]`+zloc f v ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠find-value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_find_value"}
-  {:doc "arglists attributes + [ zloc k ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc k ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠get",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_get"}
-  {:doc "arglists attributes + [ zloc item ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠insert-child",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_child_2"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-child*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_child_3"}
-  {:doc "arglists attributes + [ zloc item ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠insert-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_left_2"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-left*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_left_3"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-newline-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_newline_left"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-newline-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_newline_right"}
-  {:doc "arglists attributes + [ zloc item ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠insert-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_right_2"}
-  {:doc "arglists attributes + [ zloc item ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc item ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-right*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_right_3"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-space-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_space_left"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-space-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_space_right"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_left_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +left*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_left_3"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠leftmost",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +leftmost*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost_3"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠leftmost?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_leftmost_4"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +length",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_length_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +linebreak?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_linebreak_4"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠list?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_list"}
-  {:doc "arglists attributes + [ f zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map"}
-  {:doc "arglists attributes + [ f zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠map-keys",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_keys"}
-  {:doc "arglists attributes + [ f zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠map-vals",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_vals"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +namespaced-map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespaced_map"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠next",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_next_3"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +next*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_next_4"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_node_5"}
-  {:doc "arglists attributes + [ s ] + [ s opts ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+s ] **` [green]#[# [green]`+s opts ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠of-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_of_string"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +position",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position_3"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +position-span",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_position_span_2"}
   {:doc
-   "arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc f ] **` [green]#[# [green]`+zloc p? f ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +postwalk",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_postwalk"}
-  {:doc "arglists attributes + [ zloc s ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc s ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠prefix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prefix"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ :deprecated **` [green]`+0.5.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +prepend-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prepend_newline"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc n ] :type + :var :deprecated + 0.5.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ :deprecated **` [green]`+0.5.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +prepend-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prepend_space"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠prev",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prev_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +prev*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prev_3"}
   {:doc
-   "arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc f ] **` [green]#[# [green]`+zloc p? f ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +prewalk",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prewalk"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc writer ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc writer ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +print",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_print"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc writer ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc writer ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +print-root",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_print_root"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +reapply-context",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_reapply_context"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠remove",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +remove*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_3"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠remove-preserve-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_preserve_newline"}
-  {:doc "arglists attributes + [ zloc value ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc value ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠replace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace_2"}
-  {:doc "arglists attributes + [ zloc node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc node ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +replace*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_replace_3"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_right_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +right*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_right_3"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠rightmost",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +rightmost*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost_3"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠rightmost?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rightmost_4"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠root",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_2"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠root-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_string_2"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠seq?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_seq"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠set?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_set"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_3"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +sexpr-able?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_able_3"}
-  {:doc "arglists attributes + [ f p? zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f p? zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +skip",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip"}
-  {:doc "arglists attributes + [ zloc ] + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +skip-whitespace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip_whitespace"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +skip-whitespace-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_skip_whitespace_left"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠splice",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_splice"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_3"}
-  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +subedit->",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit"}
-  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +subedit->>",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_2"}
-  {:doc "arglists attributes + [ zloc f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +subedit-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_node"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +subzip",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subzip"}
-  {:doc "arglists attributes + [ zloc s ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc s ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠suffix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_suffix"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_tag_2"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠up",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_up_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +up*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_up_3"}
   {:doc
-   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_value_3"}
-  {:doc "arglists attributes + [ zloc ] :type = :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠vector?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_vector"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +whitespace-or-comment?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_or_comment_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +whitespace?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_whitespace_4"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.base",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_base"}
   {:doc
-   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +->root-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_string_3"}
   {:doc
-   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +->string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_string_4"}
@@ -8771,15 +9109,18 @@
    :name "rwt-cljs vs rwt-clj v1 - =child-sexprs",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_child_sexprs_4"}
-  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+  {:doc
+   "arglists attributes = [ node ] **` [green]#[# [green]`+node opts ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠edn",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edn_3"}
-  {:doc "arglists attributes = [ node ] + [ node opts ] :type = :var ",
+  {:doc
+   "arglists attributes = [ node ] **` [green]#[# [green]`+node opts ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠edn*",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edn_4"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +get-opts",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_get_opts"}
@@ -8787,17 +9128,18 @@
    :name "rwt-cljs vs rwt-clj v1 - =length",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_length_3"}
-  {:doc "arglists attributes = [ s ] + [ s opts ] :type = :var ",
+  {:doc
+   "arglists attributes = [ s ] **` [green]#[# [green]`+s opts ] :type = :var ",
    :name "rwt-cljs vs rwt-clj v1 - ≠of-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_of_string_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc writer ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc writer ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +print",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_print_2"}
   {:doc
-   "arglists attributes + [ zloc ] + [ zloc writer ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc writer ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +print-root",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_print_root_2"}
@@ -8805,7 +9147,8 @@
    :name "rwt-cljs vs rwt-clj v1 - =root-string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_root_string_4"}
-  {:doc "arglists attributes + [ zloc opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc opts ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +set-opts",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_set_opts"}
@@ -8813,7 +9156,8 @@
    :name "rwt-cljs vs rwt-clj v1 - =sexpr",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_4"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +sexpr-able?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_sexpr_able_4"}
@@ -8826,7 +9170,7 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_tag_3"}
   {:doc
-   "arglists attributes + [ zloc ] :type + :var :deprecated + 0.4.0 ",
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ :deprecated **` [green]`+0.4.0 ",
    :name "rwt-cljs vs rwt-clj v1 - +value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_value_4"}
@@ -8834,11 +9178,12 @@
    :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.zip.context",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_context"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +reapply-context",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_reapply_context_2"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.editz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_editz"}
@@ -8862,7 +9207,7 @@
    :name "rwt-cljs vs rwt-clj v1 - =suffix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_suffix_2"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.findz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_findz"}
@@ -8927,7 +9272,7 @@
    :name "rwt-cljs vs rwt-clj v1 - -in-range?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_in_range"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.move",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_move"}
@@ -8975,7 +9320,7 @@
    :name "rwt-cljs vs rwt-clj v1 - =up",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_up_4"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.removez",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_removez"}
@@ -8987,7 +9332,7 @@
    :name "rwt-cljs vs rwt-clj v1 - =remove-preserve-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_remove_preserve_newline_2"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.seqz",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_seqz"}
@@ -9019,7 +9364,8 @@
    :name "rwt-cljs vs rwt-clj v1 - =map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_map_4"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +namespaced-map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_namespaced_map_2"}
@@ -9039,31 +9385,38 @@
    :name "rwt-cljs vs rwt-clj v1 - + rewrite-clj.zip.subedit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_subedit"}
-  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edit->",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_7"}
-  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edit->>",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_8"}
-  {:doc "arglists attributes + [ zloc f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +edit-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_edit_node_2"}
-  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +subedit->",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_3"}
-  {:doc "arglists attributes + [ zloc & body ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc & body ] :type **` [green]`:macro+ ",
    :name "rwt-cljs vs rwt-clj v1 - +subedit->>",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_4"}
-  {:doc "arglists attributes + [ zloc f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +subedit-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subedit_node_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +subzip",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_subzip_2"}
@@ -9108,30 +9461,31 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_walk"}
   {:doc
-   "arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc f ] **` [green]#[# [green]`+zloc p? f ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +postwalk",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_postwalk_2"}
-  {:doc "arglists attributes + [ p? f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+p? f zloc ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +postwalk-subtree",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_postwalk_subtree"}
   {:doc
-   "arglists attributes + [ zloc f ] + [ zloc p? f ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc f ] **` [green]#[# [green]`+zloc p? f ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +prewalk",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prewalk_2"}
-  {:doc ":no-doc + true ",
+  {:doc ":no-doc **` [green]`+true ",
    :name "rwt-cljs vs rwt-clj v1 - ≠ rewrite-clj.zip.whitespace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_rewrite_clj_zip_whitespace"}
   {:doc
-   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ",
+   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated **` [green]`+0.5.0 ",
    :name "rwt-cljs vs rwt-clj v1 - ≠append-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_newline_2"}
   {:doc
-   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ",
+   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated **` [green]`+0.5.0 ",
    :name "rwt-cljs vs rwt-clj v1 - ≠append-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_append_space_2"}
@@ -9139,19 +9493,23 @@
    :name "rwt-cljs vs rwt-clj v1 - =comment?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_comment_3"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-newline-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_newline_left_2"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-newline-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_newline_right_2"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-space-left",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_space_left_2"}
-  {:doc "arglists attributes + [ zloc ] + [ zloc n ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] **` [green]#[# [green]`+zloc n ] :type **` [green]`:var+ ",
    :name "rwt-cljs vs rwt-clj v1 - +insert-space-right",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_insert_space_right_2"}
@@ -9160,12 +9518,12 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_linebreak_5"}
   {:doc
-   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ",
+   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated **` [green]`+0.5.0 ",
    :name "rwt-cljs vs rwt-clj v1 - ≠prepend-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prepend_newline_2"}
   {:doc
-   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated + 0.5.0 ",
+   "arglists attributes = [ zloc ] = [ zloc n ] :type = :var :deprecated **` [green]`+0.5.0 ",
    :name "rwt-cljs vs rwt-clj v1 - ≠prepend-space",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-cljs-vs-rwt-clj-v1#_prepend_space_2"}
@@ -9202,7 +9560,8 @@
    :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.node.protocols",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_node_protocols"}
-  {:doc "arglists attributes + [ class ] :type + :macro ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+class ] :type **` [green]`:macro+ ",
    :name "rwt-clj v1 clj vs cljs all - +make-printable-clj!",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_make_printable_clj"}
@@ -9210,7 +9569,8 @@
    :name "rwt-clj v1 clj vs cljs all - -make-printable-cljs!",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_make_printable_cljs"}
-  {:doc "arglists attributes + [ writer node ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+writer node ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +write-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_write_node"}
@@ -9218,7 +9578,8 @@
    :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.node.string",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_node_string"}
-  {:doc "arglists attributes + [ lines ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+lines ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +string-node",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_string_node"}
@@ -9226,11 +9587,13 @@
    :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.parser",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_parser"}
-  {:doc "arglists attributes + [ f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +parse-file",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_parse_file"}
-  {:doc "arglists attributes + [ f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +parse-file-all",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_parse_file_all"}
@@ -9238,11 +9601,13 @@
    :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_reader"}
-  {:doc "arglists attributes + [ f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +file-reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_file_reader"}
-  {:doc "arglists attributes + [ rdr ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+rdr ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +newline-normalizing-reader",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_newline_normalizing_reader"}
@@ -9250,7 +9615,8 @@
    :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.zip",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip"}
-  {:doc "arglists attributes + [ f ] + [ f opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f ] **` [green]#[# [green]`+f opts ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +of-file",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_of_file"}
@@ -9258,7 +9624,8 @@
    :name "rwt-clj v1 clj vs cljs all - ≠ rewrite-clj.zip.base",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_base"}
-  {:doc "arglists attributes + [ f ] + [ f opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f ] **` [green]#[# [green]`+f opts ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +of-file",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_of_file_2"}
@@ -9266,23 +9633,28 @@
    :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.zip.edit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_edit"}
-  {:doc "arglists attributes + [ zloc f & args ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc f & args ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +edit",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_edit"}
-  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc s ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +prefix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_prefix"}
-  {:doc "arglists attributes + [ zloc value ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc value ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +replace",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_replace"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +splice",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_splice"}
-  {:doc "arglists attributes + [ zloc s ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc s ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +suffix",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_suffix"}
@@ -9291,59 +9663,62 @@
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_find"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_depth_first"}
   {:doc
-   "arglists attributes + [ zloc pos ] + [ zloc pos p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc pos ] **` [green]#[# [green]`+zloc pos p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-last-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_last_by_pos"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-next",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next"}
-  {:doc "arglists attributes + [ zloc p? ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-next-depth-first",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next_depth_first"}
   {:doc
-   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc t ] **` [green]#[# [green]`+zloc f t ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-next-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next_tag"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-next-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next_token"}
   {:doc
-   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc v ] **` [green]#[# [green]`+zloc f v ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-next-value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_next_value"}
   {:doc
-   "arglists attributes + [ zloc t ] + [ zloc f t ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc t ] **` [green]#[# [green]`+zloc f t ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-tag",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_tag"}
-  {:doc "arglists attributes + [ zloc pos t ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc pos t ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-tag-by-pos",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_tag_by_pos"}
   {:doc
-   "arglists attributes + [ zloc p? ] + [ zloc f p? ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc p? ] **` [green]#[# [green]`+zloc f p? ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-token",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_token"}
   {:doc
-   "arglists attributes + [ zloc v ] + [ zloc f v ] :type + :var ",
+   "arglists attributes **` [green]#[# [green]`+zloc v ] **` [green]#[# [green]`+zloc f v ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +find-value",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_find_value"}
@@ -9351,11 +9726,13 @@
    :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.zip.remove",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_remove"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +remove",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_remove"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +remove-preserve-newline",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_remove_preserve_newline"}
@@ -9363,43 +9740,53 @@
    :name "rwt-clj v1 clj vs cljs all - + rewrite-clj.zip.seq",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_rewrite_clj_zip_seq"}
-  {:doc "arglists attributes + [ zloc k v ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc k v ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +assoc",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_assoc"}
-  {:doc "arglists attributes + [ zloc k ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc k ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +get",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_get"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +list?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_list"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +map",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_map"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +map-keys",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_map_keys"}
-  {:doc "arglists attributes + [ f zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +map-vals",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_map_vals"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +map?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_map_2"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +seq?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_seq"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +set?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_set"}
-  {:doc "arglists attributes + [ zloc ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+zloc ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs all - +vector?",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-all#_vector"}
@@ -9412,11 +9799,13 @@
    :name "rwt-clj v1 clj vs cljs public - ≠ rewrite-clj.parser",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_rewrite_clj_parser"}
-  {:doc "arglists attributes + [ f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs public - +parse-file",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_parse_file"}
-  {:doc "arglists attributes + [ f ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs public - +parse-file-all",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_parse_file_all"}
@@ -9424,7 +9813,8 @@
    :name "rwt-clj v1 clj vs cljs public - ≠ rewrite-clj.zip",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_rewrite_clj_zip"}
-  {:doc "arglists attributes + [ f ] + [ f opts ] :type + :var ",
+  {:doc
+   "arglists attributes **` [green]#[# [green]`+f ] **` [green]#[# [green]`+f opts ] :type **` [green]`:var+ ",
    :name "rwt-clj v1 clj vs cljs public - +of-file",
    :path
    "/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/design/api-differences/rwt-clj-v1-clj-vs-cljs-public#_of_file"}


### PR DESCRIPTION
This allowed us to turf jruby dep to overcome CVE.

But also:

Ascidoctorj bumped asciidoctor from v2.0.18 to v2.0.20. This included a bug fix for passthrough processing.

Seems that rewrite-clj docs for api diffs has some passthrough adoc that only happened to work but was never supported.

I confirmed this with the very helpful mojavelinux on asciidoctor zulip chat:
https://asciidoctor.zulipchat.com/#narrow/stream/279642-users/topic/complex-ish.20passthrough.20is.20rendering.20differently.20in.202.2E0.2E20/near/363769467

Our searchset tests expectations needed to be regenerated because the html generated by adoc for rewrite-clj is now different.

If I remember, I'll come back and bump rewrite-clj here after addressing adoc nonsense there.