### PR TITLE
docker: increase max jvm heap size

### DIFF
--- a/script/docker_entrypoint.clj
+++ b/script/docker_entrypoint.clj
@@ -47,7 +47,8 @@
     (turf-old-heap-dumps heap-dump-dir)
     (println "Launching cljdoc server")
     (process/exec "clojure"
-                  "-J-XshowSettings:vm"
+                  "-J-XshowSettings:vm" ;; prints heap usage to to stderr
+                  "-J-XX:MaxRAMPercentage=75" ;; increase from default of 25% to 75%
                   "-J-Dcljdoc.host=0.0.0.0"
                   "-J-XX:+ExitOnOutOfMemoryError"
                   "-J-XX:+HeapDumpOnOutOfMemoryError"


### PR DESCRIPTION
Our docker jvm max heap is reported as:

```
$ nomad alloc logs -stderr 488e4d6d
VM settings:
    Max. Heap Size (Estimated): 386.69M
    Using VM: OpenJDK 64-Bit Server VM
```

Our current docker container is 1600mb.
The default ram percentage used by the jvm is 25% or ~400mb. This is a conservative default.

As far as I remember, we don't have much else going on in our cljdoc docker container. So let's try bumping the ram percentage to 75% or ~1200mb.