### PR TITLE
Improve link previews

### DIFF
--- a/doc/cljdoc-developer-technical-guide.adoc
+++ b/doc/cljdoc-developer-technical-guide.adoc
@@ -350,3 +350,13 @@ bb docker-image
 ```
 
 Run `bb clean` first to ensure no cached resources are being used.
+
+=== Link Previews for Slack/Socials
+
+cljdoc uses https://dynogee.com[Dynogee] to create content-based OpenGraph
+images (https://github.com/cljdoc/cljdoc/pull/884[original PR]).
+https://ogp.me/[OpenGraph] is a simple protocol based on HTML `<meta>` tags to
+provide additional information to be displayed alongside links when they are
+shared.
+If you want to update the OpenGraph image templates, you can create a new
+template on Dynogee and replace the `id` that's specified in the code.

--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -28,7 +28,8 @@
           {:top-bar (layout/top-bar version-entity (-> cache-bundle :version :scm :url))
            :main-sidebar-contents (sidebar/sidebar-contents route-params cache-bundle last-build)})
          (layout/page {:title (str (proj/clojars-id version-entity) " " (:version version-entity))
-                       :og-img-data {:page-title (:description pom)
+                       :og-img-data {:id "4j9ovv5ojagy8ik"
+                                     :page-title (:description pom)
                                      :project-version (:version version-entity)
                                      :project-name (proj/clojars-id version-entity)}
                        :description (layout/artifact-description version-entity (:description pom))
@@ -86,7 +87,8 @@
                        :canonical-url (some->> (bundle/more-recent-version cache-bundle)
                                                (merge route-params)
                                                (routes/url-for :artifact/doc :path-params))
-                       :og-img-data {:page-title (if default-doc?
+                       :og-img-data {:id "4j9ovv5ojagy8ik"
+                                     :page-title (if default-doc?
                                                    (:description pom)
                                                    (:title doc-p))
                                      :project-version (:version version-entity)
@@ -136,7 +138,8 @@
                                                         :valid-ref-pred valid-ref-pred
                                                         :opts opts})}))
          (layout/page {:title (str (:namespace ns-emap) " — " (proj/clojars-id version-entity) " " (:version version-entity))
-                       :og-img-data {:page-title (str "(ns " (:namespace ns-emap) ")")
+                       :og-img-data {:id "4j9ovv5ojagy8ik"
+                                     :page-title (str "(ns " (:namespace ns-emap) ")")
                                      :subtitle (platf/get-field ns-data :doc)
                                      :project-version (:version version-entity)
                                      :project-name (proj/clojars-id version-entity)}

--- a/src/cljdoc/render/home.clj
+++ b/src/cljdoc/render/home.clj
@@ -105,6 +105,8 @@
 
         (footer)]
        (layout/page {:title "cljdoc — documentation for Clojure/Script libraries"
+                     :og-img-data {:id "wut3pyewypqpsvo"
+                                   :page-title "Documentation Hosting for the Clojure/Script ecosystem"}
                      :responsive? true
                      :static-resources (:static-resources context)})
        (str)))

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -7,6 +7,7 @@
             [cljdoc.util.scm :as scm]
             [cljdoc-shared.proj :as proj]
             [clojure.string :as string]
+            [ring.util.codec :as ring-codec]
             [hiccup2.core :as hiccup]
             [hiccup.page]))
 
@@ -108,6 +109,15 @@
                  [:meta {:content "website" :property "og:type"}]
                  [:meta {:content (:title opts) :property "og:title"}]
                  [:meta {:content (:description opts) :property "og:description"}]
+                 (when (:id (:og-img-data opts))
+                   [:meta {:content (str "https://dynogee.com/gen?"
+                                         (->> (:og-img-data opts)
+                                              (keep (fn [[k v]]
+                                                      (when (string? v)
+                                                        (str (name k) "=" (ring-codec/url-encode v)))))
+                                              (string/join "&")))
+                           :property "og:image"}])
+                 [:meta {:name "twitter:card" :content "summary_large_image"}]
                  ;; Disable image for now; doesn't add much and occupies a lot of space in Slack and similar
                  ;; [:meta {:content (str "https://cljdoc.org"
                  ;;                   (get (:static-resources opts) "/cljdoc-logo-beta-square.png"))


### PR DESCRIPTION
This adds improved link preview images for documentation on cljdoc, powered by [Dynogee](https://dynogee.com?ref=cljdoc). Happy to provide this to cljdoc for free (would potentially ask for a backlink at some point). 

### Homepage

<img src="https://dynogee.com/gen?id=wut3pyewypqpsvo&page-title=Documentation+Hosting+for+the+Clojure%2FScript+ecosystem" width=400>

### Project default page

This is the default / first article in the doc tree, instead of showing "Readme" or "Home" it shows the description according to `pom.xml`

<img src="https://dynogee.com/gen?id=4j9ovv5ojagy8ik&project-name=io.github.noahtheduke%2Fsplint&project-version=1.15.2&page-title=Lint+Clojure+by+shape.&subtitle=" width=400>

Other article pages show the title of the article according to the doctree

<img src="https://dynogee.com/gen?id=4j9ovv5ojagy8ik&project-name=io.github.noahtheduke%2Fsplint&project-version=1.15.2&page-title=Rules+Overview&subtitle=" width=400>

### Namespace page

Integrates namespace name, and a snippet of the ns docstring

<img src="https://dynogee.com/gen?id=4j9ovv5ojagy8ik&project-name=io.github.noahtheduke%2Fsplint&project-version=1.15.2&page-title=(ns%20noahtheduke.splint)&subtitle=Entry-point%20for%20splint.%20Loads%20all%20of%20the%20lints%20up%20front%2C%20delegates%20all%20work%0Ato%20library%20functions." width=400>



### Slack (as an example)

In Slack these images would be displayed as below (note that I doctored that screenshot a bit, the domain, page title etc would be cljdoc's)

![Screenshot 2024-06-23 at 14 25 03](https://github.com/cljdoc/cljdoc/assets/97496/a2cd2313-8477-4c72-ac9e-5b1c008d725b)

