### PR TITLE
Bump memory allowance for cljdoc container in Nomad

### DIFF
--- a/modules/deploy/resources/cljdoc.jobspec.edn
+++ b/modules/deploy/resources/cljdoc.jobspec.edn
@@ -22,7 +22,7 @@
             :Name "backend",
             :Resources
               {:CPU 800,
-               :MemoryMB 1600,
+               :MemoryMB 2800,
                :Networks [{:DynamicPorts [{:Label "http", :Value 0}],
                            :MBits 10}]},
             :Services [{:Name "cljdoc",


### PR DESCRIPTION
We increased the server memory a while ago but I think we didn't increase the allocation in Nomad. This PR does that so that hopefully OOM issues occur less often. That said the permanent solution will likely involve tracking down where we're leaking memory... 