### PR TITLE
Start using eslint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,10 @@ jobs:
           name: Compile TypeScript to Check for Issues
           command: bb lint-js
 
+      - run:
+          name: Run eslint
+          command: bb eslint
+
       - *save_npm_cache
 
   #

--- a/bb.edn
+++ b/bb.edn
@@ -71,6 +71,13 @@
            (if (zero? exit)
              (println "Exited with 0, so all seems good.")
              (System/exit exit)))}
+  eslint
+  {:doc "eslint typescript"
+   :depends [deps-js]
+   :task (let [exit (-> (apply shell {:continue true} "npx eslint" *command-line-args*) :exit)]
+           (if (zero? exit)
+             (println "No eslint errors detected")
+             (System/exit exit)))}
   server
   {:doc "Launch cljdoc server"
    :depends [deps-js compile-js compile-java]

--- a/doc/cljdoc-developer-technical-guide.adoc
+++ b/doc/cljdoc-developer-technical-guide.adoc
@@ -334,7 +334,7 @@ You can also run `bb code-format fix` to have cljfmt fix any code formatting iss
 
 ==== Other linting
 
-Lint client-side sources via `bb code-format-js` and `bb lint-js`. 
+Lint client-side sources via `bb code-format-js`, `bb lint-js` and `bb eslint`
 
 === Outdated dependencies
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,9 @@ export default tseslint.config(
       globals: {
         ...globals.browser
       }
+    },
+    rules: {
+      "@typescript-eslint/no-unused-expressions": ['error', {allowShortCircuit: true}]
     }
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,14 @@ export default tseslint.config(
       }
     },
     rules: {
-      "@typescript-eslint/no-unused-expressions": ['error', {allowShortCircuit: true}]
+      "@typescript-eslint/no-unused-expressions": ['error', {allowShortCircuit: true}],
+      "@typescript-eslint/no-unused-vars": ['error', {args: "all",
+                                                      argsIgnorePattern: "^_",
+                                                      caughtErrors: "all",
+                                                      caughtErrorsIgnorePattern: "^_",
+                                                      destructuredArrayIgnorePattern: "^_",
+                                                      varsIgnorePattern: "^_",
+                                                      ignoreRestSiblings: true}]
     }
   },
   {

--- a/js/cljdoc.ts
+++ b/js/cljdoc.ts
@@ -13,20 +13,20 @@ function isNSOfflinePage(): boolean {
 }
 
 function isProjectDocumentationPage(): boolean {
-  let pathSegs = window.location.pathname.split("/");
+  const pathSegs = window.location.pathname.split("/");
   return pathSegs.length >= 5 && pathSegs[1] == "d";
 }
 
 function initSrollIndicator(): void {
-  var mainScrollView = document.querySelector(".js--main-scroll-view");
-  var sidebarScrollView = document.querySelector(
+  const mainScrollView = document.querySelector(".js--main-scroll-view");
+  const sidebarScrollView = document.querySelector(
     ".js--namespace-contents-scroll-view"
   );
-  var defBlocks = Array.from(document.querySelectorAll(".def-block"));
-  var defItems = Array.from(document.querySelectorAll(".def-item"));
+  const defBlocks = Array.from(document.querySelectorAll(".def-block"));
+  const defItems = Array.from(document.querySelectorAll(".def-item"));
 
   function isElementVisible(container: Element, el: Element) {
-    var { y: etop, height } = el.getBoundingClientRect(),
+    const { y: etop, height } = el.getBoundingClientRect(),
       ebottom = etop + height,
       cbottom = window.innerHeight,
       ctop = cbottom - container.clientHeight;
@@ -35,7 +35,7 @@ function initSrollIndicator(): void {
 
   function drawScrollIndicator() {
     defBlocks.forEach((el: Element, idx) => {
-      var defItem = defItems[idx];
+      const defItem = defItems[idx];
       if (
         mainScrollView &&
         sidebarScrollView &&
@@ -60,19 +60,19 @@ function initSrollIndicator(): void {
 }
 
 function initToggleRaw() {
-  let toggles: HTMLElement[] = Array.from(
+  const toggles: HTMLElement[] = Array.from(
     document.querySelectorAll(".js--toggle-raw")
   );
 
   function addToggleHandlers() {
     toggles.forEach(el => {
       el.addEventListener("click", function () {
-        let parent = el.parentElement;
-        let markdowns = parent && parent.querySelectorAll(".markdown");
-        let raws = parent && parent.querySelectorAll(".raw");
+        const parent = el.parentElement;
+        const markdowns = parent && parent.querySelectorAll(".markdown");
+        const raws = parent && parent.querySelectorAll(".raw");
         markdowns &&
           markdowns.forEach((markdown, idx) => {
-            let raw = raws && raws[idx];
+            const raw = raws && raws[idx];
             if (markdown.classList.contains("dn")) {
               markdown.classList.remove("dn");
               raw && raw.classList.add("dn");
@@ -156,8 +156,8 @@ function saveSidebarScrollPos() {
     const anchorElems = mainSidebar.querySelectorAll("a");
     anchorElems.forEach(anchor => {
       anchor.addEventListener("click", function () {
-        var scrollTop = mainSidebar.scrollTop;
-        var data: SidebarScrollState = {
+        const scrollTop = mainSidebar.scrollTop;
+        const data: SidebarScrollState = {
           libVersionPath: libVersionPath(),
           scrollTop: scrollTop
         };

--- a/js/doctree.ts
+++ b/js/doctree.ts
@@ -3,8 +3,8 @@ function isDocLink(linkEl: HTMLAnchorElement) {
 }
 
 export function hideNestedArticles() {
-  let currentPath = location.pathname;
-  let articleLinks: HTMLAnchorElement[] = Array.from(
+  const currentPath = location.pathname;
+  const articleLinks: HTMLAnchorElement[] = Array.from(
     document.querySelectorAll(".js--articles a")
   );
 
@@ -18,7 +18,7 @@ export function hideNestedArticles() {
 }
 
 export function showNestedArticles() {
-  let hiddenLinks = Array.from(
+  const hiddenLinks = Array.from(
     document.querySelectorAll(".js--articles ul.dn")
   );
   hiddenLinks.map(n => n.classList.remove("dn"));

--- a/js/hljs-merge-plugin.ts
+++ b/js/hljs-merge-plugin.ts
@@ -103,7 +103,11 @@ function nodeStream(node: HTMLElement): Event[] {
  * @param highlighted - stream of the highlighted source
  * @param value - the original source itself
  */
-function mergeStreams(original: Event[], highlighted: Event[], value: string): string {
+function mergeStreams(
+  original: Event[],
+  highlighted: Event[],
+  value: string
+): string {
   let processed = 0;
   let result = "";
   const nodeStack: HTMLElement[] = [];

--- a/js/hljs-merge-plugin.ts
+++ b/js/hljs-merge-plugin.ts
@@ -4,7 +4,7 @@
 // See https://github.com/highlightjs/highlight.js/issues/2889
 
 // Naively transcribed to TypeScript
-var originalStream: Event[];
+let originalStream: Event[];
 
 /**
  * @param value

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -1,4 +1,4 @@
-import { h, render } from "preact";
+import { render } from "preact";
 import { trackProjectOpened, Switcher } from "./switcher";
 import { App } from "./search";
 import { MobileNav } from "./mobile";

--- a/js/listselect.tsx
+++ b/js/listselect.tsx
@@ -8,10 +8,10 @@ import { h, Component, FunctionComponent } from "preact";
 // is the currently selected one.
 
 function restrictToViewport(container: Element, selectedIndex: number) {
-  let containerRect = container.getBoundingClientRect();
-  let selectedRect = container.children[selectedIndex].getBoundingClientRect();
-  let deltaTop = selectedRect.top - containerRect.top;
-  let deltaBottom = selectedRect.bottom - containerRect.bottom;
+  const containerRect = container.getBoundingClientRect();
+  const selectedRect = container.children[selectedIndex].getBoundingClientRect();
+  const deltaTop = selectedRect.top - containerRect.top;
+  const deltaBottom = selectedRect.bottom - containerRect.bottom;
   if (deltaTop < 0) {
     container.scrollBy(0, deltaTop);
   } else if (deltaBottom > 0) {

--- a/js/listselect.tsx
+++ b/js/listselect.tsx
@@ -9,7 +9,8 @@ import { Component, FunctionComponent } from "preact";
 
 function restrictToViewport(container: Element, selectedIndex: number) {
   const containerRect = container.getBoundingClientRect();
-  const selectedRect = container.children[selectedIndex].getBoundingClientRect();
+  const selectedRect =
+    container.children[selectedIndex].getBoundingClientRect();
   const deltaTop = selectedRect.top - containerRect.top;
   const deltaBottom = selectedRect.bottom - containerRect.bottom;
   if (deltaTop < 0) {

--- a/js/listselect.tsx
+++ b/js/listselect.tsx
@@ -1,4 +1,4 @@
-import { h, Component, FunctionComponent } from "preact";
+import { Component, FunctionComponent } from "preact";
 
 // Various functions and components used to show lists of results
 

--- a/js/listselect.tsx
+++ b/js/listselect.tsx
@@ -33,17 +33,17 @@ function restrictToViewport(container: Element, selectedIndex: number) {
 export type ResultViewComponent<ResultType> = FunctionComponent<{
   result: ResultType;
   isSelected: boolean;
-  selectResult: () => any;
+  selectResult: () => void;
 }>;
 
-type ResultsViewProps<Type> = {
-  resultView: ResultViewComponent<Type>;
-  results: Type[];
+type ResultsViewProps<ResultType> = {
+  resultView: ResultViewComponent<ResultType>;
+  results: ResultType[];
   selectedIndex: number;
-  onMouseOver: (index: number) => any;
+  onMouseOver: (index: number) => void;
 };
 
-type ResultsViewState = any;
+type ResultsViewState = Record<string, never>;
 
 export class ResultsView<ResultType> extends Component<
   ResultsViewProps<ResultType>,
@@ -63,7 +63,7 @@ export class ResultsView<ResultType> extends Component<
     }
   }
 
-  render(props: ResultsViewProps<ResultType>, _state: any) {
+  render(props: ResultsViewProps<ResultType>, _state: ResultsViewState) {
     return (
       <div
         className="bg-white br1 br--bottom bb bl br b--blue w-100 overflow-y-scroll"

--- a/js/mobile.tsx
+++ b/js/mobile.tsx
@@ -1,6 +1,6 @@
 import { Component } from "preact";
 
-type MobileNavProps = any;
+type MobileNavProps = Record<string,never>;
 
 type MobileNavState = {
   mainViewScrollPos: number;

--- a/js/mobile.tsx
+++ b/js/mobile.tsx
@@ -1,6 +1,6 @@
 import { Component } from "preact";
 
-type MobileNavProps = Record<string,never>;
+type MobileNavProps = Record<string, never>;
 
 type MobileNavState = {
   mainViewScrollPos: number;
@@ -17,7 +17,8 @@ export class MobileNav extends Component<MobileNavProps, MobileNavState> {
   toggleNav() {
     const mainScrollView = document.querySelector(".js--main-scroll-view");
     const mainSidebar = document.querySelector(".js--main-sidebar");
-    const isNavShown = mainScrollView && mainScrollView.classList.contains("dn");
+    const isNavShown =
+      mainScrollView && mainScrollView.classList.contains("dn");
     if (isNavShown) {
       const scrollPos = window.scrollY;
       mainScrollView!.classList.remove("dn"); // show main scroll view / content area

--- a/js/mobile.tsx
+++ b/js/mobile.tsx
@@ -1,4 +1,4 @@
-import { h, Component } from "preact";
+import { Component } from "preact";
 
 type MobileNavProps = any;
 

--- a/js/mobile.tsx
+++ b/js/mobile.tsx
@@ -15,17 +15,17 @@ export class MobileNav extends Component<MobileNavProps, MobileNavState> {
   }
 
   toggleNav() {
-    let mainScrollView = document.querySelector(".js--main-scroll-view");
-    let mainSidebar = document.querySelector(".js--main-sidebar");
-    let isNavShown = mainScrollView && mainScrollView.classList.contains("dn");
+    const mainScrollView = document.querySelector(".js--main-scroll-view");
+    const mainSidebar = document.querySelector(".js--main-sidebar");
+    const isNavShown = mainScrollView && mainScrollView.classList.contains("dn");
     if (isNavShown) {
-      let scrollPos = window.scrollY;
+      const scrollPos = window.scrollY;
       mainScrollView!.classList.remove("dn"); // show main scroll view / content area
       mainSidebar && mainSidebar.classList.replace("db", "dn"); // hide sidebar
       window.scrollTo(0, this.state.mainViewScrollPos); // scroll after(!) swapping content
       this.setState({ showNav: false, navViewScrollPos: scrollPos });
     } else {
-      let scrollPos = window.scrollY;
+      const scrollPos = window.scrollY;
       mainScrollView && mainScrollView.classList.add("dn"); // hide main scroll view / content area
       mainSidebar && mainSidebar.classList.add("flex-grow-1"); // make sure nav fills width of screen
       mainSidebar && mainSidebar.classList.replace("dn", "db"); // show sidebar
@@ -35,11 +35,11 @@ export class MobileNav extends Component<MobileNavProps, MobileNavState> {
   }
 
   render(_props: MobileNavProps, state: MobileNavState) {
-    let btnMsg = state.showNav
+    const btnMsg = state.showNav
       ? "Back to Content"
       : "Tap for Articles & Namespaces";
-    let btnIcon = state.showNav ? "chevronLeft" : "list";
-    let btnSrc = "https://microicon-clone.vercel.app/" + btnIcon + "/32";
+    const btnIcon = state.showNav ? "chevronLeft" : "list";
+    const btnSrc = "https://microicon-clone.vercel.app/" + btnIcon + "/32";
     return (
       <div class="bg-light-gray">
         <button

--- a/js/navigator.tsx
+++ b/js/navigator.tsx
@@ -2,7 +2,10 @@
 
 import { Component } from "preact";
 
-class Navigator extends Component {
+type NavigatorProps = Record<string, never>;
+type NavigatorState = Record<string, never>;
+
+class Navigator extends Component<NavigatorProps, NavigatorState> {
   clojarsIdInput?: HTMLInputElement | null;
   versionInput?: HTMLInputElement | null;
 
@@ -25,7 +28,7 @@ class Navigator extends Component {
     }
   }
 
-  render(_props: any, _state: any) {
+  render(_props: NavigatorProps, _state: NavigatorState) {
     return (
       <div>
         <div class="cf nl2 nr2">

--- a/js/navigator.tsx
+++ b/js/navigator.tsx
@@ -1,6 +1,6 @@
 // A small component to navigate users to documentation pages based on clojars ID and version inputs
 
-import { h, Component } from "preact";
+import { Component } from "preact";
 
 class Navigator extends Component {
   clojarsIdInput?: HTMLInputElement | null;

--- a/js/navigator.tsx
+++ b/js/navigator.tsx
@@ -12,8 +12,8 @@ class Navigator extends Component {
   }
 
   navigate() {
-    let clojarsId = this.clojarsIdInput && this.clojarsIdInput.value;
-    let version = this.versionInput && this.versionInput.value;
+    const clojarsId = this.clojarsIdInput && this.clojarsIdInput.value;
+    const version = this.versionInput && this.versionInput.value;
 
     if (clojarsId && 0 != clojarsId.length) {
       if (clojarsId.includes("/")) {

--- a/js/recent-doc-links.tsx
+++ b/js/recent-doc-links.tsx
@@ -1,4 +1,4 @@
-import { h, render } from "preact";
+import { render } from "preact";
 import { VisitedLibrary } from "./switcher";
 import { docsUri, project } from "./library";
 import { formatDistanceToNowStrict } from "date-fns";

--- a/js/search.tsx
+++ b/js/search.tsx
@@ -34,7 +34,7 @@ function cleanSearchStr(str: string) {
 }
 
 // Raw JSON response from cljdoc server
-type RawSearchResult = {
+type RawSearchResult = Record<string, unknown> & {
   ["artifact-id"]: string;
   ["group-id"]: string;
   description: string;
@@ -48,7 +48,7 @@ type RawSearchResults = {
   results: RawSearchResult[];
 };
 
-interface SearchResult extends Library {
+interface SearchResult extends Record<string,unknown>, Library {
   blurb: string;
   origin: string;
   score: number;

--- a/js/search.tsx
+++ b/js/search.tsx
@@ -27,7 +27,7 @@ function debounced<T extends (...args: any[]) => any>(
 function cleanSearchStr(str: string) {
   // replace square and curly brackets in case people copy from
   // Leiningen/Boot files or deps.edn
-  return str.replace(/[\{\}\[\]\"]+/g, "");
+  return str.replace(/[{}[]"]+/g, "");
 }
 
 // Raw JSON response from cljdoc server

--- a/js/search.tsx
+++ b/js/search.tsx
@@ -1,4 +1,4 @@
-import { h, Component } from "preact";
+import { Component } from "preact";
 import { useState } from "preact/hooks";
 import { ResultsView, ResultViewComponent } from "./listselect";
 import { Library, docsUri, project } from "./library";

--- a/js/search.tsx
+++ b/js/search.tsx
@@ -48,7 +48,7 @@ type RawSearchResults = {
   results: RawSearchResult[];
 };
 
-interface SearchResult extends Record<string,unknown>, Library {
+interface SearchResult extends Record<string, unknown>, Library {
   blurb: string;
   origin: string;
   score: number;
@@ -61,7 +61,10 @@ type SearchResults = {
 
 type LoadCallback = (sr: SearchResult[]) => void;
 
-const renameKeys = <T extends Record<string, unknown>, U extends Record<string, unknown>>(
+const renameKeys = <
+  T extends Record<string, unknown>,
+  U extends Record<string, unknown>
+>(
   obj: T,
   keys: { [key: string]: string }
 ): U => {

--- a/js/search.tsx
+++ b/js/search.tsx
@@ -5,6 +5,9 @@ import { Library, docsUri, project } from "./library";
 
 // Doing types for debouncing functions is really hard.
 // https://gist.github.com/ca0v/73a31f57b397606c9813472f7493a940
+
+// usage of any seems appropriate here, so have eslint ignore it
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function debounced<T extends (...args: any[]) => any>(
   delayInMs: number,
   callbackFn: T
@@ -56,20 +59,20 @@ type SearchResults = {
   results: SearchResult[];
 };
 
-type LoadCallback = (sr: SearchResult[]) => any;
+type LoadCallback = (sr: SearchResult[]) => void;
 
-const renameKeys = <T extends {}, U>(
+const renameKeys = <T extends Record<string, unknown>, U extends Record<string, unknown>>(
   obj: T,
   keys: { [key: string]: string }
 ): U => {
-  const newObj: { [key: string]: any } = {};
+  const newObj = {} as U;
 
   for (const [k, v] of Object.entries(obj)) {
     const key = keys[k] || k;
-    newObj[key] = v;
+    (newObj as Record<string, unknown>)[key] = v;
   }
 
-  return newObj as U;
+  return newObj;
 };
 
 const refineSearchResults = (raw: RawSearchResults): SearchResults => ({
@@ -96,11 +99,11 @@ const loadResults = (str: string, cb: LoadCallback) => {
 };
 
 type SearchInputProps = {
-  onEnter: () => any;
-  focus: () => any;
-  unfocus: () => any;
-  onArrowUp: () => any;
-  onArrowDown: () => any;
+  onEnter: () => void;
+  focus: () => void;
+  unfocus: () => void;
+  onArrowUp: () => void;
+  onArrowDown: () => void;
   initialValue: string | null | undefined;
   newResultsCallback: LoadCallback;
 };
@@ -145,7 +148,7 @@ class SearchInput extends Component<SearchInputProps> {
         onBlur={(_e: Event) => setTimeout(() => props.unfocus(), 200)}
         onKeyDown={(e: KeyboardEvent) => this.onKeyDown(e)}
         onInput={(e: Event) => {
-          const target = e.target as HTMLFormElement;
+          const target = e.target as HTMLInputElement;
           setInputValue(target.value);
           debouncedLoader(
             cleanSearchStr(target.value),
@@ -197,21 +200,19 @@ class App extends Component<AppProps, AppState> {
   }
 
   render(_props: AppProps, state: AppState) {
-    function resultsView(selectResult: (index: number) => any) {
-      return (
-        <div
-          class="bg-white br1 br--bottom bb bl br b--blue w-100 absolute"
-          style="top: 2.3rem; box-shadow: 0 4px 10px rgba(0,0,0,0.1)"
-        >
-          <ResultsView
-            resultView={SingleResultView}
-            results={state.results}
-            selectedIndex={state.selectedIndex}
-            onMouseOver={selectResult}
-          />{" "}
-        </div>
-      );
-    }
+    const resultsView = (selectResult: (index: number) => void) => (
+      <div
+        class="bg-white br1 br--bottom bb bl br b--blue w-100 absolute"
+        style="top: 2.3rem; box-shadow: 0 4px 10px rgba(0,0,0,0.1)"
+      >
+        <ResultsView
+          resultView={SingleResultView}
+          results={state.results}
+          selectedIndex={state.selectedIndex}
+          onMouseOver={selectResult}
+        />{" "}
+      </div>
+    );
 
     return (
       <div className="relative system-sans-serif">

--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -1,4 +1,4 @@
-import { h, render } from "preact";
+import { render } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
 import { debounced } from "./search";
 import { DBSchema, IDBPDatabase, openDB } from "idb";

--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -79,10 +79,12 @@ type Def = {
   path: string;
   platform: string;
   doc?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   arglists?: any[][];
   members: {
     type: string;
     name: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     arglists: any[][];
     doc?: string;
   };

--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -249,7 +249,7 @@ const ResultIcon = (props: { item: IndexItem }) => {
   let label: string = item.kind;
   let text: string;
 
-  const colors = {
+  const colors: Record<string, string> = {
     NS: "bg-light-purple",
     DOC: "bg-green",
     VAR: "bg-dark-blue",
@@ -273,8 +273,8 @@ const ResultIcon = (props: { item: IndexItem }) => {
       throw new Error(`Unknown item kind: ${item}`);
   }
 
-  // @ts-ignore
-  const color = colors[text] || defaultColor;
+  // Check if `text` is a valid key in `colors`
+  const color = colors[text] ?? defaultColor;
 
   return (
     <div
@@ -407,7 +407,7 @@ const search = (
 
   const resultsWithDocs = results?.map(r => ({
     result: r,
-    // I assume that Cora wanted this for a reason
+    // I assume that Cora wanted this for a reason, so ignoring eslint
     // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
     doc: searchIndex?.documentStore.getDoc(r.ref)!
   }));

--- a/js/single-docset-search.tsx
+++ b/js/single-docset-search.tsx
@@ -407,6 +407,8 @@ const search = (
 
   const resultsWithDocs = results?.map(r => ({
     result: r,
+    // I assume that Cora wanted this for a reason
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
     doc: searchIndex?.documentStore.getDoc(r.ref)!
   }));
 

--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -1,4 +1,4 @@
-import { h, Component } from "preact";
+import { Component } from "preact";
 import fuzzysort from "fuzzysort";
 import { Library, docsUri, project } from "./library";
 import { ResultsView, ResultViewComponent } from "./listselect";

--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -32,7 +32,7 @@ function trackProjectOpened() {
     const maxTrackedCount = 15;
     const project = parseCljdocURI(window.location.pathname) as VisitedLibrary;
     if (project) {
-      var previouslyOpened: VisitedLibrary[] = JSON.parse(
+      let previouslyOpened: VisitedLibrary[] = JSON.parse(
         localStorage.getItem("previouslyOpened") || "[]"
       );
       // remove identical values
@@ -112,7 +112,7 @@ class Switcher extends Component<SwitcherProps, SwitcherState> {
     }
 
     // If target is document body, trigger  on key `cmd+k` for MacOs `ctrl+k` otherwise
-    let isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+    const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
     let switcherShortcut = false;
 
     if (e.key === "k") {
@@ -141,10 +141,10 @@ class Switcher extends Component<SwitcherProps, SwitcherState> {
     if (searchStr === "") {
       this.initializeState();
     } else {
-      let fuzzysortOptions = {
+      const fuzzysortOptions = {
         key: "project_id"
       };
-      let results = fuzzysort.go(
+      const results = fuzzysort.go(
         searchStr,
         this.state.previouslyOpened,
         fuzzysortOptions
@@ -164,7 +164,7 @@ class Switcher extends Component<SwitcherProps, SwitcherState> {
   }
 
   initializeState() {
-    let previouslyOpened: VisitedLibrary[] = JSON.parse(
+    const previouslyOpened: VisitedLibrary[] = JSON.parse(
       localStorage.getItem("previouslyOpened") || "[]"
     );
 

--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -80,7 +80,7 @@ const SwitcherSingleResultView: ResultViewComponent<VisitedLibrary> = props => {
   );
 };
 
-type SwitcherProps = any;
+type SwitcherProps = Record<string,never>;
 
 type SwitcherState = {
   results: VisitedLibrary[];
@@ -193,8 +193,7 @@ class Switcher extends Component<SwitcherProps, SwitcherState> {
 
   componentDidUpdate(
     _previousProps: SwitcherProps,
-    previousState: SwitcherState,
-    _previousContext: any
+    previousState: SwitcherState
   ) {
     if (!previousState.show && this.state.show && this.inputNode) {
       this.inputNode.focus();

--- a/js/switcher.tsx
+++ b/js/switcher.tsx
@@ -80,7 +80,7 @@ const SwitcherSingleResultView: ResultViewComponent<VisitedLibrary> = props => {
   );
 };
 
-type SwitcherProps = Record<string,never>;
+type SwitcherProps = Record<string, never>;
 
 type SwitcherState = {
   results: VisitedLibrary[];

--- a/js/window.d.ts
+++ b/js/window.d.ts
@@ -2,8 +2,12 @@ export {};
 
 interface HighlightJSPlugin {
   // what we are using, add more if we ever use more
-  'before:highlightElement'?: (args: { el: HTMLElement }) => void;
-  'after:highlightElement'?: (args: { el: HTMLElement; result: { value: string }; text: string }) => void;
+  "before:highlightElement"?: (args: { el: HTMLElement }) => void;
+  "after:highlightElement"?: (args: {
+    el: HTMLElement;
+    result: { value: string };
+    text: string;
+  }) => void;
 }
 
 declare global {

--- a/js/window.d.ts
+++ b/js/window.d.ts
@@ -1,9 +1,14 @@
 export {};
 
+interface HighlightJSPlugin {
+  // what we are using, add more if we ever use more
+  'before:highlightElement'?: (args: { el: HTMLElement }) => void;
+  'after:highlightElement'?: (args: { el: HTMLElement; result: { value: string }; text: string }) => void;
+}
+
 declare global {
   interface Window {
-    // allows us to expose our hljs plugins
-    mergeHTMLPlugin: any;
-    copyButtonPlugin: any;
+    mergeHTMLPlugin: HighlightJSPlugin;
+    copyButtonPlugin: HighlightJSPlugin;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
         "preact": "^10.22.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.3.0",
+        "@eslint/js": "^9.4.0",
         "@parcel/packager-xml": "^2.12.0",
         "@parcel/transformer-image": "^2.12.0",
         "@parcel/transformer-xml": "^2.12.0",
         "@types/elasticlunr": "^0.9.9",
         "@types/eslint__js": "^8.42.3",
         "@types/lunr": "^2.3.7",
-        "eslint": "^9.3.0",
+        "eslint": "^9.4.0",
         "parcel": "^2.12.0",
         "parcel-namer-custom": "^0.2.0",
         "parcel-reporter-static-files-copy": "^1.5.3",
@@ -29,7 +29,7 @@
         "prettier": "^3.2.5",
         "pretty-quick": "^4.0.0",
         "typescript": "^5.4.5",
-        "typescript-eslint": "^8.0.0-alpha.20"
+        "typescript-eslint": "^8.0.0-alpha.24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -176,6 +176,20 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint/config-array": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.15.1.tgz",
+      "integrity": "sha512-K4gzNq+yymn/EVsXYmf+SBcBro8MTf+aXJZUphM96CdzUEr+ClGDvAbpmaEK+cGVigVXIgs9gNmvHAlrzzY5JQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
@@ -200,26 +214,21 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.3.0.tgz",
-      "integrity": "sha512-niBqk8iwv96+yuTwjM6bWg8ovzAPF9qkICsGtcoa5/dmqcEMfdwNAX7+/OHcJHc7wj7XqPxH98oAHytFYlw6Sw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
+      "integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.3.tgz",
+      "integrity": "sha512-HAbhAYKfsAC2EkTqve00ibWIZlaU74Z1EHwAjYr4PXF0YU2VEA1zSIKSSpKszRLRWwHzzRZXvK632u+uXzvsvw==",
       "dev": true,
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
-      },
       "engines": {
-        "node": ">=10.10.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -234,12 +243,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "dev": true
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.3.0",
@@ -261,9 +264,9 @@
       "dev": true
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.0.tgz",
-      "integrity": "sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.1.tgz",
+      "integrity": "sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==",
       "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -2034,14 +2037,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz",
-      "integrity": "sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.24.tgz",
+      "integrity": "sha512-Eph9zvO4xvqWZGVzTdtdEJ0Vqf0VIML/o/e4Qd2RLOqtfgnlRi7avmMu5C0oqciJ0tk+hqdUKVUZ4JPoPaiGvQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@swc/counter": "^0.1.2",
-        "@swc/types": "0.1.7"
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.7"
       },
       "engines": {
         "node": ">=10"
@@ -2051,19 +2054,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.5.7",
-        "@swc/core-darwin-x64": "1.5.7",
-        "@swc/core-linux-arm-gnueabihf": "1.5.7",
-        "@swc/core-linux-arm64-gnu": "1.5.7",
-        "@swc/core-linux-arm64-musl": "1.5.7",
-        "@swc/core-linux-x64-gnu": "1.5.7",
-        "@swc/core-linux-x64-musl": "1.5.7",
-        "@swc/core-win32-arm64-msvc": "1.5.7",
-        "@swc/core-win32-ia32-msvc": "1.5.7",
-        "@swc/core-win32-x64-msvc": "1.5.7"
+        "@swc/core-darwin-arm64": "1.5.24",
+        "@swc/core-darwin-x64": "1.5.24",
+        "@swc/core-linux-arm-gnueabihf": "1.5.24",
+        "@swc/core-linux-arm64-gnu": "1.5.24",
+        "@swc/core-linux-arm64-musl": "1.5.24",
+        "@swc/core-linux-x64-gnu": "1.5.24",
+        "@swc/core-linux-x64-musl": "1.5.24",
+        "@swc/core-win32-arm64-msvc": "1.5.24",
+        "@swc/core-win32-ia32-msvc": "1.5.24",
+        "@swc/core-win32-x64-msvc": "1.5.24"
       },
       "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "*"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -2072,9 +2075,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.7.tgz",
-      "integrity": "sha512-bZLVHPTpH3h6yhwVl395k0Mtx8v6CGhq5r4KQdAoPbADU974Mauz1b6ViHAJ74O0IVE5vyy7tD3OpkQxL/vMDQ==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.24.tgz",
+      "integrity": "sha512-M7oLOcC0sw+UTyAuL/9uyB9GeO4ZpaBbH76JSH6g1m0/yg7LYJZGRmplhDmwVSDAR5Fq4Sjoi1CksmmGkgihGA==",
       "cpu": [
         "arm64"
       ],
@@ -2088,9 +2091,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.7.tgz",
-      "integrity": "sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSByaw==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.24.tgz",
+      "integrity": "sha512-MfcFjGGYognpSBSos2pYUNYJSmqEhuw5ceGr6qAdME7ddbjGXliza4W6FggsM+JnWwpqa31+e7/R+GetW4WkaQ==",
       "cpu": [
         "x64"
       ],
@@ -2104,9 +2107,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.7.tgz",
-      "integrity": "sha512-cTZWTnCXLABOuvWiv6nQQM0hP6ZWEkzdgDvztgHI/+u/MvtzJBN5lBQ2lue/9sSFYLMqzqff5EHKlFtrJCA9dQ==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.24.tgz",
+      "integrity": "sha512-amI2pwtcWV3E/m/nf+AQtn1LWDzKLZyjCmWd3ms7QjEueWYrY8cU1Y4Wp7wNNsxIoPOi8zek1Uj2wwFD/pttNQ==",
       "cpu": [
         "arm"
       ],
@@ -2120,9 +2123,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.7.tgz",
-      "integrity": "sha512-hoeTJFBiE/IJP30Be7djWF8Q5KVgkbDtjySmvYLg9P94bHg9TJPSQoC72tXx/oXOgXvElDe/GMybru0UxhKx4g==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.24.tgz",
+      "integrity": "sha512-sTSvmqMmgT1ynH/nP75Pc51s+iT4crZagHBiDOf5cq+kudUYjda9lWMs7xkXB/TUKFHPCRK0HGunl8bkwiIbuw==",
       "cpu": [
         "arm64"
       ],
@@ -2136,9 +2139,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.7.tgz",
-      "integrity": "sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.24.tgz",
+      "integrity": "sha512-vd2/hfOBGbrX21FxsFdXCUaffjkHvlZkeE2UMRajdXifwv79jqOHIJg3jXG1F3ZrhCghCzirFts4tAZgcG8XWg==",
       "cpu": [
         "arm64"
       ],
@@ -2152,9 +2155,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.7.tgz",
-      "integrity": "sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.24.tgz",
+      "integrity": "sha512-Zrdzi7NqzQxm2BvAG5KyOSBEggQ7ayrxh599AqqevJmsUXJ8o2nMiWQOBvgCGp7ye+Biz3pvZn1EnRzAp+TpUg==",
       "cpu": [
         "x64"
       ],
@@ -2168,9 +2171,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.7.tgz",
-      "integrity": "sha512-0VN9Y5EAPBESmSPPsCJzplZHV26akC0sIgd3Hc/7S/1GkSMoeuVL+V9vt+F/cCuzr4VidzSkqftdP3qEIsXSpg==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.24.tgz",
+      "integrity": "sha512-1F8z9NRi52jdZQCGc5sflwYSctL6omxiVmIFVp8TC9nngjQKc00TtX/JC2Eo2HwvgupkFVl5YQJidAck9YtmJw==",
       "cpu": [
         "x64"
       ],
@@ -2184,9 +2187,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.7.tgz",
-      "integrity": "sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.24.tgz",
+      "integrity": "sha512-cKpP7KvS6Xr0jFSTBXY53HZX/YfomK5EMQYpCVDOvfsZeYHN20sQSKXfpVLvA/q2igVt1zzy1XJcOhpJcgiKLg==",
       "cpu": [
         "arm64"
       ],
@@ -2200,9 +2203,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.7.tgz",
-      "integrity": "sha512-Xm0TfvcmmspvQg1s4+USL3x8D+YPAfX2JHygvxAnCJ0EHun8cm2zvfNBcsTlnwYb0ybFWXXY129aq1wgFC9TpQ==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.24.tgz",
+      "integrity": "sha512-IoPWfi0iwqjZuf7gE223+B97/ZwkKbu7qL5KzGP7g3hJrGSKAvv7eC5Y9r2iKKtLKyv5R/T6Ho0kFR/usi7rHw==",
       "cpu": [
         "ia32"
       ],
@@ -2216,9 +2219,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.7.tgz",
-      "integrity": "sha512-tp43WfJLCsKLQKBmjmY/0vv1slVywR5Q4qKjF5OIY8QijaEW7/8VwPyUyVoJZEnDgv9jKtUTG5PzqtIYPZGnyg==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.24.tgz",
+      "integrity": "sha512-zHgF2k1uVJL8KIW+PnVz1To4a3Cz9THbh2z2lbehaF/gKHugH4c3djBozU4das1v35KOqf5jWIEviBLql2wDLQ==",
       "cpu": [
         "x64"
       ],
@@ -2308,16 +2311,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-/dBqhcdiVHB3SzaU5Mczy1QoVel8hZ8TX7T2WE1Qq2ujrv4X9I2/H2DMHnNtmlcGY9hcezsPtu76BTiZAeMQqw==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-14rK2L+ayITgprWmtaoI7ImzAZtHpnzQ7ujKJDQP6FrLSpd2Xv9ndViiG1XvhXYnwH1ppHGRZDzOkOMmDgp3Mg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.0.0-alpha.20",
-        "@typescript-eslint/type-utils": "8.0.0-alpha.20",
-        "@typescript-eslint/utils": "8.0.0-alpha.20",
-        "@typescript-eslint/visitor-keys": "8.0.0-alpha.20",
+        "@typescript-eslint/scope-manager": "8.0.0-alpha.24",
+        "@typescript-eslint/type-utils": "8.0.0-alpha.24",
+        "@typescript-eslint/utils": "8.0.0-alpha.24",
+        "@typescript-eslint/visitor-keys": "8.0.0-alpha.24",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -2341,15 +2344,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-C1gnMM1k6i0phZ7l6HJPecVIGMErrONnurQ9ssRBZNek7gJInDGEDUC7LlL3QIWxFkHcdwYXWzuc7IueyxU6YQ==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-Dpt40m3taG7Eidv6F1WLvMmt3mGDNib8l/rYiY+7CwjijgXYmwsX95W/P2+fW6LeBvB8ATIEcbSbdX7TUmcg5Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.0.0-alpha.20",
-        "@typescript-eslint/types": "8.0.0-alpha.20",
-        "@typescript-eslint/typescript-estree": "8.0.0-alpha.20",
-        "@typescript-eslint/visitor-keys": "8.0.0-alpha.20",
+        "@typescript-eslint/scope-manager": "8.0.0-alpha.24",
+        "@typescript-eslint/types": "8.0.0-alpha.24",
+        "@typescript-eslint/typescript-estree": "8.0.0-alpha.24",
+        "@typescript-eslint/visitor-keys": "8.0.0-alpha.24",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2369,13 +2372,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-+Ncj0Q6DT8ZHYNp8h5RndW4Siv52kiPpHEz/i8Sj2rh2y8ZCc5pKSHSslk+eZi0Bdj+/+swNOmDNcL2CrlaEnA==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-ATe1bLKAyJ3alyrAoC0Wel1mnBThFB0/OBoXHp9GKoiTHdqJAhs2cCgZOgQWyJmWLiLFQHLyJj3EIFpoaDOX+Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.0.0-alpha.20",
-        "@typescript-eslint/visitor-keys": "8.0.0-alpha.20"
+        "@typescript-eslint/types": "8.0.0-alpha.24",
+        "@typescript-eslint/visitor-keys": "8.0.0-alpha.24"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2386,13 +2389,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-/eUDosUnJlEwzRFPwaKYM3H0VS+40oXx+5ZN+CFCtdXMZjGsTwKM3XNvI+4orisjn+qhNVlHZby4PHnH8qAh8Q==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-jNh21K0/2aTekfPQAONImIEi0yTsLLH/dmOjuXLEX56QniTPoMKFrO9JYVUfjTRIlEHl8/F8VDv9yTINNcx/2w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.0.0-alpha.20",
-        "@typescript-eslint/utils": "8.0.0-alpha.20",
+        "@typescript-eslint/typescript-estree": "8.0.0-alpha.24",
+        "@typescript-eslint/utils": "8.0.0-alpha.24",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -2410,9 +2413,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-xpU1rMQfnnNZxpHN6YUfr18sGOMcpC9hvt54fupcU6N1qMCagEtkRt1U15x086oJAgAITJGa67454ffAoCxv/w==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-MwBAoDe8nf1KrquszS586fHp+b9LV4jd2zEzwB6FdfLmJavyHrJGVFmCVSoDNZ40MqCQklgY78px6TXnKulCfg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2423,13 +2426,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-VQ8Mf8upDCuf0uMTjX/Pdw3gvCZomkG43nuThUuzhK3YFwFmIDTqx0ZWSsYJkVGfll0WrXgIua+rKSP/n6NBWw==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-d/WTeR5eG9BboB9rPdcv7o8fZV4Jyy643Xxb9s0O9xX2X5oZrj5lqD7O/J+9aT9l/iE4U81sp1bceQKoUDJq0A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.0.0-alpha.20",
-        "@typescript-eslint/visitor-keys": "8.0.0-alpha.20",
+        "@typescript-eslint/types": "8.0.0-alpha.24",
+        "@typescript-eslint/visitor-keys": "8.0.0-alpha.24",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2475,15 +2478,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-0aMhjDTvIrkGkHqyM0ZByAwR8BV1f2HhKdYyjtxko8S/Ca4PGjOIjub6VoF+bQwCRxEuV8viNUld78rqm9jqLA==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-Ph3Mvh+KRlf8zPmhyFqSpDVCyfcCfNd7mLujLWzXo/TgJfXbdjjs7CLv8yc+tmB7zwgiv/XIeul1iyYUVKjMEw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.0.0-alpha.20",
-        "@typescript-eslint/types": "8.0.0-alpha.20",
-        "@typescript-eslint/typescript-estree": "8.0.0-alpha.20"
+        "@typescript-eslint/scope-manager": "8.0.0-alpha.24",
+        "@typescript-eslint/types": "8.0.0-alpha.24",
+        "@typescript-eslint/typescript-estree": "8.0.0-alpha.24"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2497,12 +2500,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-ej06rfct0kalfJgIR8nTR7dF1mgfF83hkylrYas7IAElHfgw4zx99BUGa6VrnHZ1PkxdJBp5PgcO2FmmlOoaRQ==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-9gu8YsifuPFXC1ZDPEXroGon1/IbSXD5bYFs6mmE8GwVo++Z1UTaO3tjTp+k/b85d8MBRkhetgBSFKKsIWetTw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.0.0-alpha.20",
+        "@typescript-eslint/types": "8.0.0-alpha.24",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -2701,9 +2704,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001624",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001624.tgz",
-      "integrity": "sha512-0dWnQG87UevOCPYaOR49CBcLBwoZLpws+k6W37nLjWUhumP1Isusj0p2u+3KhjNloRWK9OKMgjBBzPujQHw4nA==",
+      "version": "1.0.30001625",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001625.tgz",
+      "integrity": "sha512-4KE9N2gcRH+HQhpeiRZXd+1niLB/XNLAhSy4z7fI8EzcbcPoAqjNInxVHTiTwWfTIV4w096XG8OtCOCQQKPv3w==",
       "dev": true,
       "funding": [
         {
@@ -2737,9 +2740,9 @@
       }
     },
     "node_modules/chrome-trace-event": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
       "engines": {
         "node": ">=6.0"
@@ -2989,9 +2992,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -3120,9 +3123,9 @@
       "integrity": "sha512-5YM9LFQgVYfuLNEoqMqVWIBuF2UNCA+xu/jz1TyryLN/wmBcQSb+GNAwvLKvEpGESwgGN8XA1nbLAt6rKlyHYQ=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.783",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.783.tgz",
-      "integrity": "sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ==",
+      "version": "1.4.787",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz",
+      "integrity": "sha512-d0EFmtLPjctczO3LogReyM2pbBiiZbnsKnGF+cdZhsYzHm/A0GV7W94kqzLD8SN4O3f3iHlgLUChqghgyznvCQ==",
       "dev": true
     },
     "node_modules/entities": {
@@ -3177,16 +3180,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.3.0.tgz",
-      "integrity": "sha512-5Iv4CsZW030lpUqHBapdPo3MJetAPtejVW8B84GIcIIv8+ohFaddXsrn1Gn8uD9ijDb+kcYKFUVmC8qG8B2ORQ==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.4.0.tgz",
+      "integrity": "sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/config-array": "^0.15.1",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.3.0",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint/js": "9.4.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
@@ -4953,14 +4956,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.0.0-alpha.20.tgz",
-      "integrity": "sha512-/cx37A2S+AOne5uFpD8GzHzV5b/7wncAh4agmIRieAZWXJWbRcue7e8RI6LnpQ7CHy9IHPmALcHcXPXogM6jcQ==",
+      "version": "8.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.0.0-alpha.24.tgz",
+      "integrity": "sha512-YZD7Uz/8oze7Eal4REHRrltl7I7dg6A05sIVzZnkppRXvmUPTSBOPNwKoEkmAursQiVMasjAIYHR166t6IS/2w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.0.0-alpha.20",
-        "@typescript-eslint/parser": "8.0.0-alpha.20",
-        "@typescript-eslint/utils": "8.0.0-alpha.20"
+        "@typescript-eslint/eslint-plugin": "8.0.0-alpha.24",
+        "@typescript-eslint/parser": "8.0.0-alpha.24",
+        "@typescript-eslint/utils": "8.0.0-alpha.24"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react": "preact/compat",
     "react-dom": "preact/compat",
     "react/jsx-runtime": "preact/jsx-runtime",
-    "react/jsx-dev-runtime": "preact/jsx-dev-runtime"
+    "react/jsx-dev-runtime": "preact/jsx-dev-runtime",
+    "preact/jsx-dev-runtime": "preact/jsx-runtime"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "preact": "^10.22.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.3.0",
+    "@eslint/js": "^9.4.0",
     "@parcel/packager-xml": "^2.12.0",
     "@parcel/transformer-image": "^2.12.0",
     "@parcel/transformer-xml": "^2.12.0",
     "@types/elasticlunr": "^0.9.9",
     "@types/eslint__js": "^8.42.3",
     "@types/lunr": "^2.3.7",
-    "eslint": "^9.3.0",
+    "eslint": "^9.4.0",
     "parcel": "^2.12.0",
     "parcel-namer-custom": "^0.2.0",
     "parcel-reporter-static-files-copy": "^1.5.3",
@@ -33,7 +33,7 @@
     "prettier": "^3.2.5",
     "pretty-quick": "^4.0.0",
     "typescript": "^5.4.5",
-    "typescript-eslint": "^8.0.0-alpha.20"
+    "typescript-eslint": "^8.0.0-alpha.24"
   },
   "staticFiles": {
     "staticPath": "resources/public/static"

--- a/package.json
+++ b/package.json
@@ -46,5 +46,11 @@
   },
   "parcel-namer-custom": {
     ".css$": "[name].[hash].[ext]"
+  },
+  "alias": {
+    "react": "preact/compat",
+    "react-dom": "preact/compat",
+    "react/jsx-runtime": "preact/jsx-runtime",
+    "react/jsx-dev-runtime": "preact/jsx-dev-runtime"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "esModuleInterop": true,
-    "jsx": "react",
-    "jsxFactory": "h",
-    "jsxFragmentFactory": "Fragment",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "lib": ["dom", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
Our front end is written in TypeScript, but not many of us know TypeScript very well.
A linter may help us stay in line.

I had added eslint deps a while back, but this PR addresses (or ignores in a few cases) all eslint findings.

The new bb task `eslint` is now also invoked with CI front-end checks.