### PR TITLE
Support Table of Contents in markdown

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,6 +38,8 @@
         {:mvn/version "0.64.8"}
         com.vladsch.flexmark/flexmark-ext-tables             ;; support for tables
         {:mvn/version "0.64.8"}
+        com.vladsch.flexmark/flexmark-ext-toc                ;; support for table of contents
+        {:mvn/version "0.64.8"}
         com.vladsch.flexmark/flexmark-ext-anchorlink         ;; adds github id style anchor links to headings
         {:mvn/version "0.64.8"}
         com.vladsch.flexmark/flexmark-ext-wikilink           ;; support for our docstring [[my-ns/var]] link feature

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -6,6 +6,7 @@
            (com.vladsch.flexmark.ext.anchorlink AnchorLinkExtension)
            (com.vladsch.flexmark.ext.autolink AutolinkExtension)
            (com.vladsch.flexmark.ext.tables TablesExtension)
+           (com.vladsch.flexmark.ext.toc TocExtension)
            (com.vladsch.flexmark.ext.wikilink WikiLink WikiLinkExtension)
            (com.vladsch.flexmark.ext.wikilink.internal WikiLinkNodeRenderer$Factory)
            (com.vladsch.flexmark.html HtmlRenderer LinkResolver LinkResolverFactory)
@@ -42,6 +43,7 @@
    (TablesExtension/create)
    (AutolinkExtension/create)
    (AnchorLinkExtension/create)
+   (TocExtension/create)
    (GitHubAlertExtension/create)])
 
 (def md-parser-opts (doto (MutableDataSet.)
@@ -56,6 +58,7 @@
                       (.set TablesExtension/WITH_CAPTION false)
                       (.set TablesExtension/MIN_HEADER_ROWS ^Integer (int 1))
                       (.set TablesExtension/MAX_HEADER_ROWS ^Integer (int 1))
+                      (.set TocExtension/TITLE "Table of Contents")
                       (.toImmutable)))
 
 (defn- md-parser


### PR DESCRIPTION
Closes #910 

I didn't see anywhere to note the new feature, there's no "list of supported Markdown extensions". Might be worthwhile to write something up in the future?