### PR TITLE
Support displaying docstrings as plaintext only

### DIFF
--- a/doc/userguide/for-library-authors.adoc
+++ b/doc/userguide/for-library-authors.adoc
@@ -115,7 +115,7 @@ Cljdoc will look at the `<url>` and the `<tag>`:
 * `<tag>` is a valid pointer to the git revision of your release's sources.
 It can be a git tag, or commit sha.
 
-TIP: You can optionally link:#articles-override[override] the revision for articles.
+TIP: You can optionally link:#override-config[override] the revision for articles and docstring format.
 
 NOTE: We strongly recommend you explicitly specify the `<tag>` in your `pom.xml` for cljdoc and other tools. +
 But... If you do not specify a `<tag>`, cljdoc will search for a version tag based on the artifact version.
@@ -139,24 +139,25 @@ For example:
 
 Whatever method you choose, take care to ensure that your jar's pom points back to the exact revision of its sources on git.
 
-[[articles-override]]
-=== Overriding Articles Revision
-Sometimes you'll want cljdoc to present articles from your git repo after your library's release commit.
+[[override-config]]
+=== Overriding Cljdoc Config & Articles
+Sometimes you'll want cljdoc to present minor adjustments after your library's release commit.
 For examples:
 
 * a README that includes the git sha of the release will necessarily appear in a commit after the library release.
 * perhaps you'd like fix or edit an article without cutting a new release
 * you'd like to adjust your link:#cljdoc-config[article table of contents]
+* you might also want to change how link:#docstrings[cljdoc presents docstrings].
 
 To support these scenarios, cljdoc recognizes the `cljdoc-<version>` git tag.
 For library version `1.2.3` cljdoc will look for git tag `cljdoc-1.2.3` (or `cljdoc-v1.2.3`) and import your articles from that commit instead of the link:#git-sources[default commit].
 
 If you add/move a `cljdoc-<version>` tag after the initial cljdoc build is complete, you can request a link:#rebuild[rebuild].
 
-TIP: This affects articles only.
-Any changes to docstrings will require a new library release.
+TIP: This affects all of and only: docstring format, article table of contents, and articles.
+Any changes, for example, to docstring content will require a new library release.
 
-TIP: You'll want to make articles adjustments before you start working on your next release.
+TIP: You'll want to make any adjustments before you start working on your next release.
 All articles are re-imported.
 
 [[cljdoc-config]]
@@ -170,6 +171,8 @@ You can use this configuration file to tell cljdoc more about your documentation
 By default, cljdoc will link:#auto-discovered-articles[automatically discover articles].
 * `:cljdoc/languages` - Tells cljdoc which link:#languages[languages] your API uses. +
 By default, cljdoc will automatically detect languages based on the sources it finds in your jar.
+* `:cljdoc/docstring-format` - Tells cljdoc how you'd like your link:#docstrings[docstrings] displayed. +
+By default, cljdoc will render docstrings from link:#markup[Markdown format].
 * `:cljdoc/include-namespaces-from-dependencies` - Tells cljdoc to amalgamate API docs from multiple link:#modules[modules]. +
 Rarely used, but very useful when your project is made up of modules.
 
@@ -211,7 +214,7 @@ Cljdoc will rewrite built article to article links automatically. Markdown examp
 
 === Link to API docs
 
-* When linking from docstring to API docs, use the link:#wikilink[`+[[wikilink]]+`] 
+* When linking from markdown docstring to API docs, use the link:#wikilink[`+[[wikilink]]+`]
 * When linking from article to API docs, or from outside your git repo:
 ** link to var `malli.core/explain` in current release
 *** `https://cljdoc.org/d/metosin/malli/CURRENT/api/malli.core#explain`
@@ -294,7 +297,15 @@ You can specify maven repositories:
 [[docstrings]]
 === Docstrings
 
-Docstrings are rendered as link:#markup[Markdown]. Consider https://www.martinklepsch.org/posts/writing-awesome-docstrings.html[these recommendations] when writing your docstrings:
+Docstrings are rendered from link:#markup[Markdown] by default.
+
+You can choose to override this behaviour in your `doc/cljdoc.edn` file via the `:cljdoc/docstring-format` option.
+Valid values are:
+
+* `:markdown` - the default, an option to view "raw docstring" as plaintext is available to the user.
+* `:plaintext` - presents only the raw docstring.
+
+Consider https://www.martinklepsch.org/posts/writing-awesome-docstrings.html[these recommendations] when writing your docstrings in markdown format:
 
 1. Backtick-Quote ``` function arguments & special keywords to `make` them `stand` out `more`
 2. Link to other functions using link:#wikilink[`+[[wikilink]]+`] syntax
@@ -309,7 +320,7 @@ Any HTML embedded within docstrings is escaped.
 [[wikilink]]
 ==== Wikilinks
 
-You can link to other namespaces and functions from your docstrings using the `\[[wikilink]]` syntax.
+You can link to other namespaces and functions from your markdown docstrings using the `\[[wikilink]]` syntax.
 
 Note that if you want to link to vars outside the current namespace you need to either fully qualify those vars or specify them relative to the current namespace. An example: if you want to link to `compojure.core/GET` from `compojure.route` you'll need to provide the wiki in one of the two forms below:
 

--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -5,6 +5,7 @@
             [cljdoc.render.articles :as articles]
             [cljdoc.render.sidebar :as sidebar]
             [cljdoc.render.api :as api]
+            [cljdoc.user-config :as user-config]
             [cljdoc.util.fixref :as fixref]
             [cljdoc.util.scm :as scm]
             [cljdoc.bundle :as bundle]
@@ -93,13 +94,16 @@
         [[dominant-platf] :as platf-stats] (api/platform-stats ns-defs)
         ns-data (bundle/get-namespace cache-bundle (:namespace ns-emap))
         top-bar-component (layout/top-bar version-entity (bundle/scm-url cache-bundle))
-        fix-opts {:scm (bundle/scm-info cache-bundle)
-                  :uri-map (fixref/uri-mapping version-entity
-                                               (-> cache-bundle
-                                                   :version
-                                                   :doc
-                                                   doctree/add-slug-path
-                                                   doctree/flatten*))}]
+        opts {:docstring-format (user-config/docstring-format
+                                 (-> cache-bundle :version :config)
+                                 (proj/clojars-id version-entity))
+              :scm (bundle/scm-info cache-bundle)
+              :uri-map (fixref/uri-mapping version-entity
+                                           (-> cache-bundle
+                                               :version
+                                               :doc
+                                               doctree/add-slug-path
+                                               doctree/flatten*))}]
     (->> (if ns-data
            (layout/layout
             {:top-bar top-bar-component
@@ -111,7 +115,7 @@
                                            :ns-data ns-data
                                            :defs ns-defs
                                            :valid-ref-pred valid-ref-pred
-                                           :fix-opts fix-opts})})
+                                           :opts opts})})
            (layout/layout
             {:top-bar top-bar-component
              :main-sidebar-contents (sidebar/sidebar-contents route-params cache-bundle last-build)
@@ -119,7 +123,7 @@
                                                         :namespaces (bundle/namespaces cache-bundle)
                                                         :defs (bundle/all-defs cache-bundle)
                                                         :valid-ref-pred valid-ref-pred
-                                                        :fix-opts fix-opts})}))
+                                                        :opts opts})}))
          (layout/page {:title (str (:namespace ns-emap) " — " (proj/clojars-id version-entity) " " (:version version-entity))
                        :canonical-url (some->> (bundle/more-recent-version cache-bundle)
                                                (merge route-params)

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -108,7 +108,7 @@
                  (some-> doc-page :children seq article-toc)])))
        (into [:ol])))
 
-(defn- index-page [cache-bundle fix-opts]
+(defn- index-page [cache-bundle opts]
   [:div
    (when (-> cache-bundle :version :doc)
      [:div
@@ -120,24 +120,24 @@
          :let [defs (bundle/defs-for-ns
                       (bundle/all-defs cache-bundle)
                       (platf/get-field ns :name))]]
-     (api/namespace-overview ns-url ns defs  (api/valid-ref-pred-fn cache-bundle) fix-opts))])
+     (api/namespace-overview ns-url ns defs  (api/valid-ref-pred-fn cache-bundle) opts))])
 
-(defn- doc-page [doc-tuple fix-opts]
+(defn- doc-page [doc-tuple opts]
   [:div
    [:div.cljdoc-article.cljdoc-markup.lh-copy.pv4
     {:class (name (first doc-tuple))}
     (hiccup/raw
      (fixref/fix (rich-text/render-text doc-tuple)
-                 fix-opts))]])
+                 opts))]])
 
-(defn- ns-page [ns defs valid-ref-pred fix-opts]
+(defn- ns-page [ns defs valid-ref-pred opts]
   (let [ns-name (platf/get-field ns :name)
         render-wiki-link (api/render-wiki-link-fn ns-name valid-ref-pred #(str % ".html"))]
     [:div.ns-offline-page
      [:h1 ns-name]
-     (api/render-ns-docs ns render-wiki-link fix-opts)
+     (api/render-ns-docs ns render-wiki-link opts)
      (for [def defs]
-       (api/def-block def render-wiki-link fix-opts))]))
+       (api/def-block def render-wiki-link opts))]))
 
 (defn- docs-files
   "Return a list of [file-path content] pairs describing a zip archive.

--- a/src/cljdoc/spec/cache_bundle.clj
+++ b/src/cljdoc/spec/cache_bundle.clj
@@ -52,6 +52,9 @@
                                 [:vector
                                  [:ref ::doc-tree-entry]]]}}
             ::doc-tree-entry]]
+          [:cljdoc/docstring-format
+           {:optional true}
+           [:enum [:markdown :plaintext]]]
           [:cljdoc/include-namespaces-from-dependencies
            {:optional true}
            [:vector symbol?]]]]]]]

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -90,7 +90,7 @@
 
 (defnp ^:private get-version
   "Returns metadata for specific `version-id` a map:
-   - `:config` - a copy of the actual (TODO: or sometimes generated?), cljdoc.edn in the library  git repo for example:
+   - `:config` - a copy of the actual cljdoc.edn in the library git repo for example:
        ```
        {:cljdoc.doc/tree [[\"Readme\" {:file \"README.md\"}]
                           [\"Document tests\" {:file \"doc/overview.adoc\"}
@@ -242,6 +242,7 @@
     (if-not primary-resolved
       (throw (Exception. (format "Could not find version %s" v)))
       (let [version-data (or (get-version db-spec (:id primary-resolved)) {})
+            ;; TODO: is this misleading? I don't know that version data config retrieved from db will ever have sub-project configs merged
             include-cfg  (user-config/include-namespaces-from-deps (:config version-data) (proj/clojars-id v))
             wanted?      (set (map proj/normalize include-cfg))
             extra-deps   (filter #(wanted? (str (:group-id %) "/" (:artifact-id %))) resolved-versions)
@@ -291,6 +292,8 @@
 (comment
   ;; Note to reader: if this link still worked, it would reference new naming convention: .../cljdoc-analysis-edn/.../cljdoc-analysis.edn
   (def data (clojure.edn/read-string (slurp "https://2941-119377591-gh.circle-artifacts.com/0/cljdoc-edn/stavka/stavka/0.4.1/cljdoc.edn")))
+
+  (require '[cljdoc.config])
 
   (def db-spec
     (cljdoc.config/db (cljdoc.config/config)))

--- a/test/cljdoc/analysis/git_test.clj
+++ b/test/cljdoc/analysis/git_test.clj
@@ -10,7 +10,7 @@
                       :commit "c210e7f1c2f8a163676c8e3abeab8e50951458bb"}}}
          (git-ana/analyze-git-repo "metosin/reitit" "0.1.1" "https://github.com/metosin/reitit" nil))))
 
-(t/deftest ^:slow without-article-amendment-tag-test
+(t/deftest ^:slow without-cljdoc-tag-test
   (t/is (match?
          {:scm {:tag {:name "v1.0.0"}}
           :scm-articles m/absent
@@ -20,7 +20,7 @@
                      {:title "Inferred Title docb" :attrs {:cljdoc/asciidoc #"version: v1.0.0"}}]}
          (git-ana/analyze-git-repo "org.cljdoc/cljdoc-test-repo" "1.0.0" "https://github.com/cljdoc/cljdoc-test-repo" nil))))
 
-(t/deftest ^:slow with-article-amendment-tag-test
+(t/deftest ^:slow with-cljdoc-v101-tag-test
   (t/is (match?
          {:scm {:tag {:name "v1.0.1"}}
           :scm-articles {:tag {:name "cljdoc-v1.0.1"}}
@@ -32,11 +32,12 @@
                      {:title "explicit docb title" :attrs {:cljdoc/asciidoc #"version: cljdoc-v1.0.1"}}]}
          (git-ana/analyze-git-repo "org.cljdoc/cljdoc-test-repo" "1.0.1" "https://github.com/cljdoc/cljdoc-test-repo" nil))))
 
-(t/deftest ^:slow version-after-article-amendment-tag-test
+(t/deftest ^:slow version-cljdoc-102-tag-test
   (t/is (match?
          {:scm {:tag {:name "v1.0.2"}}
-          :scm-articles m/absent
-          :config (m/equals {})
+          :scm-articles {:tag {:name "cljdoc-v1.0.2"}}
+          :config (m/equals {:cljdoc.doc/tree m/absent
+                             :cljdoc/docstring-format :plaintext})
           :doc-tree [{:title "Readme" :attrs {:cljdoc/markdown #"version: v1.0.2"}}
                      {:title "Inferred Title doca" :attrs {:cljdoc/markdown #"version: v1.0.2"}}
                      {:title "Inferred Title docb" :attrs {:cljdoc/asciidoc #"version: v1.0.2"}}]}


### PR DESCRIPTION
Library authors can now specify `:cljdoc/docstring-format :plaintext` in their git hosted `doc/cljdoc.edn` config file.

Also: tweaked user-config a tad, simplified the code that chooses module library artifact config. I think it should be easier to grok now.

Closes #779