### PR TITLE
Add docstring format toggle to namespace docs

### DIFF
--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -1,7 +1,7 @@
 import { SidebarScrollPos } from "./index";
 
 function isNSOverviewPage(): boolean {
-  return !!document.querySelector(".ns-overview-page")
+  return !!document.querySelector(".ns-overview-page");
 }
 
 function isNSPage(): boolean {

--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -1,11 +1,15 @@
 import { SidebarScrollPos } from "./index";
 
+function isNSOverviewPage(): boolean {
+  return !!document.querySelector(".ns-overview-page")
+}
+
 function isNSPage(): boolean {
   return !!document.querySelector(".ns-page");
 }
 
 function isNSOfflinePage(): boolean {
-  return !!document.querySelector("ns-offline-page");
+  return !!document.querySelector(".ns-offline-page");
 }
 
 function isProjectDocumentationPage(): boolean {
@@ -171,6 +175,7 @@ export {
   toggleMetaDialog,
   toggleArticlesTip,
   isNSPage,
+  isNSOverviewPage,
   isNSOfflinePage,
   isProjectDocumentationPage,
   addPrevNextPageKeyHandlers

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -5,6 +5,7 @@ import { MobileNav } from "./mobile";
 import { Navigator } from "./navigator";
 import {
   isNSPage,
+  isNSOverviewPage,
   isNSOfflinePage,
   isProjectDocumentationPage,
   initSrollIndicator,
@@ -50,6 +51,10 @@ if (searchNode && searchNode.dataset) {
 // Used for navigating on the /versions page.
 const navigatorNode = document.querySelector("#js--cljdoc-navigator");
 navigatorNode && render(<Navigator />, navigatorNode);
+
+if (isNSOverviewPage()) {
+  initToggleRaw();
+}
 
 // Namespace page for online docs.
 if (isNSPage()) {


### PR DESCRIPTION
We already had raw<->formatted toggle for var docstrings. This adds same for namespace docstrings.

Also: noticed toggle had no effect for downloaded offline var docstrings, so fixed that.

Also: noticed `cljdoc/docstring-format :plaintext` had no effect for offline docs, so fixed that too.

Closes #782