### PR TITLE
lint: tweak clojure vs bb deps

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,5 @@
-{:paths ["." "script"]
+{:min-bb-version "1.3.184"
+ :paths ["." "script"]
  :deps {doric/doric {:mvn/version "0.9.0"}
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}

--- a/build.clj
+++ b/build.clj
@@ -1,7 +1,12 @@
 (ns build
   (:require
    [build-shared :as bs]
-   [clojure.tools.build.api :as b]))
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [clojure.string :as str]
+   [clojure.edn :as edn]
+   [clojure.tools.build.api :as b]
+   [clj-kondo.core :as kondo]))
 
 (def basis (b/create-basis {:project "deps.edn"}))
 
@@ -13,3 +18,19 @@
             :javac-opts ["--release" "17"
                          "-Xlint:all,-serial,-processing"
                          "-Werror"]} ))
+
+(defn lint-cache
+  "Build lint cache as a build task to avoid blowing max command line length on Windows"
+  [_opts]
+  (fs/delete-tree ".clj-kondo/.cache")
+  (let [bb-deps (-> (process/shell {:out :string} "bb print-deps")
+                    :out
+                    edn/read-string)
+        ;; ideally we'd be smarter about merging bb-deps, i.e, choosing latest version
+        ;; for any libs that overlap, but this should be good enough for now
+        basis (b/create-basis {:aliases [:test :cli] :extra bb-deps})
+        cp-roots (:classpath-roots basis)]
+    (println "- copying configs")
+    (kondo/run! {:skip-lint true :copy-configs true :lint cp-roots})
+    (println "\n- creating cache")
+    (kondo/run! {:dependencies true :parallel true :lint cp-roots})))

--- a/deps.edn
+++ b/deps.edn
@@ -96,7 +96,10 @@
             :main-opts ["-m" "kaocha.runner"]}
 
            :build
-           {:deps {io.github.clojure/tools.build {:mvn/version "0.9.5"}}
+           {:deps {io.github.clojure/tools.build {:mvn/version "0.9.5"}
+                   clj-kondo/clj-kondo {:mvn/version "2023.09.07"}
+                   babashka/fs {:mvn/version "0.4.19"}
+                   babashka/process {:mvn/version "0.5.21"}}
             :ns-default build}
 
            :clj-kondo

--- a/script/docker_entrypoint.clj
+++ b/script/docker_entrypoint.clj
@@ -46,7 +46,6 @@
     (preserve-heap-dump heap-dump-file heap-dump-dir)
     (turf-old-heap-dumps heap-dump-dir)
     (println "Launching cljdoc server")
-    #_:clj-kondo/ignore ;; bb.edn requires etaoin wich requires an older version of process that has a more limited signature
     (process/exec "clojure"
                   "-J-Dcljdoc.host=0.0.0.0"
                   "-J-XX:+HeapDumpOnOutOfMemoryError"

--- a/script/lint.clj
+++ b/script/lint.clj
@@ -1,35 +1,13 @@
 #!/usr/bin/env bb
 
 (ns lint
-  (:require [babashka.classpath :as bbcp]
-            [babashka.fs :as fs]
-            [clojure.string :as string]
+  (:require [babashka.fs :as fs]
             [helper.main :as main]
             [helper.shell :as shell]
             [lread.status-line :as status]))
 
-(def clj-kondo-cache ".clj-kondo/.cache")
-
-(defn- cache-exists? []
-  (fs/exists? clj-kondo-cache))
-
-(defn- delete-cache []
-  (when (cache-exists?)
-    (fs/delete-tree clj-kondo-cache)))
-
 (defn- build-cache []
-  (when (cache-exists?)
-    (delete-cache))
-  (let [clj-cp (-> (shell/clojure {:out :string}
-                                  "-Spath -M:test")
-                   with-out-str
-                   string/trim)
-        bb-cp (bbcp/get-classpath)]
-
-    (status/line :detail "- copying configs")
-    (shell/command "clojure -M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
-    (status/line :detail "- creating cache")
-    (shell/command "clojure -M:clj-kondo --dependencies --parallel --lint" clj-cp bb-cp)))
+  (shell/clojure "-T:build lint-cache"))
 
 (defn- check-cache [{:keys [rebuild-cache]}]
   (status/line :head "clj-kondo: cache check")
@@ -37,11 +15,12 @@
                             rebuild-cache
                             "Rebuild requested"
 
-                            (not (cache-exists?))
+                            (not (fs/exists? ".clj-kondo/.cache"))
                             "Cache not found"
 
                             :else
-                            (let [updated-dep-files (fs/modified-since clj-kondo-cache ["deps.edn" "bb.edn"])]
+                            (let [updated-dep-files (fs/modified-since ".clj-kondo/.cache"
+                                                                       ["deps.edn" "bb.edn"])]
                               (when (seq updated-dep-files)
                                 (format "Found deps files newer than lint cache: %s" (mapv str updated-dep-files)))))]
     (do (status/line :detail rebuild-reason)
@@ -53,7 +32,7 @@
   (status/line :head "clj-kondo: linting")
   (let [{:keys [exit]}
         (shell/command {:continue true}
-                       "clojure -M:clj-kondo --lint src test script deps.edn bb.edn modules")]
+                       "clojure -M:clj-kondo -m clj-kond.main --lint src test script deps.edn bb.edn modules")]
     (cond
       (= 2 exit) (status/die exit "clj-kondo found one or more lint errors")
       (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")


### PR DESCRIPTION
Use new "bb print-deps" for full list of bb dependencies including built-ins. Tack this onto clojure deps when calculating classpath for lint cache build.

To support Windows, with its limited command-line length, move to building cache programmatically in clojure in build.clj.

This is not perfect, if a bb dep version is older than a clojure dep version, we'll end up using the older dep, but it is better than before and unlikely to cause issues.