### PR TITLE
builds page: add from-date, show date headers

### DIFF
--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -30,7 +30,7 @@
 
 (defn build-log-routes []
   #{["/builds/:id" :get nop :route-name :show-build]
-    ["/builds" :get nop :route-name :all-builds]})
+    ["/builds" :get nop :route-name :builds-summary]})
 
 (defn documentation-routes []
   ;; param :group-id of first route is a bit misleading

--- a/src/cljdoc/util/datetime.clj
+++ b/src/cljdoc/util/datetime.clj
@@ -1,6 +1,6 @@
 (ns cljdoc.util.datetime
   "Helpers function to work with dates and times."
-  (:import (java.time Instant ZoneId)
+  (:import (java.time LocalDate)
            (java.time.format DateTimeFormatter)
            (java.util Locale)))
 
@@ -17,30 +17,51 @@
       3 "rd"
       "th")))
 
-(defn human-short
+(defn date->human-short
   "Turns timestamp to a nice, human readable date format."
-  [ts]
-  (let [datetime (Instant/parse ts)
-        utc      (ZoneId/of "UTC")]
-    (str (.format (.withZone (DateTimeFormatter/ofPattern "EEE, MMM dd" Locale/ENGLISH) utc) datetime)
-         (day-suffix (.getDayOfMonth (.atZone datetime utc))))))
+  [date-str]
+  (let [date (LocalDate/parse date-str)]
+    (str (.format (DateTimeFormatter/ofPattern "EEE, MMM d" Locale/ENGLISH) date)
+         (day-suffix (.getDayOfMonth date)))))
 
-(defn timestamp [datetime-str]
+(defn date->human-long
+  [date-str]
+  (let [date (LocalDate/parse date-str)]
+    (str (.format (DateTimeFormatter/ofPattern "EEEE, MMMM d" Locale/ENGLISH) date)
+         (day-suffix (.getDayOfMonth date))
+         ", "
+         (.format (DateTimeFormatter/ofPattern "yyyy" Locale/ENGLISH) date))))
+
+(defn datetime->timestamp [datetime-str]
   (let [d (java.time.ZonedDateTime/parse datetime-str)]
     (.format d (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss.S"))))
 
+(defn valid-date? [yyyymmdd]
+  (boolean (try
+             (.parse (DateTimeFormatter/ofPattern "yyyy-MM-dd") yyyymmdd)
+             (catch Throwable _ex))))
+
 (comment
+  (valid-date? "2024-01-31")
+  ;; => true
+
+  (valid-date? "2024-01-32")
+  ;; => false
+
   (day-suffix 21)
   ;; => "st"
 
-  (->analytics-format "2018-10-22T11:12:13.12313Z")
+  (date->human-short "2018-10-22")
   ;; => "Mon, Oct 22nd"
 
+  (date->human-long "2018-10-22")
+  ;; => "Monday, October 22nd, 2018"
+
   ;; doesn't round fractional seconds, truncates, that's ok for our usage
-  (timestamp "2018-10-17T20:58:21.491730Z")
+  (datetime->timestamp "2018-10-17T20:58:21.491730Z")
   ;; => "2018-10-17 20:58:21.4"
 
-  (timestamp "2018-10-17T20:58:21.411730Z")
+  (datetime->timestamp "2018-10-17T20:58:21.411730Z")
   ;; => "2018-10-17 20:58:21.4"
 
   :eoc)

--- a/test/cljdoc/util/datetime_test.clj
+++ b/test/cljdoc/util/datetime_test.clj
@@ -19,4 +19,7 @@
   (t/is (= "st" (dt/day-suffix 31))))
 
 (t/deftest human-short-format-test
-  (t/is (= "Mon, Oct 22nd" (dt/human-short "2018-10-22T20:58:21.491730Z"))))
+  (t/is (= "Mon, Oct 22nd" (dt/date->human-short "2018-10-22"))))
+
+(t/deftest human-long-format-test
+  (t/is (= "Monday, October 22nd, 2018" (dt/date->human-long "2018-10-22"))))


### PR DESCRIPTION
The builds page now recognizes an optional `?end-date=2024-03-02` query string.

We now show the last 5 days of builds instead of maybe the last 5 days of builds for the last 100 builds.

Builds page now has a header for each day.

We now recognize that some days might have no builds.

All of the above is to support dev/ops and will help when verifying #561 work locally against production.