### PR TITLE
Bump pedestal back to 0.6.0-beta-2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,14 +8,7 @@
         integrant/repl {:mvn/version "0.3.2"}                ;;  with reload support
 
         ;; web server/services
-        io.pedestal/pedestal.jetty {:mvn/version "0.5.11-beta-1"}   ;; web site/service with jetty engine
-        ;; override pedestal jetty 9.4.48 deps to overcome CVEs (delete/recheck after bumping pedetal.jetty)
-        org.eclipse.jetty/jetty-servlet ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.http2/http2-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-api ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-servlet ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty/jetty-alpn-server ^{:antq/exclude ["10.x" "11.x"]} {:mvn/version "9.4.51.v20230217"}
+        io.pedestal/pedestal.jetty {:mvn/version "0.6.0-beta-2"}   ;; web site/service with jetty engine
 
         co.deps/ring-etag-middleware {:mvn/version "0.2.1"}  ;; fast checksum based ETags for http responses
         ;; override pedestal dep on old dep that generate warning noise for clojure 1.11,

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -702,7 +702,8 @@
          ;; - https://groups.google.com/forum/#!topic/pedestal-users/caRnQyUOHWA
          ::http/secure-headers {:content-security-policy-settings {:object-src "'none'"}}
          ::http/resource-path "public/out"
-         ::http/not-found-interceptor not-found-interceptor}
+         ::http/not-found-interceptor not-found-interceptor
+         ::http/path-params-decoder nil}
         http/default-interceptors
         (update ::http/interceptors #(into [sentry/interceptor
                                             static-resource-interceptor

--- a/test/cljdoc/integration_test.clj
+++ b/test/cljdoc/integration_test.clj
@@ -159,6 +159,14 @@
                                             :headers {"Accept" accept}))
                   (format "build info defaults to html %s" accept)))))))
 
+  (t/testing "Can ask to build a library with a + in its version"
+    ;; we had a problem with +s with clojars
+    ;; and then after an upgrade to pedestal, hence this explicit test
+    (t/is (match? {:status 404
+                   :headers {"Content-Type" "text/html"}
+                   :body #"Want to build some documentation?"}
+                  (pdt/response-for *service* :get "/d/com.github.strojure/parsesso/1.2.2+295"))))
+
   (t/testing "sitemap for built libs (used by search engines)"
     (t/is (match? {:status 200
                    :headers {"Content-Type" "text/xml"}


### PR DESCRIPTION
Notes for future me:
- I missed pedestal breaking change.
- The pedestal project had described releases under GitHub releases, but for 0.6.0 they have not. I assumed I was reading about the current release when I was reading about an old release.
- Also not totally obvious: when you do find 0.6.0 described in the pedestal changelog file, it is marked as "unreleased" even though a beta has been released.

Now adapting to breaking change by setting `:path-params-decoder` to `nil` on server creation. This fixes our `+` in URL issue and closes #764.

Since `+` in URLs have now bitten us twice, added an explicit integration test.