### PR TITLE
ci: sudo bb install when necessary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,12 @@ aliases:
     run:
       name: Install bb
       command: |
-        bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+        if [ ! -w "/usr/local/bin" ]; then
+          SUDO='sudo'
+        else
+          SUDO=''
+        fi
+        $SUDO bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
 
   - &npm_deps_install
     run:


### PR DESCRIPTION
Our clojure docker image user is sudo, but the image we use to publish to docker requires the sudo command.