### PR TITLE
Add support for plaintext .txt articles

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -16,6 +16,15 @@ pre {
   font-size: 12px;
 }
 
+/* plaintext for .txt articles */
+
+.plaintext
+{
+  white-space: pre;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
+    monospace;
+}
+
 /* Markdown / AsciiDoc
  *
  * Class legend

--- a/src/cljdoc/doc_tree.clj
+++ b/src/cljdoc/doc_tree.clj
@@ -80,6 +80,7 @@
 (defmethod filepath->type "markdown" [_] :cljdoc/markdown)
 (defmethod filepath->type "md" [_] :cljdoc/markdown)
 (defmethod filepath->type "adoc" [_] :cljdoc/asciidoc)
+(defmethod filepath->type "txt" [_] :cljdoc/plaintext)
 
 (defn- uslug
   "Unicode friendly version of `slug` function.


### PR DESCRIPTION
Clojure's README is readme.txt and uses plain text.

I don't know of any other library that uses .txt for articles, but this one is important enough to add the necessary support.

Closes #819