### PR TITLE
Allow docs to be built for io.github.clojure/tools.build

### DIFF
--- a/src/cljdoc/server/search/maven_central.clj
+++ b/src/cljdoc/server/search/maven_central.clj
@@ -131,7 +131,7 @@
   NOTE: Takes ± 2s as of 11/2019"
   [force?]
   (let [artifacts (mapcat #(load-maven-central-artifacts-for % force?) maven-groups)]
-    (log/infof "Downloaded %d artfacts from Maven Central" (count artifacts))
+    (log/infof "Downloaded %d artifacts from Maven Central" (count artifacts))
     artifacts))
 
 (s/fdef load-maven-central-artifacts

--- a/src/cljdoc/server/search/maven_central.clj
+++ b/src/cljdoc/server/search/maven_central.clj
@@ -14,6 +14,7 @@
 ;; There are not many clojars libraries on maven central.
 ;; We'll manualy adjust this list for now:
 (def ^:private maven-groups ["org.clojure"
+                             "io.github.clojure"
                              "com.turtlequeue"])
 
 (def ^:private maven-grp-version-counts

--- a/src/cljdoc/server/search/search.clj
+++ b/src/cljdoc/server/search/search.clj
@@ -138,10 +138,12 @@
   "Return document's popularity relative to other documents.
 
   For clojars this is the artifact download count divided the download count for the most downloaded artifact.
-  For maven we don't have download stats, so are return 1.0 for now."
+  For maven we don't have download stats, so return 1.0 for now."
   [clojars-stats {:as _jar :keys [origin artifact-id group-id]}]
   (case origin
-    :maven-central 1.0
+    :maven-central (if (and (= "org.clojure" group-id) (= "tools.build" artifact-id))
+                     0.99 ;; we want current io.github.clojure/tools.build to appear before legacy org.clojure/tools.build
+                     1.0)
     :clojars (let [dl-max (clojars-stats/download-count-max clojars-stats)
                    dl-lib (clojars-stats/download-count-artifact clojars-stats group-id artifact-id)]
                (clojars-download-boost dl-max dl-lib))))

--- a/src/cljdoc/server/search/search.clj
+++ b/src/cljdoc/server/search/search.clj
@@ -138,7 +138,7 @@
   "Return document's popularity relative to other documents.
 
   For clojars this is the artifact download count divided the download count for the most downloaded artifact.
-  For maven we don't have download stats, so return 1.0 for now."
+  For maven we don't have download stats, so return ~1.0 for now."
   [clojars-stats {:as _jar :keys [origin artifact-id group-id]}]
   (case origin
     :maven-central (if (and (= "org.clojure" group-id) (= "tools.build" artifact-id))


### PR DESCRIPTION
Clojure's `tools.build` moved from group `org.clojure` to `io.github.clojure` a while back.

Allow docs for the lib at the new coordinates to be built.

Give the legacy coordinates a slight down-boost to favour the new coordinates in search.

Closes todo 4 from #901 