### PR TITLE
Work around Flexmark link-ref image-ref bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,7 @@ jobs:
       - run:
           name: Report Tools Versions
           command: |
+            java --version
             bb --version
             node --version
 

--- a/bb.edn
+++ b/bb.edn
@@ -7,6 +7,7 @@
  :tasks
  {;; setup
   :requires ([babashka.fs :as fs]
+             [build-shared :as bs]
              [lread.status-line :as status]
              [version])
   :enter (let [{:keys [name task-decoration] :as f} (current-task)]
@@ -56,6 +57,11 @@
                  (shell "npm run format"))
              (do (println "checking")
                  (shell "npm run lint"))))}
+  compile-java
+  {:doc "Compile java sources"
+   :task (if (seq (fs/modified-since bs/class-dir (fs/glob "." "src/**.java")))
+           (clojure "-T:build" "compile-java")
+           (println "Java sources already compiled to" bs/class-dir))}
   lint-js
   {:doc "lint typescript"
    :depends [deps-js]
@@ -65,20 +71,22 @@
              (System/exit exit)))}
   run
   {:doc "Launch cljdoc server"
-   :depends [deps-js compile-js]
+   :depends [deps-js compile-js compile-java]
    :task (apply clojure "-M:cli run" *command-line-args*)}
   ingest
   {:doc "Ingest docs locally for testing"
+   :depends [compile-java]
    :task (apply clojure "-M:cli ingest" *command-line-args*)}
   test
   {:doc "Run tests"
-   :depends [deps-js compile-js]
+   :depends [deps-js compile-js compile-java]
    :task (apply clojure "-M:test" *command-line-args*)}
   lint
   {:doc "[--rebuild] lint source code using clj-kondo"
    :task lint/-main}
   eastwood
   {:doc "lint source code using eastwood"
+   :depends [compile-java]
    :task (clojure "-M:test:eastwood")}
   code-format
   {:doc "(check|fix) check whitespace formatting"
@@ -95,6 +103,7 @@
            (println "Skipped: target/cljdoc.zip exists")
            (do
              (run 'compile-js)
+             (run 'compile-java)
              (apply package/-main *command-line-args*)))}
   docker-image
   {:doc "Create docker image"

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,15 @@
+(ns build
+  (:require
+   [build-shared :as bs]
+   [clojure.tools.build.api :as b]))
+
+(def basis (b/create-basis {:project "deps.edn"}))
+
+(defn compile-java [_opts]
+  (println "Compiling java sources")
+  (b/javac {:src-dirs bs/sources
+            :class-dir bs/class-dir
+            :basis basis
+            :javac-opts ["--release" "17"
+                         "-Xlint:all,-serial,-processing"
+                         "-Werror"]} ))

--- a/build_shared.clj
+++ b/build_shared.clj
@@ -1,0 +1,6 @@
+(ns build-shared
+  "Common to babashka and clojure")
+
+(def target "target")
+(def sources ["src"])
+(def class-dir (str target "/classes"))

--- a/deps.edn
+++ b/deps.edn
@@ -86,13 +86,17 @@
         cljdoc/cljdoc-shared {:git/url "https://github.com/cljdoc/cljdoc-shared.git"
                               :git/sha "53c113e375df94d50cf96c6f2c1b3842dc0e9b35"}}
 
- :paths ["src" "resources" "resources-compiled"]
+ :paths ["src" "resources" "resources-compiled" "target/classes"]
  :aliases {:test
            {:extra-paths ["test"]
             :extra-deps {lambdaisland/kaocha {:mvn/version "1.85.1342"}
                          org.clojure/test.check {:mvn/version "1.1.1"}
                          nubank/matcher-combinators {:mvn/version "3.8.5" :exclusions [midje/midje]}}
             :main-opts ["-m" "kaocha.runner"]}
+
+           :build
+           {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}}
+            :ns-default build}
 
            :clj-kondo
            {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.07.13"}}

--- a/doc/cljdoc-developer-technical-guide.adoc
+++ b/doc/cljdoc-developer-technical-guide.adoc
@@ -217,6 +217,20 @@ alongside, in the same directory, the draw.io source `system-overview.drawio`.
 
 To make things easy to find, images should sit in the same directory as the doc.
 
+== Java Source
+
+We have a wee bit of Java source to work-around a flexmark bug.
+
+We probably could have incorporated this fix in Clojure using `gen-class`, but a little Java code is often simpler than puzzling out how to get `gen-class` working.
+
+Before you start a REPL you'll need to:
+
+```
+bb compile-java
+```
+
+And if you make any changes to Java source, you'll need restart your REPL after a `bb compile-java`.
+
 == Tasks
 
 We make use of babashka tasks.

--- a/script/package.clj
+++ b/script/package.clj
@@ -18,7 +18,7 @@
     (fs/create-dirs target)
     (fs/delete-if-exists zipfile)
     ;; fs/zip does not preserve executable status, but InfoZip does so shell out.
-    (t/shell "zip -q -r" zipfile "src" "modules" "script" "resources" "resources-compiled" "deps.edn")))
+    (t/shell "zip -q -r" zipfile "src" "modules" "script" "resources" "resources-compiled" "deps.edn" "target/classes")))
 
 (defn -main [& _args]
   (package))

--- a/src/cljdoc/render/FixupImgRefLinksExtension.java
+++ b/src/cljdoc/render/FixupImgRefLinksExtension.java
@@ -1,0 +1,27 @@
+package cljdoc.render;
+
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.data.MutableDataHolder;
+
+/**
+ * Flexmark extension work around img ref link bug.
+ * See: https://github.com/vsch/flexmark-java/issues/551
+ */
+public class FixupImgRefLinksExtension implements Parser.ParserExtension {
+    private FixupImgRefLinksExtension() {
+    }
+
+    public static FixupImgRefLinksExtension create() {
+        return new FixupImgRefLinksExtension();
+    }
+
+    @Override
+    public void parserOptions(MutableDataHolder mutableDataHolder) {
+    }
+
+    @Override
+    public void extend(Parser.Builder parserBuilder) {
+        parserBuilder.postProcessorFactory(new FixupImgRefLinksPostProcessor.Factory());
+    }
+
+}

--- a/src/cljdoc/render/FixupImgRefLinksPostProcessor.java
+++ b/src/cljdoc/render/FixupImgRefLinksPostProcessor.java
@@ -1,0 +1,60 @@
+package cljdoc.render;
+
+import com.vladsch.flexmark.ast.*;
+import com.vladsch.flexmark.parser.block.NodePostProcessor;
+import com.vladsch.flexmark.parser.block.NodePostProcessorFactory;
+import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.ast.NodeTracker;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Flexmark post processor to work around ref link bug.
+ * See: https://github.com/vsch/flexmark-java/issues/551
+ *
+ * For every ImageRef node, we look for the pattern the bug produces
+ * and manipulate AST to correct.
+ *
+ * `[<ImageRef>]<LinkRef>` is converted to `<LinkRef>` with `<ImageRef>`
+ * as body.
+ *
+ * The pattern is unique enough that I expect it would be unlikely it affects
+ * any other AST.
+ */
+public class FixupImgRefLinksPostProcessor extends NodePostProcessor {
+
+    @Override
+    public void process(@NotNull NodeTracker state, @NotNull Node node) {
+        if (node instanceof ImageRef imageRef) {
+            if ((imageRef.getPrevious() instanceof Text leftBr)
+                && (leftBr.getChars().toString().equals("["))) {
+                if ((imageRef.getNext() instanceof Text rightBr)
+                    && (rightBr.getChars().toString().equals("]"))) {
+                    if (rightBr.getNext() instanceof LinkRef linkRef) {
+                        linkRef.removeChildren();
+                        linkRef.appendChild(imageRef);
+                        state.nodeAdded(imageRef);
+
+                        rightBr.unlink();
+                        leftBr.unlink();
+                        state.nodeRemoved(rightBr);
+                        state.nodeRemoved(leftBr);
+                    }
+                }
+            }
+        }
+    }
+
+    public static class Factory extends NodePostProcessorFactory {
+        public Factory() {
+            super(false);
+            addNodes(ImageRef.class);
+        }
+
+        @NotNull
+        @Override
+        public NodePostProcessor apply(@NotNull Document document) {
+            return new FixupImgRefLinksPostProcessor();
+        }
+    }
+}

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -1,6 +1,7 @@
 (ns cljdoc.render.rich-text
   (:require [cljdoc.render.sanitize :as sanitize])
   (:import (org.asciidoctor Asciidoctor Asciidoctor$Factory Options Attributes)
+           (cljdoc.render FixupImgRefLinksExtension)
            (com.vladsch.flexmark.parser Parser LinkRefProcessorFactory LinkRefProcessor)
            (com.vladsch.flexmark.html HtmlRenderer LinkResolverFactory LinkResolver)
            (com.vladsch.flexmark.html.renderer ResolvedLink LinkType LinkStatus LinkResolverBasicContext DelegatingNodeRendererFactory NodeRenderer NodeRenderingHandler NodeRenderingHandler$CustomNodeRenderer)
@@ -35,7 +36,8 @@
         sanitize/clean)))
 
 (def md-extensions
-  [(TablesExtension/create)
+  [(FixupImgRefLinksExtension/create)
+   (TablesExtension/create)
    (AutolinkExtension/create)
    (AnchorLinkExtension/create)])
 

--- a/test/cljdoc/render/rich_text_test.clj
+++ b/test/cljdoc/render/rich_text_test.clj
@@ -25,6 +25,50 @@
                (rich-text/markdown-to-html "[[]]"
                                            {:render-wiki-link (fn [wikilink-ref] (when (= "my.namespace.here/fn1" wikilink-ref) "/resolved/to/something"))}))))))
 
+(t/deftest markdown-imgref-linkref-test
+  ;; we have hacked around a flexmark bug, here we test that hack.
+  (t/testing "as described https://github.com/vsch/flexmark-java/issues/551"
+    (t/is (= "<p><a href=\"http://www.example.com/index.html\"><img src=\"https://picsum.photos/200\" alt=\"alt text\" /></a></p>\n"
+             (rich-text/markdown-to-html (str "[![alt text][img-url]][target-url]\n"
+                                              "\n"
+                                              "[target-url]: http://www.example.com/index.html\n"
+                                              "[img-url]: https://picsum.photos/200\n")))))
+  (t/testing "extract from reported https://github.com/cljdoc/cljdoc/issues/743"
+    (t/is (= (str "<h1><a href=\"#mathboxcljs\" id=\"mathboxcljs\" class=\"md-anchor\">MathBox.cljs</a></h1>\n"
+                  "<p>A <a href=\"https://reagent-project.github.io/\">Reagent</a> interface to the <a href=\"https://github.com/unconed/mathbox\">MathBox</a> mathematical\nvisualization library.</p>\n"
+                  "<p><a href=\"https://github.com/mentat-collective/mathbox.cljs/actions/workflows/kondo.yml\"><img src=\"https://github.com/mentat-collective/mathbox.cljs/actions/workflows/kondo.yml/badge.svg?branch&#61;main\" alt=\"Build Status\" /></a>\n"
+                  "<a href=\"LICENSE\"><img src=\"https://img.shields.io/badge/license-MIT-brightgreen.svg\" alt=\"License\" /></a>\n"
+                  "<a href=\"https://cljdoc.org/d/org.mentat/mathbox.cljs/CURRENT\"><img src=\"https://cljdoc.org/badge/org.mentat/mathbox.cljs\" alt=\"cljdoc badge\" /></a>\n"
+                  "<a href=\"https://clojars.org/org.mentat/mathbox.cljs\"><img src=\"https://img.shields.io/clojars/v/org.mentat/mathbox.cljs.svg\" alt=\"Clojars Project\" /></a>\n"
+                  "<a href=\"https://discord.gg/hsRBqGEeQ4\"><img src=\"https://img.shields.io/discord/731131562002743336?style&#61;flat&amp;colorA&#61;000000&amp;colorB&#61;000000&amp;label&#61;&amp;logo&#61;discord\" alt=\"Discord Shield\" /></a></p>\n")
+             (rich-text/markdown-to-html "# MathBox.cljs
+
+A [Reagent][reagent-url] interface to the [MathBox][mathbox-url] mathematical
+visualization library.
+
+[![Build Status][build-status]][build-status-url]
+[![License][license]][license-url]
+[![cljdoc badge][cljdoc]][cljdoc-url]
+[![Clojars Project][clojars]][clojars-url]
+[![Discord Shield][discord]][discord-url]
+
+[build-status-url]: https://github.com/mentat-collective/mathbox.cljs/actions/workflows/kondo.yml
+[build-status]: https://github.com/mentat-collective/mathbox.cljs/actions/workflows/kondo.yml/badge.svg?branch=main
+[cljdoc-url]: https://cljdoc.org/d/org.mentat/mathbox.cljs/CURRENT
+[cljdoc]: https://cljdoc.org/badge/org.mentat/mathbox.cljs
+[clojars-url]: https://clojars.org/org.mentat/mathbox.cljs
+[clojars]: https://img.shields.io/clojars/v/org.mentat/mathbox.cljs.svg
+[discord-url]: https://discord.gg/hsRBqGEeQ4
+[discord]: https://img.shields.io/discord/731131562002743336?style=flat&colorA=000000&colorB=000000&label=&logo=discord
+[license-url]: LICENSE
+[license]: https://img.shields.io/badge/license-MIT-brightgreen.svg
+[mathbox-url]: https://github.com/unconed/mathbox
+[reagent-url]: https://reagent-project.github.io/
+"))))
+  (t/testing "a solo imgref is not broken by our fix"
+    (t/is (= "<p><img src=\"foo.png\" alt=\"foo alt\" /></p>\n"
+             (rich-text/markdown-to-html "![foo alt][foo-img-url]\n\n[foo-img-url]: foo.png")))))
+
 (t/deftest md-html-escaping
   (t/is (= "<p>&lt;h1&gt;Hello&lt;/h1&gt;</p>\n"
            (rich-text/markdown-to-html "<h1>Hello</h1>" {:escape-html? true})))


### PR DESCRIPTION
We use Flexmark to render markdown.

Add a custom Flexmark post processor to fixup Flexmark AST for a link-ref whose body is an image-ref.

Closes #743