### PR TITLE
ci: bump circleci node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ aliases:
       command: bb download-deps
 
 orbs:
-  node: circleci/node@5.2.0
+  node: circleci/node@6.3.0
 
 jobs:
   #


### PR DESCRIPTION
Node failed to install last CI run, let's see if bumping node orb helps.