### PR TITLE
Add copy button to code blocks

### DIFF
--- a/js/hljs-copybutton-plugin.ts
+++ b/js/hljs-copybutton-plugin.ts
@@ -1,0 +1,38 @@
+// A plugin to add a copy button to code blocks
+// There is https://github.com/arronhunt/highlightjs-copy but it seems to have some
+// unresolved issues. There is not much code to this, so let's just do a bare bones ourselves.
+
+const copyButtonPlugin = {
+  "after:highlightElement": ({
+    el,
+    text
+  }: {
+    el: HTMLElement;
+    text: string;
+  }) => {
+    let button: HTMLButtonElement = Object.assign(
+      document.createElement("button"),
+      {
+        innerHTML: "copy",
+        className: "hljs-copy-button"
+      }
+    );
+    button.dataset.copied = "false";
+    el.parentElement?.classList.add("hljs-copy-wrapper");
+    el.parentElement?.appendChild(button);
+    button.onclick = () => {
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(() => {
+          button.innerHTML = "copied";
+          button.dataset.copied = "true";
+        });
+        setTimeout(() => {
+          button.innerHTML = "copy";
+          button.dataset.copied = "false";
+        }, 2000);
+      }
+    };
+  }
+};
+
+export { copyButtonPlugin };

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -19,6 +19,7 @@ import {
 import { initRecentDocLinks } from "./recent-doc-links";
 import { mountSingleDocsetSearch } from "./single-docset-search";
 import { mergeHTMLPlugin } from "./hljs-merge-plugin";
+import { copyButtonPlugin } from "./hljs-copybutton-plugin";
 
 export type SidebarScrollPos = { page: string; scrollTop: number };
 
@@ -89,5 +90,6 @@ mountSingleDocsetSearch();
 // Save the sidebar scroll position when navigating away from the site so we can restore it later.
 window.onbeforeunload = saveSidebarScrollPos;
 
-// make the hljs plugin available to our layout page
+// make the hljs plugins available to our layout page
 window.mergeHTMLPlugin = mergeHTMLPlugin;
+window.copyButtonPlugin = copyButtonPlugin;

--- a/js/window.d.ts
+++ b/js/window.d.ts
@@ -2,6 +2,8 @@ export {};
 
 declare global {
   interface Window {
-    mergeHTMLPlugin: any; // allows us to expose our hljs plugin
+    // allows us to expose our hljs plugins
+    mergeHTMLPlugin: any;
+    copyButtonPlugin: any;
   }
 }

--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -901,3 +901,46 @@ table.frame-sides > colgroup + * > :first-child > * {
 .hljs-link {
   text-decoration: underline;
 }
+
+/*
+ * Highlight js copyButtonPlugin support
+ */
+
+.hljs-copy-wrapper {
+  position: relative;
+}
+
+.hljs-copy-wrapper:hover .hljs-copy-button {
+  visibility: visible;
+}
+
+.hljs-copy-button {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  width: 2rem;
+  height: 2rem;
+  color: #999;
+  border-radius: 0.25rem;
+  border: 1px solid #999;
+  background-color: #f6f8fa;
+  background-image: url(https://microicon-clone.vercel.app/content_paste/999);
+  background-repeat: no-repeat;
+  background-position: center;
+  visibility: hidden;
+}
+
+.hljs-copy-button:hover, hljs-copy-button:focus {
+  border-color: #357edd;
+  background-image: url(https://microicon-clone.vercel.app/content_paste/357edd);
+}
+
+.hljs-copy-button[data-copied="false"] {
+  text-indent: -9999px; /* Hide the inner text */
+}
+
+.hljs-copy-button[data-copied="true"] {
+  text-indent: 0px; /* Show the inner text */
+  width: auto;
+  background-image: none;
+}

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -14,6 +14,7 @@
   [:script
    (hiccup/raw
     "hljs.configure({ignoreUnescapedHTML: true});
+     hljs.addPlugin(copyButtonPlugin);
      hljs.addPlugin(mergeHTMLPlugin);
      hljs.registerLanguage('cljs', function (hljs) { return hljs.getLanguage('clj') });
      hljs.highlightAll();")])


### PR DESCRIPTION
I had a look around for an existing library and found https://github.com/arronhunt/highlightjs-copy.
It seems good, but maybe does more than we'd like and also perhaps has some unresolved issues.

So, taking some inspriaton from the above,  I coded up something simpler for cljdoc.

These UI things are subjective, but I think this is a reasonable first cut.

Closes #786