### PR TITLE
ops: visualvm tweaks

### DIFF
--- a/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
+++ b/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
@@ -23,8 +23,8 @@
             :Resources
               {:CPU 1000,
                :MemoryMB 1600,
-               :Networks [{:DynamicPorts [{:Label "http", :Value 0}]
-                           :ReservedPorts [{:Label "jmx", :Value 9010}]
+               :Networks [{:DynamicPorts [{:Label "http", :Value 0}
+                                          {:Label "jmx", :Value 0}]
                            :MBits 10}]},
             :Services [{:Name "cljdoc",
                         :PortLabel "http",


### PR DESCRIPTION
Right... because we blue and green are up at the same time, we can't expose static ports because they will collide.