### PR TITLE
maint: re-bump lucene

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -25,10 +25,10 @@
         com.taoensso/nippy {:mvn/version "3.3.0"}            ;; fast compact serializer that we use for blobs
 
         ;; full text search database
-        org.apache.lucene/lucene-core {:mvn/version "9.9.2"} ;; search engine
-        org.apache.lucene/lucene-analysis-common {:mvn/version "9.9.2"}
-        org.apache.lucene/lucene-analysis-icu {:mvn/version "9.9.2"}
-        org.apache.lucene/lucene-queryparser {:mvn/version "9.9.2"}
+        org.apache.lucene/lucene-core {:mvn/version "9.10.0"} ;; search engine
+        org.apache.lucene/lucene-analysis-common {:mvn/version "9.10.0"}
+        org.apache.lucene/lucene-analysis-icu {:mvn/version "9.10.0"}
+        org.apache.lucene/lucene-queryparser {:mvn/version "9.10.0"}
 
         ;; markdown
         org.asciidoctor/asciidoctorj {:mvn/version "2.5.11"} ;; render adoc to html

--- a/src/cljdoc/server/search/api.clj
+++ b/src/cljdoc/server/search/api.clj
@@ -51,6 +51,9 @@
   (let [index (if index-factory ;; to support unit testing
                 (index-factory)
                 (search/disk-index index-dir))]
+    ;; Force creation of initial index. It might not exist yet, for example, when upgrading to a new version of lucene.
+    ;; This avoids exceptions on searching a non-existing index.
+    (search/index! clojars-stats index [])
     (map->Searcher {:index index
                     :clojars-stats clojars-stats
                     :artifact-indexer (when enable-indexer?


### PR DESCRIPTION
I had reverted bumping lucence but I don't think it was actually problematic.

I did notice the throwing of exceptions when searching an non-existent lucene index, so we now ensure one always exists for searches.