### PR TITLE
Fix vertical spacing for images (and other) blocks

### DIFF
--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -205,6 +205,15 @@ pre {
   margin-bottom: 0.25em;
 }
 
+.asciidoc .audioblock,
+.asciidoc .imageblock,
+.asciidoc .literalblock,
+.asciidoc .listingblock,
+.asciidoc .stemblock,
+.asciidoc .videoblock {
+  margin-bottom: 1.25em;
+}
+
 /*
    AsciiDoctor renders lists like so:
 


### PR DESCRIPTION
Margin bottom spacing transcribed from:
https://github.com/asciidoctor/asciidoctor/blob/be27047cad5de15ab53513be894f3a423f5734b0/src/stylesheets/asciidoctor.css#L1112-L1119

Closes #842