### PR TITLE
Migrate from clojure.java.jdbc to next.jdbc

### DIFF
--- a/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
@@ -1,4 +1,5 @@
 {:hooks
  {:analyze-call
   {next.jdbc/with-transaction
-   hooks.com.github.seancorfield.next-jdbc/with-transaction}}}
+   hooks.com.github.seancorfield.next-jdbc/with-transaction}}
+ :lint-as {next.jdbc/on-connection clojure.core/with-open}}

--- a/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
@@ -1,0 +1,18 @@
+(ns hooks.com.github.seancorfield.next-jdbc
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-transaction
+  "Expands (with-transaction [tx expr opts] body)
+  to (let [tx expr] opts body) per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))

--- a/deps.edn
+++ b/deps.edn
@@ -18,11 +18,12 @@
         commons-fileupload/commons-fileupload {:mvn/version "1.5"}
 
         ;; relational database
-        org.clojure/java.jdbc {:mvn/version "0.7.12"}        ;; jdbc abstraction
+        com.github.seancorfield/next.jdbc {:mvn/version "1.3.883"} ;; jdbc abstraction
         org.xerial/sqlite-jdbc {:mvn/version "3.42.0.0"}     ;; jdbc driver needed to talk to our SQLite db
         dev.weavejester/ragtime {:mvn/version "0.9.3"}       ;; database migrations
         com.mjachimowicz/ragtime-clj {:mvn/version "0.1.2"}  ;; database migration support for Clojure code migrations
-        com.layerware/hugsql {:mvn/version "0.5.1"}          ;; SQL abstraction
+        com.layerware/hugsql-core {:mvn/version "0.5.3"}     ;; SQL abstraction
+        com.layerware/hugsql-adapter-next-jdbc {:mvn/version "0.5.3"}
         com.taoensso/nippy {:mvn/version "3.2.0"}            ;; fast compact serializer that we use for blobs
 
         ;; full text search database
@@ -119,6 +120,4 @@
            {:replace-deps {com.github.liquidz/antq {:mvn/version "2.5.1109"}
                            org.slf4j/slf4j-simple {:mvn/version "2.0.9"}} ;; to rid ourselves of logger warnings
             :main-opts ["-m" "antq.core"
-                        "--exclude=com.layerware/hugsql@0.5.2" ;; Not sure of effect of https://github.com/layerware/hugsql/issues/138
-                        "--exclude=com.layerware/hugsql@0.5.3"
                         "--ignore-locals"]}}}

--- a/resources/migrations/010_convert_builds_error_info_from_exception_to_data.clj
+++ b/resources/migrations/010_convert_builds_error_info_from_exception_to_data.clj
@@ -1,18 +1,22 @@
 (ns migrations.010-convert-builds-error-info-from-exception-to-data
   "Adds new error_info_map column to builds table leaving existing error_info column to support
    reversion to old code if necessary."
-  (:require [clojure.java.jdbc :as jdbc]
+  (:require [next.jdbc :as jdbc]
+            [next.jdbc.sql :as sql]
+            [next.jdbc.result-set :as rs]
             [clojure.tools.logging :as log]
             [taoensso.nippy :as nippy]))
 
 (defn up [db-spec]
   (binding [])
-  (let [cnt (-> (jdbc/query db-spec ["select count(*) as c from builds where error_info is not null"])
+  (let [cnt (-> (sql/query db-spec ["select count(*) as c from builds where error_info is not null"]
+                           {:builder-fn rs/as-unqualified-maps})
                 first
                 :c)]
     (log/info "rows to udpate:" cnt)
-    (jdbc/execute! db-spec ["alter table builds add error_info_map"])
-    (doseq [row (jdbc/query db-spec ["select id, error_info from builds where error_info is not null"])
+    (jdbc/execute-one! db-spec ["alter table builds add error_info_map"])
+    (doseq [row (sql/query db-spec ["select id, error_info from builds where error_info is not null"]
+                           {:builder-fn rs/as-unqualified-maps} )
             :let [id (:id row)
                   ;; For security reasons, newer versions of nippy are restrictive on what
                   ;; classes they will thaw. For this conversion from exception-object to
@@ -20,7 +24,7 @@
                   ex (binding [nippy/*thaw-serializable-allowlist* #{"*"}]
                        (nippy/thaw (:error_info row)))
                   ex-as-data (nippy/freeze (Throwable->map ex))]]
-      (jdbc/update! db-spec :builds {:error_info_map ex-as-data} ["id = ?" id]))))
+      (sql/update! db-spec :builds {:error_info_map ex-as-data} {:id id}))))
 
 (defn down [db-spec]
   ;; sqlite3 supports dropping columns starting with v3.35.5, but we are not using
@@ -31,11 +35,14 @@
 
 (comment
   (def db-spec {:dbtype "sqlite" :dbname "data/cljdoc.db.sqlite"})
-  (def before (jdbc/query db-spec ["select id, error_info from builds where error_info is not null"]))
+  (def before (sql/query db-spec ["select id, error_info from builds where error_info is not null"]
+                         {:builder-fn rs/as-unqualified-maps}))
   (count before);; => 589
 
   (up db-spec)
 
-  (def after (jdbc/query db-spec ["select id, error_info, error_info_map from builds where error_info_map is not null"]))
+  (def after (sql/query db-spec ["select id, error_info, error_info_map from builds where error_info_map is not null"]
+                        {:builder-fn rs/as-unqualified-maps} ))
   (count after);; => 589
-)
+
+  nil)

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -56,16 +56,16 @@
 
 (defn db
   [config]
-  {:classname "org.sqlite.JDBC",
-   :subprotocol "sqlite",
+  {:dbtype "sqlite",
+   :host :none
    :foreign_keys true
    :cache_size 10000
-   :subname (let [new-path (str (fs/file (data-dir config) "cljdoc.db.sqlite"))
-                  old-path (str (fs/file (data-dir config) "build-log.db"))]
-              (if (fs/exists? old-path)
-                (do (log/warnf "Database needs to be moved from %s to %s" old-path new-path)
-                    old-path)
-                new-path))
+   :dbname (let [new-path (str (fs/file (data-dir config) "cljdoc.db.sqlite"))
+                 old-path (str (fs/file (data-dir config) "build-log.db"))]
+             (if (fs/exists? old-path)
+               (do (log/warnf "Database needs to be moved from %s to %s" old-path new-path)
+                   old-path)
+               new-path))
    ;; These settings are permanent but it seems like
    ;; this is the easiest way to set them. In a migration
    ;; they fail because they return results.
@@ -77,9 +77,8 @@
    :key-col "key"
    :value-col "value"
    :db-spec {:dbtype "sqlite"
-             :classname "org.sqlite.JDBC"
-             :subprotocol "sqlite"
-             :subname (str (fs/file (data-dir config) "cache.db"))}})
+             :host :none
+             :dbname (str (fs/file (data-dir config) "cache.db"))}})
 
 (defn autobuild-clojars-releases? [config]
   (get-in config [:cljdoc/server :autobuild-clojars-releases?]))

--- a/src/cljdoc/server/build_log.clj
+++ b/src/cljdoc/server/build_log.clj
@@ -49,7 +49,7 @@
     (failed! this build-id error nil))
   (failed! [_ build-id error e]
     (sql/update! db-spec :builds (cond-> {:error error}
-                                    e (assoc :error_info_map (nippy/freeze (Throwable->map e))))
+                                   e (assoc :error_info_map (nippy/freeze (Throwable->map e))))
                  {:id build-id}))
   (api-imported! [_this build-id namespaces-count]
     (sql/update! db-spec
@@ -69,7 +69,7 @@
     (sql/update! db-spec :builds {:import_completed_ts (now)} {:id build-id}))
   (get-build [_ build-id]
     (-> (sql/query db-spec ["SELECT * FROM builds WHERE id = ?" build-id]
-                        {:builder-fn rs/as-unqualified-maps})
+                   {:builder-fn rs/as-unqualified-maps})
         first))
   (recent-builds [_ days]
     (sql/query db-spec [(str "SELECT * FROM builds "
@@ -81,30 +81,30 @@
                {:builder-fn rs/as-unqualified-maps}))
   (running-build [_ group-id artifact-id version]
     (-> (sql/query db-spec [(str "select * from builds where error is null "
-                              "and import_completed_ts is null "
-                              "and group_id = ? and artifact_id = ? and version = ? "
+                                 "and import_completed_ts is null "
+                                 "and group_id = ? and artifact_id = ? and version = ? "
                               ;; HACK; this datetime scoping shouldn't be required but
                               ;; in practice it happens that some webhooks don't reach
                               ;; the cljdoc api and builds end up in some sort of limbo
                               ;; where neither an error nor completion has occurred
-                              "and datetime(analysis_requested_ts) > datetime(?) "
-                              "order by id desc "
-                              "limit 1")
-                         group-id artifact-id version
-                         (str (.minus (Instant/now) (Duration/ofMinutes 10)))]
-               {:builder-fn rs/as-unqualified-maps} )
+                                 "and datetime(analysis_requested_ts) > datetime(?) "
+                                 "order by id desc "
+                                 "limit 1")
+                            group-id artifact-id version
+                            (str (.minus (Instant/now) (Duration/ofMinutes 10)))]
+                   {:builder-fn rs/as-unqualified-maps})
         first))
   (last-build [_ group-id artifact-id version]
     (-> (sql/query db-spec [(str "select * from builds where "
-                              "(group_id = ? "
-                              "and artifact_id = ? "
-                              "and version = ?) "
-                              "and (import_completed_ts is not null "
-                              "or error is not null) "
-                              "order by id desc "
-                              "limit 1")
-                         group-id artifact-id version]
-                {:builder-fn rs/as-unqualified-maps} )
+                                 "(group_id = ? "
+                                 "and artifact_id = ? "
+                                 "and version = ?) "
+                                 "and (import_completed_ts is not null "
+                                 "or error is not null) "
+                                 "order by id desc "
+                                 "limit 1")
+                            group-id artifact-id version]
+                   {:builder-fn rs/as-unqualified-maps})
         first)))
 
 (defn api-import-successful? [build]
@@ -149,7 +149,6 @@
                       "leeg" "leea" "1.2.3" (now)]
                      {:builder-fn rs/as-unqualified-maps})
   ;; => {:id 68832}
-
 
   (analysis-requested! bt "bidi" "bidi" "2.1.3")
 

--- a/src/cljdoc/server/clojars_stats.clj
+++ b/src/cljdoc/server/clojars_stats.clj
@@ -48,7 +48,7 @@
 
 (defn- to-import [db-spec ^LocalDate retention-date]
   (let [existing (set (map :date (sql/query db-spec ["select distinct date from clojars_stats"]
-                                            {:builder-fn rs/as-unqualified-maps} )))]
+                                            {:builder-fn rs/as-unqualified-maps})))]
     (->> (stats-files retention-date)
          (map (fn [f] {:file f :date (uri->date f)}))
          (remove #(.isBefore ^LocalDate (:date %) retention-date))
@@ -109,7 +109,7 @@
   (let [cnts (->> (sql/query db-spec [(str "select group_id, artifact_id, sum(downloads) as downloads "
                                            "from clojars_stats "
                                            "group by group_id, artifact_id")]
-                            {:builder-fn rs/as-unqualified-maps} )
+                             {:builder-fn rs/as-unqualified-maps})
                   (reduce (fn [acc {:keys [group_id artifact_id downloads]}]
                             (assoc acc [group_id artifact_id] downloads))
                           {}))]
@@ -158,7 +158,7 @@
   (def db-spec (-> (cfg/config) (cfg/db)))
 
   (set (map :date (sql/query db-spec ["select distinct date from clojars_stats"]
-                             {:builder-fn rs/as-unqualified-maps} )))
+                             {:builder-fn rs/as-unqualified-maps})))
 
   (::max (memoized-download-counts db-spec))
 

--- a/src/cljdoc/server/release_monitor.clj
+++ b/src/cljdoc/server/release_monitor.clj
@@ -6,7 +6,8 @@
             [cljdoc.config :as config]
             [cljdoc.server.search.api :as sc]
             [clojure.edn :as edn]
-            [clojure.java.jdbc :as sql]
+            [next.jdbc.sql :as sql]
+            [next.jdbc.result-set :as rs]
             [clojure.tools.logging :as log]
             [integrant.core :as ig]
             [tea-time.core :as tt]
@@ -50,7 +51,8 @@
 ;;
 
 (defn- last-release-ts ^Instant [db-spec]
-  (some-> (sql/query db-spec ["SELECT * FROM releases ORDER BY datetime(created_ts) DESC LIMIT 1"])
+  (some-> (sql/query db-spec ["SELECT * FROM releases ORDER BY datetime(created_ts) DESC LIMIT 1"]
+                     {:builder-fn rs/as-unqualified-maps} )
           first
           :created_ts
           Instant/parse))
@@ -61,7 +63,8 @@
   The 10min delay has been put into place to avoid building projects before people had a chance
   to push the respective commits or tags to their git repositories."
   [db-spec]
-  (first (sql/query db-spec ["SELECT * FROM releases WHERE build_id IS NULL AND datetime(created_ts) < datetime('now', '-10 minutes') ORDER BY retry_count ASC, datetime(created_ts) ASC LIMIT 1"])))
+  (first (sql/query db-spec ["SELECT * FROM releases WHERE build_id IS NULL AND datetime(created_ts) < datetime('now', '-10 minutes') ORDER BY retry_count ASC, datetime(created_ts) ASC LIMIT 1"]
+                    {:builder-fn rs/as-unqualified-maps})))
 
 (defn- update-build-id!
   [db-spec release-id build-id]
@@ -72,13 +75,13 @@
 
 (defn- queue-new-releases [db-spec releases]
   (log/infof "Queuing %s new releases" (count releases))
-  (sql/insert-multi! db-spec "releases" releases))
+  (sql/insert-multi! db-spec :releases releases))
 
 (defn- inc-retry-count! [db-spec {:keys [id retry_count] :as _release}]
   (sql/update! db-spec
-               "releases"
+               :releases
                {:retry_count (inc retry_count)}
-               ["id = ?" id]))
+               {:id id}))
 
 ;;
 ;; Logic and jobs
@@ -200,15 +203,19 @@
 
   (ig/halt-key! :cljdoc/release-monitor rm)
 
-  (doseq [r (repositories/releases-since (.minus (Instant/now) (Duration/ofDays 2)))]
+  (doseq [r (clojars-releases-since (.minus (Instant/now) (Duration/ofDays 2)))]
     (insert db-spec r))
 
-  (last (sql/query db-spec ["SELECT * FROM releases"]))
+  (last (sql/query db-spec ["SELECT * FROM releases"]
+                   {:builder-fn rs/as-unqualified-maps}))
 
-  (trigger-build db-spec (first (sql/query db-spec ["SELECT * FROM releases"])))
+  (trigger-build db-spec (first (sql/query db-spec ["SELECT * FROM releases"]
+                                           {:builder-fn rs/as-unqualified-maps})))
 
   (clojure.pprint/pprint
-   (->> (repositories/releases-since (last-release-ts db-spec))
+   (->> (clojars-releases-since (last-release-ts db-spec))
         (map #(select-keys % [:created_ts]))))
 
-  (oldest-not-built db-spec))
+  (oldest-not-built db-spec)
+
+  )

--- a/src/cljdoc/server/release_monitor.clj
+++ b/src/cljdoc/server/release_monitor.clj
@@ -52,7 +52,7 @@
 
 (defn- last-release-ts ^Instant [db-spec]
   (some-> (sql/query db-spec ["SELECT * FROM releases ORDER BY datetime(created_ts) DESC LIMIT 1"]
-                     {:builder-fn rs/as-unqualified-maps} )
+                     {:builder-fn rs/as-unqualified-maps})
           first
           :created_ts
           Instant/parse))
@@ -216,6 +216,4 @@
    (->> (clojars-releases-since (last-release-ts db-spec))
         (map #(select-keys % [:created_ts]))))
 
-  (oldest-not-built db-spec)
-
-  )
+  (oldest-not-built db-spec))

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -18,18 +18,21 @@
 
   #### JDBC, HUGSQL, SQLite
 
-  For most of the time this namespace only used raw `clojure.java.jdbc` functions since queries
+  For most of the time this namespace only used raw jdbc functions since queries
   were basic. At some point the need for more complex queries arose [1] and HUGSQL was added
   to the mix."
   (:require [cljdoc.user-config :as user-config]
             [cljdoc-shared.proj :as proj]
             [clojure.set :as cset]
-            [clojure.java.jdbc :as sql]
+            [next.jdbc :as jdbc]
+            [next.jdbc.sql :as sql]
+            [next.jdbc.result-set :as rs]
             [clojure.tools.logging :as log]
             [taoensso.nippy :as nippy]
             [taoensso.tufte :as tufte :refer [defnp]]
             [version-clj.core :as version-clj]
             [hugsql.core :as hugsql]
+            [hugsql.adapter.next-jdbc :as adapter]
             [clojure.string :as string])
   (:import (org.sqlite SQLiteException)))
 
@@ -38,25 +41,28 @@
 (declare sql-get-namespaces)
 (declare sql-get-vars)
 
-(hugsql/def-db-fns "sql/sqlite_impl.sql")
-;; (hugsql/def-sqlvec-fns "sql/sqlite_impl.sql")
+(hugsql/def-db-fns "sql/sqlite_impl.sql"
+  {:adapter (adapter/hugsql-adapter-next-jdbc)})
 
 ;; Writing ----------------------------------------------------------------------
 
 (defn store-artifact! [db-spec group-id artifact-id versions]
   (assert (coll? versions))
   (doseq [v versions]
-    (sql/execute! db-spec ["INSERT OR IGNORE INTO versions (group_id, artifact_id, name) VALUES (?, ?, ?)" group-id artifact-id v])))
+    (jdbc/execute-one! db-spec ["INSERT OR IGNORE INTO versions (group_id, artifact_id, name) VALUES (?, ?, ?)" group-id artifact-id v])))
 
 (defn- update-version-meta! [db-spec version-id data]
-  (sql/execute! db-spec ["UPDATE versions SET meta = ? WHERE id = ?" (nippy/freeze data) version-id]))
+  (sql/update! db-spec :versions {:meta (nippy/freeze data)} {:id version-id}))
 
 (defn- write-ns!
   [db-spec version-id {:keys [platform name] :as data}]
   {:pre [(string? name) (string? platform)]}
   (try
-    (sql/execute! db-spec ["INSERT INTO namespaces (version_id, platform, name, meta) VALUES (?, ?, ?, ?)"
-                           version-id platform name (nippy/freeze data)])
+    (sql/insert! db-spec :namespaces {:version_id version-id
+                                      :platform platform
+                                      :name name
+                                      :meta (nippy/freeze data)})
+
     (catch SQLiteException e
       (throw (ex-info (format "Failed to insert namespace %s" data)
                       {:var data}
@@ -66,27 +72,31 @@
   [db-spec version-id {:keys [platform namespace name] :as data}]
   {:pre [(string? name) (string? namespace) (string? platform)]}
   (try
-    (sql/execute! db-spec ["INSERT INTO vars (version_id, platform, namespace, name, meta) VALUES (?, ?, ?, ?, ?)"
-                           version-id platform namespace name (nippy/freeze data)])
+    (sql/insert! db-spec :vars {:version_id version-id
+                                :platform platform
+                                :namespace namespace
+                                :name name
+                                :meta (nippy/freeze data)})
     (catch SQLiteException e
       (throw (ex-info (format "Failed to insert var %s" data)
                       {:var data}
                       e)))))
 
 (defn clear-vars-and-nss! [db-spec version-id]
-  (sql/execute! db-spec ["DELETE FROM vars WHERE version_id = ?" version-id])
-  (sql/execute! db-spec ["DELETE FROM namespaces WHERE version_id = ?" version-id]))
+  (sql/delete! db-spec :vars {:version_id version-id})
+  (sql/delete! db-spec :namespaces {:version_id version-id}))
 
 ;; Reading ----------------------------------------------------------------------
 
 (defnp ^:private get-version-id
   [db-spec group-id artifact-id version-name]
   {:pre [(and group-id artifact-id version-name)]}
-  (first
-   (sql/query db-spec
-              ["select id from versions where group_id = ? and artifact_id = ? and name = ?"
-               group-id artifact-id version-name]
-              {:row-fn :id})))
+  (-> (sql/query db-spec
+                 ["select id from versions where group_id = ? and artifact_id = ? and name = ?"
+                  group-id artifact-id version-name]
+                 {:builder-fn rs/as-unqualified-maps})
+      first
+      :id))
 
 (defnp ^:private get-version
   "Returns metadata for specific `version-id` a map:
@@ -120,15 +130,19 @@
        - `:commit` - when would this be different from :sha?
      - `:commit` - sha specified in pom.xml scm->tag"
   [db-spec version-id]
-  (first (sql/query db-spec ["select meta from versions where id = ?" version-id]
-                    {:row-fn (fn [r] (some-> r :meta nippy/thaw))})))
+  (some-> (sql/query db-spec ["select meta from versions where id = ?" version-id]
+                     {:builder-fn rs/as-unqualified-maps})
+          first
+          :meta
+          nippy/thaw))
 
 (defn- version-row-fn [r]
   (cset/rename-keys r {:group_id :group-id, :artifact_id :artifact-id, :name :version}))
 
 (defnp ^:private resolve-version-ids [db-spec version-entities]
   (let [v-tuples (map (fn [v] [(:group-id v) (:artifact-id v) (:version v)]) version-entities)]
-    (sql-resolve-version-ids db-spec {:version-entities v-tuples} {} {:row-fn version-row-fn})))
+    (->> (sql-resolve-version-ids db-spec {:version-entities v-tuples})
+         (map version-row-fn))))
 
 ;; TODO We currently store various fields in metadata and the database table
 ;; this is probably a bad idea as it might lead to inconsistencies and because
@@ -183,9 +197,8 @@
   (let [ns-idents (->> namespaces-with-resolved-version-entities
                        (map (fn [ns] [(-> ns :version-entity :id) (:name ns)])))]
     (assert (seq ns-idents))
-    (sql-get-vars db-spec {:ns-idents ns-idents}
-                  {}
-                  {:row-fn vars-row-fn})))
+    (->> (sql-get-vars db-spec {:ns-idents ns-idents})
+         (map vars-row-fn))))
 
 (defn- sql-exists?
   "A small helper to deal with the complex keys that sqlite returns for exists queries."
@@ -201,10 +214,14 @@
   ;; TODO use build_id / merge with releases table?
   ([db-spec group-id]
    {:pre [(string? group-id)]}
-   (sql/query db-spec ["select group_id, artifact_id, name from versions where group_id = ? and meta not null" group-id] {:row-fn version-row-fn}))
+   (->> (sql/query db-spec ["select group_id, artifact_id, name from versions where group_id = ? and meta not null" group-id]
+                   {:builder-fn rs/as-unqualified-maps})
+        (map version-row-fn)))
   ([db-spec group-id artifact-id]
    {:pre [(string? group-id) (string? artifact-id)]}
-   (sql/query db-spec ["select group_id, artifact_id, name from versions where group_id = ? and artifact_id = ? and meta not null" group-id artifact-id] {:row-fn version-row-fn})))
+   (->> (sql/query db-spec ["select group_id, artifact_id, name from versions where group_id = ? and artifact_id = ? and meta not null" group-id artifact-id]
+                   {:builder-fn rs/as-unqualified-maps})
+        (map version-row-fn))))
 
 (defnp latest-release-version [db-spec {:keys [group-id artifact-id]}]
   (->> (get-documented-versions db-spec group-id artifact-id)
@@ -214,7 +231,9 @@
        (last)))
 
 (defn all-distinct-docs [db-spec]
-  (sql/query db-spec ["select group_id, artifact_id, name from versions"] {:row-fn version-row-fn}))
+  (->> (sql/query db-spec ["select group_id, artifact_id, name from versions"]
+                  {:builder-fn rs/as-unqualified-maps})
+       (map version-row-fn)))
 
 (defn docs-available? [db-spec group-id artifact-id version-name]
   (or (sql-exists? db-spec ["select exists(select id from versions where group_id = ? and artifact_id = ? and name = ? and meta not null)"
@@ -264,7 +283,7 @@
   (let [version-id (get-version-id db-spec group-id artifact-id version)]
     (log/info "version-id" version-id)
     (clear-vars-and-nss! db-spec version-id)
-    (sql/with-db-transaction [tx db-spec]
+    (jdbc/with-transaction [tx db-spec]
       (doseq [ns (for [[platf namespaces] codox
                        ns namespaces]
                    (-> (dissoc ns :publics)
@@ -297,6 +316,24 @@
 
   (def db-spec
     (cljdoc.config/db (cljdoc.config/config)))
+
+  (get-version db-spec 55630)
+
+  (sql-resolve-version-ids db-spec {:version-entities [["rewrite-clj" "rewrite-clj" "1.1.47"]]})
+  ;; => [{:id 55630,
+  ;;      :group_id "rewrite-clj",
+  ;;      :artifact_id "rewrite-clj",
+  ;;      :name "1.1.47"}]
+
+  (resolve-version-ids db-spec [{:group-id "rewrite-clj" :artifact-id "rewrite-clj" :version "1.1.47"}])
+  ;; => ({:id 55630,
+  ;;      :group-id "rewrite-clj",
+  ;;      :artifact-id "rewrite-clj",
+  ;;      :version "1.1.47"})
+
+  (sql-get-vars db-spec {:ns-idents [[2838 "rewrite-clj.zip"]]} )
+
+  (get-vars db-spec [{:name "rewrite-clj.zip" :version-entity {:id 2838}}])
 
   (all-distinct-docs db-spec)
 

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -331,7 +331,7 @@
   ;;      :artifact-id "rewrite-clj",
   ;;      :version "1.1.47"})
 
-  (sql-get-vars db-spec {:ns-idents [[2838 "rewrite-clj.zip"]]} )
+  (sql-get-vars db-spec {:ns-idents [[2838 "rewrite-clj.zip"]]})
 
   (get-vars db-spec [{:name "rewrite-clj.zip" :version-entity {:id 2838}}])
 

--- a/test/cljdoc/util/sqlite_cache_test.clj
+++ b/test/cljdoc/util/sqlite_cache_test.clj
@@ -17,9 +17,7 @@
    :serialize-fn       identity
    :deserialize-fn     read-string
    :db-spec            {:dbtype      "sqlite"
-                        :classname   "org.sqlite.JDBC"
-                        :subprotocol "sqlite"
-                        :subname database-filename}})
+                        :dbname database-filename}})
 
 (defn get-memoed-for-test
   "returns memoized fn and


### PR DESCRIPTION
The intent is the same behaviour as before.

To avoid too much rework, asked next.jdbc to return clojure.java.jdbc compatible result sets with `:builder-fn rs/as-unqualified-maps` option.

Opted to not ask next.jdbc to use JDBC's `Statement` `getGeneratedKeys`. We were transparently taking advantage of this in clojure.java.jdbc. But this method was deprecated by sqlite-jdbc because it is unreliable. It was removed in v3.43.0.0 (which we'll upgrade to separately).

We instead rely on SQLite's RETURNING syntax to return generated keys. This was only needed when inserting a new build log entry.

Next.jdbc does not have funtions to abstract the creation of tables, so simply generated the necessary SQL to create our cache table.

I took advantage of next.jdbc sql sugar syntaxes when the change was small.

Closes #827