### PR TITLE
more tweaks for visualvm

### DIFF
--- a/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
+++ b/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
@@ -12,7 +12,7 @@
         :Tasks
           [{:Artifacts nil,
             :Config {:image #join ["cljdoc/cljdoc:" #cljdoc.deploy/opt :docker-tag]
-                     :port_map [{:http 8000 :jmx 9010}],
+                     :port_map [{:http 8000 :jmx 9010 :rmi 9011}],
                      :volumes ["secrets:/etc/cljdoc"
                                "/data/cljdoc:/var/cljdoc"]},
             :Driver "docker",
@@ -24,7 +24,8 @@
               {:CPU 1000,
                :MemoryMB 1600,
                :Networks [{:DynamicPorts [{:Label "http", :Value 0}
-                                          {:Label "jmx", :Value 0}],
+                                          {:Label "jmx", :Value 9010}
+                                          {:Label "rmi", :Value 9011 }],
                            :MBits 10}]},
             :Services [{:Name "cljdoc",
                         :PortLabel "http",

--- a/script/docker_entrypoint.clj
+++ b/script/docker_entrypoint.clj
@@ -56,7 +56,7 @@
                   ;; perhaps temporary... allow connection via jvisualvm
                   "-J-Dcom.sun.management.jmxremote"
                   "-J-Dcom.sun.management.jmxremote.port=9010"
-                  "-J-Dcom.sun.management.jmxremote.rmi.port=9010"
+                  "-J-Dcom.sun.management.jmxremote.rmi.port=9011"
                   "-J-Dcom.sun.management.jmxremote.authenticate=false"
                   "-J-Dcom.sun.management.jmxremote.ssl=false"
                   "-J-Djava.rmi.server.hostname=localhost"


### PR DESCRIPTION
Try separate ports for jmx and rmi and try exposing to static values that match de facto conventions.