### PR TITLE
Revert "fix: adoc style for only-child code elem in table"

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -446,6 +446,11 @@ table.frame-sides > colgroup + * > :first-child > * {
   font-weight: bold;
 }
 
+.asciidoc p.tableblock > code:only-child {
+  background: none;
+  padding: 0;
+}
+
 .asciidoc p.tableblock {
   font-size: 1em;
 }


### PR DESCRIPTION
This reverts commit daec34a78bfeb008c636fa0d8fa6143dcd62c204.

Closes #805