### PR TITLE
fix: adoc style for only-child code elem in table

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -446,11 +446,6 @@ table.frame-sides > colgroup + * > :first-child > * {
   font-weight: bold;
 }
 
-.asciidoc p.tableblock > code:only-child {
-  background: none;
-  padding: 0;
-}
-
 .asciidoc p.tableblock {
   font-size: 1em;
 }


### PR DESCRIPTION
Don't see any need to format this case differently, if we learn differently, we'll adapt.

Closes #805