### PR TITLE
ops: visualvm tweaks

### DIFF
--- a/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
+++ b/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
@@ -12,7 +12,7 @@
         :Tasks
           [{:Artifacts nil,
             :Config {:image #join ["cljdoc/cljdoc:" #cljdoc.deploy/opt :docker-tag]
-                     :port_map [{:http 8000 :jmx 9010 :rmi 9011}],
+                     :port_map [{:http 8000 :jmx 9010}],
                      :volumes ["secrets:/etc/cljdoc"
                                "/data/cljdoc:/var/cljdoc"]},
             :Driver "docker",
@@ -24,8 +24,7 @@
               {:CPU 1000,
                :MemoryMB 1600,
                :Networks [{:DynamicPorts [{:Label "http", :Value 0}]
-                           :ReservedPorts [{:Label "jmx", :Value 9010}
-                                           {:Label "rmi", :Value 9011 }]
+                           :ReservedPorts [{:Label "jmx", :Value 9010}]
                            :MBits 10}]},
             :Services [{:Name "cljdoc",
                         :PortLabel "http",

--- a/script/docker_entrypoint.clj
+++ b/script/docker_entrypoint.clj
@@ -56,7 +56,7 @@
                   ;; perhaps temporary... allow connection via jvisualvm
                   "-J-Dcom.sun.management.jmxremote"
                   "-J-Dcom.sun.management.jmxremote.port=9010"
-                  "-J-Dcom.sun.management.jmxremote.rmi.port=9011"
+                  "-J-Dcom.sun.management.jmxremote.rmi.port=9010"
                   "-J-Dcom.sun.management.jmxremote.authenticate=false"
                   "-J-Dcom.sun.management.jmxremote.ssl=false"
                   "-J-Djava.rmi.server.hostname=localhost"


### PR DESCRIPTION
Jmx (or maybe rmi?) is a nasty little thing to configure. Some folks say setting both ports to the same tells the jvm to absolutely only use a single port for all comms.