### PR TITLE
ops: support visualvm -> cljdoc server

### DIFF
--- a/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
+++ b/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
@@ -34,6 +34,11 @@
                   ;; traefik is now configured through service tags
                   :Tags
                   ["traefik.enable=true"
+                   ;; jmx (only acessible locally)
+                   "traefik.tcp.routers.jxm-router.entrypoints=jmx"
+                   "traefik.tcp.routers.jmx-router.rule=HostSNI(`*`)"
+                   "traefik.tcp.routers.jmx-router.service=jmx-service"
+                   "traefik.tcp.services.jmx-service.loadbalancer.server.port=${NOMAD_HOST_PORT_jmx}"
                    ;; http
                    "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
                    "traefik.http.middlewares.redirect-to-https.redirectscheme.permanent=true"

--- a/ops/exoscale/deploy/resources/traefik.edn
+++ b/ops/exoscale/deploy/resources/traefik.edn
@@ -4,7 +4,8 @@
  :accessLog {:filePath "/data/access.log"}
  :log {:filePath "/data/traefik.log"}
  :entryPoints {:web {:address ":80"}
-               :websecure {:address ":443"}}
+               :websecure {:address ":443"}
+               :jmx {:address ":9010"}}
  :certificatesResolvers {:letsencrypt
                          {:acme {:email "martinklepsch@googlemail.com"
                                  :storage "/data/acme.json"

--- a/ops/exoscale/deploy/src/cljdoc/deploy.clj
+++ b/ops/exoscale/deploy/src/cljdoc/deploy.clj
@@ -211,7 +211,7 @@
   (aero/read-config "/home/lee/proj/oss/cljdoc/cljdoc/resources/config.edn" {:profile :default})
 
   ;; local testing against debian in a VirtualBox VM
-  (def deploy-opts {:docker-tag "0.0.2708-lread-ops-support-local-testing-of-host-e6b7d7a"
+  (def deploy-opts {:docker-tag "0.0.2718-lread-allow-visualvm-91ac4c5"
                     :cljdoc-profile "default"
                     :secrets-filename "../../../resources/secrets.edn"})
 

--- a/ops/nomad.sh
+++ b/ops/nomad.sh
@@ -46,7 +46,12 @@ cleanup () {
 trap cleanup EXIT ERR INT TERM
 
 # Start SSH port forwarding process for consul (8500) and nomad (4646)
-ssh -M -S "${socket}" -fNT -L 8080:localhost:8080 -L 8500:localhost:8500 -L 4646:localhost:4646 "${user_ip}"
+ssh -M -S "${socket}" -fNT \
+    -L 8080:localhost:8080 \
+    -L 8500:localhost:8500 \
+    -L 4646:localhost:4646 \
+    -L 9010:localhost:9010 \
+    "${user_ip}"
 
 ssh -S "${socket}" -O check "${user_ip}"
 

--- a/script/docker_entrypoint.clj
+++ b/script/docker_entrypoint.clj
@@ -59,7 +59,7 @@
                   "-J-Dcom.sun.management.jmxremote.rmi.port=9010"
                   "-J-Dcom.sun.management.jmxremote.authenticate=false"
                   "-J-Dcom.sun.management.jmxremote.ssl=false"
-                  "-J-Djava.rmi.server.hostname=0.0.0.0"
+                  "-J-Djava.rmi.server.hostname=localhost"
                   (format "-J-XX:HeapDumpPath=%s" (str heap-dump-file))
                   "-M" "-m" "cljdoc.server.system")))
 


### PR DESCRIPTION
This was a confusing slog!

Visualvm talks to jmx over rmi.
The RMI handshake starts off with a request to an RMI registry that returns the hostname on which to continue the session.

A docker container deployed by nomad is bound to the host IP. I haven't found a way around that. It thing that for normal nomad usage this is probably reasonable, our single node usage of nomad is unconventional.

The only way I can see to expose a nomad docker deployed cljdoc server port is through traefik. This is a bit non-intuitive to me because I saw traefik as our public front end, not a private ops front-end.

Traefik does support routing tcp traffic.
Docs, as usual, are on the brief side.
But I stumbled on the correct incantation.

So what we have is:
- cljdoc server jvm process enables jmx on port 9010 with an rmi hostname of localhost. We must set both the port and rmi.port to the same port, otherwise the connection will be attempted over several(?) ports (see script/docker_entrypoint.clj jvm properties on launch).
- nomad exposes internal docker port 9010 to a dynamic jmx port bound to the host server IP. We must use a dynamic port because we need to support blue/green deploys and a static port would mean a port collision during deploy.
- traefik is configured to expose port 9010 and route that to our nomad dynamic jmx port.

When we ssh port forward in, we satisfy the RMI handshake, the registry returns localhost:9010 which goes through:
- traefik port 9010
- which traefik maps to our dynamic jmx port on the cljdoc docker container
- which nomad had docker map to port 9010 inside the docker container
- which is received by the jvm

Port 9010 is not exposed by our firewall, so although it is exposed by traefik, it is private and ops-team-only via ssh port forwarding.