### PR TITLE
maint: bump deps, change test reporter

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,5 @@
 {:config-paths ^:replace [] ;; don't include user configs
- :skip-comments true ;; there's a fair bit of old test code in comment blocks that does not lint, skip it for now
+ :skip-comments true ;; there's a fair bit of old test code in (comment ...) blocks that does not lint, skip it for now
  :lint-as {taoensso.tufte/defnp clojure.core/defn
            clojure.core.cache/defcache clojure.core/defrecord
            clojure.test.check.clojure-test/defspec clojure.core/def

--- a/.clj-kondo/http-kit/http-kit/config.edn
+++ b/.clj-kondo/http-kit/http-kit/config.edn
@@ -1,0 +1,3 @@
+
+{:hooks
+ {:analyze-call {org.httpkit.server/with-channel httpkit.with-channel/with-channel}}}

--- a/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
+++ b/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
@@ -1,0 +1,16 @@
+(ns httpkit.with-channel
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-channel [{node :node}]
+  (let [[request channel & body] (rest (:children node))]
+    (when-not (and request     channel) (throw (ex-info "No request or channel provided" {})))
+    (when-not (api/token-node? channel) (throw (ex-info "Missing channel argument" {})))
+    (let [new-node
+          (api/list-node
+            (list*
+              (api/token-node 'let)
+              (api/vector-node [channel (api/vector-node [])])
+              request
+              body))]
+
+      {:node new-node})))

--- a/.clj-kondo/taoensso/encore/config.edn
+++ b/.clj-kondo/taoensso/encore/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}

--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,0 +1,16 @@
+(ns taoensso.encore
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defalias [{:keys [node]}]
+  (let [[sym-raw src-raw] (rest (:children node))
+        src (if src-raw src-raw sym-raw)
+        sym (if src-raw
+              sym-raw
+              (symbol (name (hooks/sexpr src))))]
+    {:node (with-meta
+             (hooks/list-node
+               [(hooks/token-node 'def)
+                (hooks/token-node (hooks/sexpr sym))
+                (hooks/token-node (hooks/sexpr src))])
+             (meta src))}))

--- a/deps.edn
+++ b/deps.edn
@@ -59,7 +59,7 @@
         org.clojure/tools.logging {:mvn/version "1.2.4"}     ;; logging facade
 
         ;; sentry service support
-        io.sentry/sentry-logback {:mvn/version "6.25.1"}     ;; logback appendery to Sentry service
+        io.sentry/sentry-logback {:mvn/version "6.25.2"}     ;; logback appendery to Sentry service
         raven-clj/raven-clj {:mvn/version "1.7.0"}           ;; Sentry service interface
 
         ;; reaching out to other services
@@ -70,7 +70,7 @@
         babashka/fs {:mvn/version "0.4.19"}                  ;; file system utilities (a modern version of clj-commons/fs)
         cheshire/cheshire {:mvn/version "5.11.0"}            ;; json
         clj-commons/fs {:mvn/version "1.6.310"}              ;; file system utilities
-        com.taoensso/tufte {:mvn/version "2.4.5"}            ;; profile/perf monitoring
+        com.taoensso/tufte {:mvn/version "2.5.0"}            ;; profile/perf monitoring
         lambdaisland/uri {:mvn/version "1.15.125"}           ;; URI/URLs
         org.clj-commons/digest {:mvn/version "1.4.100"}      ;; digest algs (md5, sha1, etc)
         org.clojure/core.cache {:mvn/version "1.0.225"}      ;; general caching library
@@ -95,7 +95,7 @@
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.05.26"}}
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.07.13"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :eastwood

--- a/tests.edn
+++ b/tests.edn
@@ -1,1 +1,1 @@
-#kaocha/v1 {:reporter kaocha.report.progress/report}
+#kaocha/v1 {:reporter kaocha.report/documentation}


### PR DESCRIPTION
Changed test reporter for developer run tests to document reporter. This lists each individual test as it is being run which, in my mind, provides much better feedback.

Add new .clj-kondo library lint exports downloaded by clj-kondo.