### PR TITLE
try OOM exit in sentry interceptor

### DIFF
--- a/script/docker_entrypoint.clj
+++ b/script/docker_entrypoint.clj
@@ -48,7 +48,6 @@
     (println "Launching cljdoc server")
     (process/exec "clojure"
                   "-J-Dcljdoc.host=0.0.0.0"
-                  "-J-XX:+ExitOnOutOfMemoryError"
                   "-J-XX:+HeapDumpOnOutOfMemoryError"
                   (format "-J-XX:HeapDumpPath=%s" (str heap-dump-file))
                   "-M" "-m" "cljdoc.server.system")))

--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -701,6 +701,7 @@
          ::http/secure-headers {:content-security-policy-settings {:object-src "'none'"}}
          ::http/resource-path "public/out"
          ::http/not-found-interceptor not-found-interceptor
+         ::http/request-logger nil
          ::http/path-params-decoder nil}
         http/default-interceptors
         (update ::http/interceptors #(into [sentry/interceptor


### PR DESCRIPTION
I think the reason the approach in #852 didn't work is that we're catching the OOM in the Sentry handler. 

Doing it like in this PR should also allow us to send a message to Sentry whenever the server is restarted to an OOM. 

I also had a look at the current 2 heapdumps but couldn't find anything too interesting. I wonder if collecting a few heapdumps over time could help (e.g. every 8 hours or so), apparently there's tools to diff them but I'm not too familiar. 

This PR also includes a change to not log every request, removing a lot of noise from the logs... 