### PR TITLE
dev: add missing clj-kondo imports

### DIFF
--- a/.clj-kondo/imports/hiccup/hiccup/config.edn
+++ b/.clj-kondo/imports/hiccup/hiccup/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {hiccup.def/defhtml clojure.core/defn}
+ :hooks {:analyze-call {hiccup.def/defelem hiccup.hooks/defelem}}}

--- a/.clj-kondo/imports/hiccup/hiccup/hiccup/hooks.clj
+++ b/.clj-kondo/imports/hiccup/hiccup/hiccup/hooks.clj
@@ -1,0 +1,38 @@
+(ns hiccup.hooks
+  (:require [clj-kondo.hooks-api :as api]
+            [clojure.set :as set]))
+
+;; See https://github.com/clj-kondo/clj-kondo/blob/master/doc/hooks.md
+
+(defn- parse-defn [elems]
+  (let [[fhead fbody] (split-with #(not (or (api/vector-node? %)
+                                            (api/list-node? %)))
+                                  elems)
+        arities (if (api/vector-node? (first fbody))
+                  (list (api/list-node fbody))
+                  fbody)]
+    [fhead arities]))
+
+(defn- count-args [arity]
+  (let [args (first (api/sexpr arity))]
+    (if (= '& (fnext (reverse args)))
+      true ; unbounded args
+      (count args))))
+
+(defn- dummy-arity [arg-count]
+  (api/list-node
+   (list
+    (api/vector-node
+     (vec (repeat arg-count (api/token-node '_)))))))
+
+(defn defelem [{:keys [node]}]
+  (let [[_ & rest] (:children node)
+        [fhead arities] (parse-defn rest)
+        arg-counts (set (filter number? (map count-args arities)))
+        dummy-arg-counts (set/difference (set (map inc arg-counts)) arg-counts)
+        dummy-arities (for [n dummy-arg-counts] (dummy-arity n))]
+    {:node
+     (api/list-node
+      (list*
+       (api/token-node 'clojure.core/defn)
+       (concat fhead arities dummy-arities)))}))


### PR DESCRIPTION
This one was added by clojure-lsp which I think imports all of `bb print-deps`, which seems like good thing to do.