### PR TITLE
Fixups for sidebar scroll pos save/restore

### DIFF
--- a/js/index.tsx
+++ b/js/index.tsx
@@ -21,14 +21,10 @@ import { mountSingleDocsetSearch } from "./single-docset-search";
 import { mergeHTMLPlugin } from "./hljs-merge-plugin";
 import { copyButtonPlugin } from "./hljs-copybutton-plugin";
 
-export type SidebarScrollPos = { page: string; scrollTop: number };
+export type SidebarScrollState = { libVersionPath: string; scrollTop: number };
 
 // Tracks recently opened projects in localStorage.
 trackProjectOpened();
-
-// Sidebar scroll position is saved when navigating away from the site.
-// Here we restore that position when the site loads.
-restoreSidebarScrollPos();
 
 // Enable the switcher, which lets you rapidly switch between recently opened
 // projects. The switcher is not included in offline docs.
@@ -91,8 +87,11 @@ if (docLinks) {
 // Mount the single docset search if the search element is present.
 mountSingleDocsetSearch();
 
-// Save the sidebar scroll position when navigating away from the site so we can restore it later.
-window.onbeforeunload = saveSidebarScrollPos;
+document.addEventListener("DOMContentLoaded", () => {
+  // Save the sidebar scroll position when clicking on an elem so we can restore after page loads
+  saveSidebarScrollPos();
+  restoreSidebarScrollPos();
+});
 
 // make the hljs plugins available to our layout page
 window.mergeHTMLPlugin = mergeHTMLPlugin;

--- a/src/cljdoc/render/articles.clj
+++ b/src/cljdoc/render/articles.clj
@@ -39,7 +39,7 @@
                     [:a.link.blue.hover-dark-blue.dib.pv1
                      {:style {:word-wrap "break-word"}
                       :href  (doc-link version-entity slug-path)
-                      :class (when (= current-page slug-path) "fw7")}
+                      :class (when (= current-page slug-path) "b")}
                      (:title doc-page)]
                     (doc-tree-view version-entity (:children doc-page) current-page (inc level))])))
           (into [:ul.list.ma0 {:class (if (pos? level) "f6-ns pl2" "pl0")}])))))


### PR DESCRIPTION
Switched from localStorage to sessionStorage for scroll state. I think being more ephemeral here is the better way to go.

Noticed that restored scroll position was a bit off every time. Waiting for the dom to load fixed this jitter.

Now saving scroll state when a user clicks on a sidebar item. If that state is present and is for the same doc lib/version on load, then we restore the scroll pos.

Otherwise, if the selected sidebar item is out of view, we scroll to it. This supports things like bookmarks.

Noticed that style for highlighting of article and api items were different. They are now both a tachyons `b`.

Because our docset search input is effectively part of the sidebar and scrolls with the sidebar, I opted to not to do any automatic scrolling when the user selects a docset search match.

Closes #790