### PR TITLE
fix: exclude adoc callouts from code block copy

### DIFF
--- a/js/hljs-copybutton-plugin.ts
+++ b/js/hljs-copybutton-plugin.ts
@@ -3,11 +3,7 @@
 // unresolved issues. There is not much code to this, so let's just do a bare bones ourselves.
 
 const copyButtonPlugin = {
-  "before:highlightElement": ({
-    el
-  }: {
-    el: HTMLElement;
-  }) => {
+  "before:highlightElement": ({ el }: { el: HTMLElement }) => {
     const button: HTMLButtonElement = Object.assign(
       document.createElement("button"),
       {

--- a/js/hljs-copybutton-plugin.ts
+++ b/js/hljs-copybutton-plugin.ts
@@ -3,14 +3,12 @@
 // unresolved issues. There is not much code to this, so let's just do a bare bones ourselves.
 
 const copyButtonPlugin = {
-  "after:highlightElement": ({
-    el,
-    text
+  "before:highlightElement": ({
+    el
   }: {
     el: HTMLElement;
-    text: string;
   }) => {
-    let button: HTMLButtonElement = Object.assign(
+    const button: HTMLButtonElement = Object.assign(
       document.createElement("button"),
       {
         innerHTML: "copy",
@@ -22,7 +20,7 @@ const copyButtonPlugin = {
     el.parentElement?.appendChild(button);
     button.onclick = () => {
       if (navigator.clipboard) {
-        navigator.clipboard.writeText(text).then(() => {
+        navigator.clipboard.writeText(el.innerText).then(() => {
           button.innerHTML = "copied";
           button.dataset.copied = "true";
         });


### PR DESCRIPTION
We hook in our copy button via a highlight.js plugin.

Switching from `after:highlightElement` to `before:highlightElement` and
grabbing the innerText of the element seems to have done the trick.

Closes https://github.com/cljdoc/cljdoc/issues/844