### PR TITLE
Plaintext article title is inferred from filename

### DIFF
--- a/doc/userguide/for-library-authors.adoc
+++ b/doc/userguide/for-library-authors.adoc
@@ -45,6 +45,8 @@ Cljdoc supports two markup formats:
 ** We use https://github.com/vsch/flexmark-java[flexmark-java] to render a https://github.github.com/gfm/[GitHub flavored CommonMark dialect].
 * *AsciiDoc* for `.adoc` link:#articles[articles]
 ** We use https://github.com/asciidoctor/asciidoctorj[AsciidoctorJ] to render https://docs.asciidoctor.org/asciidoc/latest/[AsciiDoc].
+* *Plaintext* for `.txt` link:#articles[articles] and optionally link:#docstrings[docstrings]
+** Plaintext support was added for older projects, we recommend using minimal Markdown for docstrings and either Markdown or Asciidoc for your articles.
 
 [[badges]]
 == Cljdoc Badge
@@ -390,7 +392,8 @@ If your git repository does not contain a link:#article-config[doc tree configur
 * `CHANGELOG.md` else `CHANGELOG.adoc`- filename search is case insensitive
 ** Title is `Changelog`
 * link:#markup[Markup] articles from your `doc/` else `docs/` folder
-** The title is read from the file's first heading. There will be no nesting and articles will be ordered alphabetically by filename.
+** The title is read from the file's first heading, and failing that, be based on the article filename.
+There will be no nesting and articles will be ordered alphabetically by filename.
 
 TIP: Use filenames prefixed with digits like `01-intro.md` to define the order of articles.
 

--- a/src/cljdoc/spec/cache_bundle.clj
+++ b/src/cljdoc/spec/cache_bundle.clj
@@ -13,7 +13,8 @@
          [:cljdoc.doc/type {:optional true} qualified-keyword?]
          [:slug string?]
          [:cljdoc.doc/contributors {:optional true} [:sequential string?]]
-         [:cljdoc/asciidoc {:optional true} string?]]
+         [:cljdoc/asciidoc {:optional true} string?]
+         [:cljdoc/plaintext {:optional true} string?]]
         arglists [:sequential [:vector any?]]]
     [:map
      [:version

--- a/src/cljdoc/storage/sqlite_impl.clj
+++ b/src/cljdoc/storage/sqlite_impl.clj
@@ -112,9 +112,10 @@
       - `:title` document title from above, example: `\"Document tests\"`
       - `:attrs` - a map of
          - `:cljdoc.doc/source-file` - scm root relative source-file, ex: `\"doc/doverview.adoc\"`
-         - `:cldoc.doc/type` - either `:cljdoc/markdown` or `:cljdoc/asciidoc`, also acts as key for content
+         - `:cldoc.doc/type` - `:cljdoc/markdown`, `:cljdoc/asciidoc`, or `:cljdoc/plaintext` also acts as key for content
          - `:cljdoc/markdown` - actual file contents when in markdown format
          - `:cljdoc/asciidoc` - actual file contents when in asciidoc format
+         - `:cljdoc/plaintext` - actual file contents when in plaintext format
          - `:slug` - url slug for article
          - `:cljdoc.doc/contributors`  - list of scm users who made changes to file
    - `:jar` - TODO: for local ingest testing?

--- a/test/cljdoc/doc_tree_test.clj
+++ b/test/cljdoc/doc_tree_test.clj
@@ -1,33 +1,64 @@
 (ns cljdoc.doc-tree-test
-  (:require [cljdoc.doc-tree :as doctree]
+  (:require [babashka.fs :as fs]
+            [cljdoc.doc-tree :as doctree]
             [clojure.test :as t]
             [clojure.test.check.clojure-test :as tc]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.spec.test.alpha :as st]
-            [clojure.spec.alpha :as spec]))
+            [clojure.spec.alpha :as spec]
+            [matcher-combinators.test]
+            [matcher-combinators.matchers :as m]))
 
 (t/use-fixtures :once (fn [f] (st/instrument) (f)))
 
 (t/deftest process-toc-test
-  (t/is (=
-         [{:title "Readme"
-           :attrs {:cljdoc.doc/source-file "README.md"
-                   :cljdoc.doc/type :cljdoc/markdown
-                   :cljdoc.doc/contributors ["A" "B" "C"]
-                   :cljdoc/markdown "README.md"
-                   :slug "readme"}
-           :children [{:title "Nested"
-                       :attrs {:cljdoc.doc/source-file "nested.adoc"
-                               :cljdoc.doc/type :cljdoc/asciidoc
-                               :cljdoc.doc/contributors ["A" "B" "C"]
-                               :cljdoc/asciidoc "nested.adoc"
-                               :slug "nested"}}]}]
+  (t/is (match?
+         (m/equals
+          [{:title "Readme"
+            :attrs {:cljdoc.doc/source-file "README.md"
+                    :cljdoc.doc/type :cljdoc/markdown
+                    :cljdoc.doc/contributors ["A" "B" "C"]
+                    :cljdoc/markdown "README.md"
+                    :slug "readme"}
+            :children [{:title "Nested"
+                        :attrs {:cljdoc.doc/source-file "nested.adoc"
+                                :cljdoc.doc/type :cljdoc/asciidoc
+                                :cljdoc.doc/contributors ["A" "B" "C"]
+                                :cljdoc/asciidoc "nested.adoc"
+                                :slug "nested"}}
+                       {:title "some-plaintext"
+                        :attrs
+                        {:cljdoc.doc/source-file "some-plaintext.txt"
+                         :cljdoc/plaintext "some-plaintext.txt"
+                         :cljdoc.doc/type :cljdoc/plaintext,
+                         :slug "some-plaintext"
+                         :cljdoc.doc/contributors ["A" "B" "C"]}}]}])
          (doctree/process-toc
           {:slurp-fn identity
            :get-contributors (constantly ["A" "B" "C"])}
           [["Readme" {:file "README.md"}
-            ["Nested" {:file "nested.adoc"}]]]))))
+            ["Nested" {:file "nested.adoc"}]
+            ["some-plaintext" {:file "some-plaintext.txt"}]]]))))
+
+(t/deftest derive-toc-test
+  (t/is (match?
+         (m/equals  [["Readme" {:file "README.md"}]
+                     ["Changelog" {:file "CHANGELOG.adoc"}]
+                     ["title for doc/01.adoc" {:file "doc/01.adoc"}]
+                     ["title for doc/02.md" {:file "doc/02.md"}]
+                     ["03" {:file "doc/03.txt"}]])
+         (doctree/derive-toc
+          ["README.md"
+           "CHANGELOG.adoc"
+           "doc/01.adoc"
+           "doc/02.md"
+           "doc/03.txt"]
+          (fn slurp-fn [f]
+            (case (fs/extension f)
+              "adoc" (format "= title for %s" f)
+              "md" (format "# title for %s" f)
+              "plaintext content"))))))
 
 ;; we redefine spec for entry because for test we want every entry have attrs with slug so that slug-path will be
 ;; generated (neighbours are found based on the slug-path)


### PR DESCRIPTION
Any `.txt` articles in doc/ or docs/ dir are now appropriately processed. Title is inferred from the article filename.

Closes #830