### PR TITLE
Avoid using HTML id attribute to avoid conflicts with user content

### DIFF
--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -118,9 +118,9 @@ function saveSidebarScrollPos() {
 
 function toggleMetaDialog() {
   if (document.querySelector(".js--main-scroll-view")) {
-    const metaIcon = document.querySelector("[data-id='cljdoc-js--meta-icon']");
-    const metaDialog = document.querySelector("[data-id='cljdoc-js--meta-dialog']");
-    const metaClose = document.querySelector("[data-id='cljdoc-js--meta-close']");
+    const metaIcon = document.querySelector("[data-id='cljdoc-js--meta-icon']") as HTMLElement;
+    const metaDialog = document.querySelector("[data-id='cljdoc-js--meta-dialog']") as HTMLElement;
+    const metaClose = document.querySelector("[data-id='cljdoc-js--meta-close']") as HTMLElement;
 
     if (metaIcon) {
       metaIcon.onclick = () => {
@@ -139,8 +139,8 @@ function toggleMetaDialog() {
 }
 
 function toggleArticlesTip() {
-  const tipToggler = document.querySelector("[data-id='cljdoc-js--articles-tip-toggler']");
-  const tip = document.querySelector("[data-id='cljdoc-js--articles-tip']");
+  const tipToggler = document.querySelector("[data-id='cljdoc-js--articles-tip-toggler']") as HTMLElement;
+  const tip = document.querySelector("[data-id='cljdoc-js--articles-tip']") as HTMLElement;
   if (tipToggler && tip) {
     tipToggler.onclick = () => {
       tip.classList.toggle("dn");

--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -118,9 +118,15 @@ function saveSidebarScrollPos() {
 
 function toggleMetaDialog() {
   if (document.querySelector(".js--main-scroll-view")) {
-    const metaIcon = document.querySelector("[data-id='cljdoc-js--meta-icon']") as HTMLElement;
-    const metaDialog = document.querySelector("[data-id='cljdoc-js--meta-dialog']") as HTMLElement;
-    const metaClose = document.querySelector("[data-id='cljdoc-js--meta-close']") as HTMLElement;
+    const metaIcon = document.querySelector(
+      "[data-id='cljdoc-js--meta-icon']"
+    ) as HTMLElement;
+    const metaDialog = document.querySelector(
+      "[data-id='cljdoc-js--meta-dialog']"
+    ) as HTMLElement;
+    const metaClose = document.querySelector(
+      "[data-id='cljdoc-js--meta-close']"
+    ) as HTMLElement;
 
     if (metaIcon) {
       metaIcon.onclick = () => {
@@ -139,8 +145,12 @@ function toggleMetaDialog() {
 }
 
 function toggleArticlesTip() {
-  const tipToggler = document.querySelector("[data-id='cljdoc-js--articles-tip-toggler']") as HTMLElement;
-  const tip = document.querySelector("[data-id='cljdoc-js--articles-tip']") as HTMLElement;
+  const tipToggler = document.querySelector(
+    "[data-id='cljdoc-js--articles-tip-toggler']"
+  ) as HTMLElement;
+  const tip = document.querySelector(
+    "[data-id='cljdoc-js--articles-tip']"
+  ) as HTMLElement;
   if (tipToggler && tip) {
     tipToggler.onclick = () => {
       tip.classList.toggle("dn");

--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -150,10 +150,10 @@ function toggleArticlesTip() {
 
 function addPrevNextPageKeyHandlers() {
   const prevLink: HTMLAnchorElement | null = document.querySelector(
-    "a#prev-article-page-link"
+    "a[data-id='cljdoc-prev-article-page-link']"
   );
   const nextLink: HTMLAnchorElement | null = document.querySelector(
-    "a#next-article-page-link"
+    "a[data-id='cljdoc-next-article-page-link']"
   );
   if (prevLink || nextLink) {
     document.addEventListener("keydown", function (e) {

--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -118,9 +118,9 @@ function saveSidebarScrollPos() {
 
 function toggleMetaDialog() {
   if (document.querySelector(".js--main-scroll-view")) {
-    const metaIcon = document.getElementById("js--meta-icon");
-    const metaDialog = document.getElementById("js--meta-dialog");
-    const metaClose = document.getElementById("js--meta-close");
+    const metaIcon = document.querySelector("[data-id='cljdoc-js--meta-icon']");
+    const metaDialog = document.querySelector("[data-id='cljdoc-js--meta-dialog']");
+    const metaClose = document.querySelector("[data-id='cljdoc-js--meta-close']");
 
     if (metaIcon) {
       metaIcon.onclick = () => {
@@ -139,8 +139,8 @@ function toggleMetaDialog() {
 }
 
 function toggleArticlesTip() {
-  const tipToggler = document.getElementById("js--articles-tip-toggler");
-  const tip = document.getElementById("js--articles-tip");
+  const tipToggler = document.querySelector("[data-id='cljdoc-js--articles-tip-toggler']");
+  const tip = document.querySelector("[data-id='cljdoc-js--articles-tip']");
   if (tipToggler && tip) {
     tipToggler.onclick = () => {
       tip.classList.toggle("dn");

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -36,7 +36,7 @@ const switcher = document.querySelector("[data-id='cljdoc-switcher']");
 switcher && render(<Switcher />, switcher);
 
 // Libraries search, found on cljdoc homepage and the 404 page.
-const searchNode: HTMLElement | null = document.querySelector("#cljdoc-search");
+const searchNode: HTMLElement | null = document.querySelector("[data-id='cljdoc-search']");
 if (searchNode && searchNode.dataset) {
   render(
     <App

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -50,7 +50,7 @@ if (searchNode && searchNode.dataset) {
 }
 
 // Used for navigating on the /versions page.
-const navigatorNode = document.querySelector("#js--cljdoc-navigator");
+const navigatorNode = document.querySelector("[data-id='cljdoc-js--cljdoc-navigator']");
 navigatorNode && render(<Navigator />, navigatorNode);
 
 if (isNSOverviewPage()) {
@@ -71,7 +71,7 @@ if (isNSOfflinePage()) {
 // For just general documentation pages, specifically routes that begin with /d/.
 if (isProjectDocumentationPage()) {
   // Special handling for mobile nav. It makes the sidebar from desktop toggleable.
-  const mobileNav = document.querySelector("#js--mobile-nav");
+  const mobileNav = document.querySelector("[data-id='cljdoc-js--mobile-nav']");
   mobileNav && render(<MobileNav />, mobileNav);
   toggleMetaDialog();
   toggleArticlesTip();

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -32,7 +32,7 @@ restoreSidebarScrollPos();
 
 // Enable the switcher, which lets you rapidly switch between recently opened
 // projects. The switcher is not included in offline docs.
-const switcher = document.querySelector("#cljdoc-switcher");
+const switcher = document.querySelector("[data-id='cljdoc-switcher']");
 switcher && render(<Switcher />, switcher);
 
 // Libraries search, found on cljdoc homepage and the 404 page.

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -79,7 +79,7 @@ if (isProjectDocumentationPage()) {
 }
 
 // Links to recent docsets on the homepage.
-const docLinks = document.querySelector("#doc-links");
+const docLinks = document.querySelector("[data-id='cljdoc-doc-links']");
 if (docLinks) {
   initRecentDocLinks(docLinks);
 }

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -36,7 +36,9 @@ const switcher = document.querySelector("[data-id='cljdoc-switcher']");
 switcher && render(<Switcher />, switcher);
 
 // Libraries search, found on cljdoc homepage and the 404 page.
-const searchNode: HTMLElement | null = document.querySelector("[data-id='cljdoc-search']");
+const searchNode: HTMLElement | null = document.querySelector(
+  "[data-id='cljdoc-search']"
+);
 if (searchNode && searchNode.dataset) {
   render(
     <App
@@ -50,7 +52,9 @@ if (searchNode && searchNode.dataset) {
 }
 
 // Used for navigating on the /versions page.
-const navigatorNode = document.querySelector("[data-id='cljdoc-js--cljdoc-navigator']");
+const navigatorNode = document.querySelector(
+  "[data-id='cljdoc-js--cljdoc-navigator']"
+);
 navigatorNode && render(<Navigator />, navigatorNode);
 
 if (isNSOverviewPage()) {

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -30,7 +30,7 @@ export const initRecentDocLinks = (docLinks: Element) => {
   );
   if (previouslyOpened.length > 0) {
     if (previouslyOpened.length >= 3) {
-      const examples = document.querySelector("#examples");
+      const examples = document.querySelector("[data-id='cljdoc-examples']");
       if (examples) examples.remove();
     }
     render(

--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -76,7 +76,7 @@ const clamp = (value: number, min: number, max: number) =>
 
 const mountSingleDocsetSearch = async () => {
   const singleDocsetSearchNode: HTMLElement | null = document.querySelector(
-    "#js--single-docset-search"
+    "[data-id='cljdoc-js--single-docset-search']"
   );
 
   const url = singleDocsetSearchNode?.dataset?.searchsetUrl;

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -16,13 +16,13 @@
    (if prev-page
      [:a.link.blue
       {:href (doc-link version-entity (-> prev-page :attrs :slug-path))
-       :id "prev-article-page-link"}
+       :data-id "cljdoc-prev-article-page-link"}
       [:span [:span.mr1 "❮"] (-> prev-page :title)]]
      [:div])
    (when next-page
      [:a.link.blue
       {:href (doc-link version-entity (-> next-page :attrs :slug-path))
-       :id "next-article-page-link"}
+       :data-id "cljdoc-next-article-page-link"}
       [:span (-> next-page :title) [:span.ml1 "❯"]]])])
 
 (defn doc-tree-view

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -49,7 +49,7 @@
   (assert doc-type)
   [:div.mw7.center
    (if doc-html
-     [:div#doc-html.cljdoc-article.cljdoc-markup.lh-copy.pv4
+     [:div.cljdoc-article.cljdoc-markup.lh-copy.pv4
       {:class (name doc-type)}
       (hiccup/raw doc-html)
       (prev-next-navigation {:prev-page prev-page

--- a/src/cljdoc/render/home.clj
+++ b/src/cljdoc/render/home.clj
@@ -29,12 +29,12 @@
           [:img {:src (get (:static-resources context) "/cljdoc-logo.svg") :alt "cljdoc logo" :width "150px"}]]
          [:p.f2-ns.f3.mv3.w-90-l.lh-copy tagline]
          (search/search-form (-> context :request :query-params :q))
-         [:p#examples.lh-copy "Read " [:a.link.blue {:href (links/github-url :rationale)} "the rationale"]
+         [:p.lh-copy {:data-id "cljdoc-examples"} "Read " [:a.link.blue {:href (links/github-url :rationale)} "the rationale"]
           " or check out some examples: "
           [:a.link.blue.nowrap {:href "/d/rum/rum/CURRENT"} "rum"] ", "
           [:a.link.blue.nowrap {:href "/d/lambdaisland/kaocha/CURRENT"} "kaocha"] ", "
           [:a.link.blue.nowrap {:href "/d/metosin/reitit/CURRENT"} "reitit"] "."]
-         [:p#doc-links.mv0]]
+         [:p.mv0 {:data-id "cljdoc-doc-links"}]]
 
         [:div.mt5-ns.bg-white
          (into [:div.dt-l.dt--fixed.bb.bt.b--light-gray.lh-copy]

--- a/src/cljdoc/render/index_pages.clj
+++ b/src/cljdoc/render/index_pages.clj
@@ -97,7 +97,7 @@
   (->> [:div
         (layout/top-bar-generic)
         [:div.pa4-ns.pa2
-         [:div#js--cljdoc-navigator]
+         [:div {:data-id "cljdoc-js--cljdoc-navigator"}]
          [:h1.mt5 (if (= :built source)
                     "All built artifacts on cljdoc:"
                     "All known available artifacts:")]

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -82,9 +82,9 @@
   the browser can't retrieve the application's JS sources."
   [opts]
   [:div.fixed.left-0.right-0.bottom-0.bg-washed-red.code.b--light-red.bw3.ba.dn
-   {:id "no-js-warning"}
+   {:data-id "no-js-warning"}
    [:script
-    (hiccup/raw (str "fetch(\"" (get (:static-resources opts) "/cljdoc.js")) "\").then(e => e.status === 200 ? null : document.getElementById('no-js-warning').classList.remove('dn'))")]
+    (hiccup/raw (str "fetch(\"" (get (:static-resources opts) "/cljdoc.js")) "\").then(e => e.status === 200 ? null : document.querySelector('[data-id=\"no-js-warning\"]').classList.remove('dn'))")]
    [:p.ph4 "Could not find JavaScript assets, please refer to " [:a.fw7.link {:href (links/github-url :running-locally)} "the documentation"] " for how to build JS assets."]])
 
 (defn page [opts contents]

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -132,7 +132,7 @@
                   contents]
                  (when (not= :prod (config/profile))
                    (no-js-warning opts))
-                 [:div#cljdoc-switcher]
+                 [:div {:data-id "cljdoc-switcher"}]
                  [:script {:src (get (:static-resources opts) "/cljdoc.js")}]
                  (highlight-js)
                  (add-requested-features (:page-features opts))]]))

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -188,8 +188,8 @@
    [:div.tr
     {:style {:flex-grow 1}}
     [:form.dn.dib-ns.mr3 {:action "/api/request-build2" :method "POST"}
-     [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "project" :name "project" :value (str (:group-id version-entity) "/" (:artifact-id version-entity))}]
-     [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "version" :name "version" :value (:version version-entity)}]
+     [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :name "project" :value (str (:group-id version-entity) "/" (:artifact-id version-entity))}]
+     [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :name "version" :value (:version version-entity)}]
      [:input.f7.white.hover-near-white.outline-0.bn.bg-white {:type "submit" :value "rebuild"}]]
     (cond
       (and scm-url (scm/http-uri scm-url))

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -150,9 +150,11 @@
 
 (defn meta-info-dialog []
   [:div
-   [:img#js--meta-icon.ma3.fixed.right-0.bottom-0.bg-white.dn.db-ns.pointer
-    {:src "https://microicon-clone.vercel.app/explore/48/357edd"}]
-   [:div#js--meta-dialog.ma3.pa3.ba.br3.b--blue.bw2.w-20.fixed.right-0.bottom-0.bg-white.dn
+   [:img.ma3.fixed.right-0.bottom-0.bg-white.dn.db-ns.pointer
+    {:data-id "cljdoc-js--meta-icon"
+     :src "https://microicon-clone.vercel.app/explore/48/357edd"}]
+   [:div.ma3.pa3.ba.br3.b--blue.bw2.w-20.fixed.right-0.bottom-0.bg-white.dn
+    {:data-id "cljdoc-js--meta-dialog"}
     [:p.ma0
      [:b "cljdoc"]
      " is a website building & hosting documentation for Clojure/Script libraries"]
@@ -165,7 +167,7 @@
                 ["Report a problem"    (links/github-url :issues)]
                 ;; ["Recent improvements" "#"] TODO add link once it exists
                 ["cljdoc on GitHub"    (links/github-url :home)]]))
-    [:a#js--meta-close.link.black.fr.pointer
+    [:a.link.black.fr.pointer {:data-id "cljdoc-js--meta-close"}
      "× close"]]])
 
 (def home-link
@@ -264,7 +266,7 @@
   [r-main-container
    [r-top-bar-container
     top-bar
-    [:div#js--mobile-nav.db.dn-ns]]
+    [:div#db.dn-ns {:data-id "cljdoc-js--mobile-nav"}]]
    mobile-nav-spacer
    [:div.flex.flex-row
     ;; Without min-height: 0 the sidebar and main content area won't

--- a/src/cljdoc/render/search.clj
+++ b/src/cljdoc/render/search.clj
@@ -5,7 +5,7 @@
   ([] (search-form ""))
   ([search-terms]
    [:div.w-90.mb4
-    [:div#cljdoc-search {:data-initial-value search-terms}]]))
+    [:div {:data-id "cljdoc-search" :data-initial-value search-terms}]]))
 
 (defn search-page [context]
   (->> [:div

--- a/src/cljdoc/render/searchset_search.clj
+++ b/src/cljdoc/render/searchset_search.clj
@@ -4,7 +4,7 @@
 
 (defn searchbar
   [version-entity]
-  [:div#js--single-docset-search
-   {:data-searchset-url (routes/url-for :api/searchset
-                                        :params
-                                        version-entity)}])
+  [:div {:data-id "cljdoc-js--single-docset-search"
+         :data-searchset-url (routes/url-for :api/searchset
+                                             :params
+                                             version-entity)}])

--- a/src/cljdoc/render/sidebar.clj
+++ b/src/cljdoc/render/sidebar.clj
@@ -67,10 +67,10 @@
       (layout/sidebar-title [:span "Articles"
                              (when articles-tip?
                                [:sup.ttl
-                                [:a#js--articles-tip-toggler {:href "#"}
+                                [:a {:href "#" :data-id "cljdoc-js--articles-tip-toggler"}
                                  [:span.link.dib.ml1.v-mid.hover-blue.ttl.silver "tip"]]])])
       (when articles-tip?
-        [:div#js--articles-tip.dn
+        [:div.dn {:data-id "cljdoc-js--articles-tip"}
          [:div.mb1.ba.br3.silver.b--blue.bw1.db.f6.w-100.pt1.pa1
           (cond
             no-scm?


### PR DESCRIPTION
A library author can specify link anchors in their articles. 
These are rendered in HTML as `id` attributes.

Cljdoc was, in various places, also using HTML `id` attributes for various things.
Some ids were common words, and therefore more likely to conflict, like `version` and `project`.

This PR moves these cljdoc `id` attributes to `data-id` attributes to avoid potential conflict with user content. (A viable alternative would have been to use class names, but I felt this made it clearer these ids are all for use from JavaScript).

There remains a few `id` attributes generated by the asciidoc converter, (ex. `toc` and `toctitle`) I've not bothered to address these at this time.

Closes #803