### PR TITLE
Exit on OutOfMemory Exceptions

### DIFF
--- a/script/docker_entrypoint.clj
+++ b/script/docker_entrypoint.clj
@@ -48,6 +48,7 @@
     (println "Launching cljdoc server")
     (process/exec "clojure"
                   "-J-Dcljdoc.host=0.0.0.0"
+                  "-J-XX:+ExitOnOutOfMemoryError"
                   "-J-XX:+HeapDumpOnOutOfMemoryError"
                   (format "-J-XX:HeapDumpPath=%s" (str heap-dump-file))
                   "-M" "-m" "cljdoc.server.system")))


### PR DESCRIPTION
Not the most elegant solution but at least this should reduce downtime while the OOM issue remains undiagnosed :) 

https://stackoverflow.com/questions/30530082/how-can-i-restart-jvm-on-outofmemoryerror-after-making-a-heap-dump