### PR TITLE
ops: nvd-scan: rebump deps check [skip ci]

### DIFF
--- a/modules/nvd-scan/deps.edn
+++ b/modules/nvd-scan/deps.edn
@@ -4,4 +4,4 @@
         #_:clj-kondo/ignore
         {:mvn/version "RELEASE"}
         ;; temporarily try bumping transitive dep to current release
-        org.owasp/dependency-check-core {:mvn/version "10.0.1"}}}
+        org.owasp/dependency-check-core {:mvn/version "10.0.2"}}}

--- a/modules/nvd-scan/nvd-suppressions.xml
+++ b/modules/nvd-scan/nvd-suppressions.xml
@@ -84,37 +84,10 @@
   </suppress>
   <suppress>
    <notes><![CDATA[
-     We are on Jetty 11.0.20...not sure why these are matching probably because there is an assumption we are on websocket api is
-     version differently, at the time of this writing it is at 2.0.0.
-     CVE-2017-7657 - In Eclipse Jetty, versions 9.2.x and older, 9.3.x...
-     CVE-2017-7658 - In Eclipse Jetty, versions 9.2.x and older, 9.3.x...
-     CVE-2009-5045 - Dump Servlet information leak in jetty before 6.1.22.
-     CVE-2017-7656 - In Eclipse Jetty, versions 9.2.x and older, 9.3.x (all configurations), and 9.4.x...
-     CVE-2017-9735 - Jetty through 9.4.x is prone to a timing...
-     CVE-2022-2048 - versions from (including) 11.0.0; versions up to (excluding) 11.0.9
-     CVE-2023-44487 - versions up to (excluding) 9.4.53
-     CVE-2020-27216 - In Eclipse Jetty versions 1.0 thru 9.4.32.v20200930, 10.0.0.alpha1 thru 10.0.0.beta2, and 11.0.0.alpha1 thru 11.0.0.beta2O...
-     CVE-2009-5046 - JSP Dump and Session Dump Servlet XSS in jetty before 6.1.22.
-     CVE-2021-28169 - For Eclipse Jetty versions <= 9.4.40, <= 10.0.2, <= 11.0.2...
-     CVE-2023-26048 - versions from (including) 11.0.0; versions up to (excluding) 11.0.14
-     CVE-2023-26049 - versions from (including) 11.0.0; versions up to (excluding) 11.0.14
-     CVE-2021-34428 - For Eclipse Jetty versions <= 9.4.40, <= 10.0.2, <= 11.0.2...
-     CVE-2022-2047 - In Eclipse Jetty versions 9.4.0 thru 9.4.46, and 10.0.0 thru 10.0.9, and 11.0.0 thru 11.0.9 versions
+     Jetty toolchain lib versioning is idependent of Jetty release.
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-jakarta\-websocket\-api@2\.0\.0$</packageUrl>
-   <cve>CVE-2017-7657</cve>
-   <cve>CVE-2017-7658</cve>
-   <cve>CVE-2009-5045</cve>
-   <cve>CVE-2017-7656</cve>
-   <cve>CVE-2017-9735</cve>
-   <cve>CVE-2022-2048</cve>
-   <cve>CVE-2023-44487</cve>
-   <cve>CVE-2020-27216</cve>
-   <cve>CVE-2009-5046</cve>
-   <cve>CVE-2021-28169</cve>
-   <cve>CVE-2023-26048</cve>
-   <cve>CVE-2023-26049</cve>
-   <cve>CVE-2021-34428</cve>
-   <cve>CVE-2022-2047</cve>
+   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/.*@.*$</packageUrl>
+   <cpe>cpe:/a:jetty:jetty</cpe>
+   <cpe>cpe:/a:eclipse:jetty</cpe>
   </suppress>
 </suppressions>


### PR DESCRIPTION
Deps check 10.0.2 is a mandatory update.

Simplify suppression rules for jetty toolchain libs.