### PR TITLE
ops: human friendly durations for nomad job spec

### DIFF
--- a/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
+++ b/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
@@ -7,8 +7,8 @@
   [{:Count 1
     :Name "cljdoc"
     :RestartPolicy {:Attempts 2
-                    :Delay #nomad/seconds 15
-                    :Interval #nomad/seconds 1800
+                    :Delay #nomad/duration "15s"
+                    :Interval #nomad/duration "30m"
                     :Mode "fail"}
     :Networks [{:DynamicPorts [{:Label "http" :To 8000}
                                {:Label "jmx" :To 9010}]}]
@@ -28,8 +28,8 @@
                   :PortLabel "http"
                   :Checks [{:Name "alive"
                             :PortLabel "http"
-                            :Interval #nomad/seconds 10
-                            :Timeout #nomad/seconds 2
+                            :Interval #nomad/duration "10s"
+                            :Timeout #nomad/duration "2s"
                             :Type "tcp"}]
                   ;; traefik is now configured through service tags
                   :Tags
@@ -62,8 +62,8 @@
                    :EmbeddedTmpl "{{key \"config/cljdoc/secrets-edn\"}}"}]}]
     :Update {:Canary 1
              :MaxParallel 1
-             :HealthyDeadline #nomad/seconds 240
-             :MinHealthyTime #nomad/seconds 10}}
+             :HealthyDeadline #nomad/duration "4m"
+             :MinHealthyTime #nomad/duration "10s"}}
    {:Name "lb"
     :Networks [{:ReservedPorts [{:Label "api" :Value 8080}
                                 {:Label "http" :Value 80}
@@ -80,8 +80,8 @@
       :Services [{:Name "traefik"
                   :PortLabel "http"
                   :Checks [{:Name "alive"
-                            :Interval #nomad/seconds 10
-                            :Timeout #nomad/seconds 2
+                            :Interval #nomad/duration "10s"
+                            :Timeout #nomad/duration "2s"
                             :Type "tcp"}]}]
       :Templates [{:DestPath "local/traefik.yaml"
                    :EmbeddedTmpl "{{key \"config/traefik-yaml\"}}"}]}]}]

--- a/ops/exoscale/deploy/src/cljdoc/deploy.clj
+++ b/ops/exoscale/deploy/src/cljdoc/deploy.clj
@@ -43,17 +43,17 @@
 
 (def duration-unit-multipliers
   (first
-    (reduce (fn [[res cur] [unit multiplier]]
-              (let [cur (* cur multiplier)]
-                [(assoc res unit cur) cur]))
-            [{} 1]
-            [["ns" 1]
-             ["us" 1000] ;; 1000 us in 1 ns
-             ["ms" 1000] ;; 1000 ms in 1 us
-             ["s"  1000] ;; 1000 s in 1 ms...
-             ["m"  60]
-             ["h"  60]
-             ["d"  24]])))
+   (reduce (fn [[res cur] [unit multiplier]]
+             (let [cur (* cur multiplier)]
+               [(assoc res unit cur) cur]))
+           [{} 1]
+           [["ns" 1]
+            ["us" 1000] ;; 1000 us in 1 ns
+            ["ms" 1000] ;; 1000 ms in 1 us
+            ["s"  1000] ;; 1000 s in 1 ms...
+            ["m"  60]
+            ["h"  60]
+            ["d"  24]])))
 
 (defn- duration->nanoseconds [s]
   (let [matches (re-seq #"(\d*\.?\d+)\s*(ns|us|ms|s|m|h|d)" s)]
@@ -253,7 +253,6 @@
                {:docker-tag "0.0.2732-lread-explore-mem-usage-6f7fa85"
                 :cljdoc-profile "default"
                 :secrets-filename "../../../resources/secrets.edn"})
-
 
   (local-test
    (nomad-post! "/v1/validate/job" (jobspec deploy-opts)))

--- a/ops/exoscale/deploy/src/cljdoc/deploy.clj
+++ b/ops/exoscale/deploy/src/cljdoc/deploy.clj
@@ -41,9 +41,35 @@
        :body
        json/parse-string))
 
-(defmethod aero/reader 'nomad/seconds
+(def duration-unit-multipliers
+  (first
+    (reduce (fn [[res cur] [unit multiplier]]
+              (let [cur (* cur multiplier)]
+                [(assoc res unit cur) cur]))
+            [{} 1]
+            [["ns" 1]
+             ["us" 1000] ;; 1000 us in 1 ns
+             ["ms" 1000] ;; 1000 ms in 1 us
+             ["s"  1000] ;; 1000 s in 1 ms...
+             ["m"  60]
+             ["h"  60]
+             ["d"  24]])))
+
+(defn- duration->nanoseconds [s]
+  (let [matches (re-seq #"(\d*\.?\d+)\s*(ns|us|ms|s|m|h|d)" s)]
+    (if-not (seq matches)
+      (throw (ex-info (str "Invalid duration " s) {}))
+      (->> matches
+           (map (fn [[_ value unit]]
+                  (* (parse-double value) (get duration-unit-multipliers unit))))
+           (reduce +)
+           (+ 0.5)
+           long))))
+
+(defmethod aero/reader 'nomad/duration
+  ;; convert human friendly duration, e.g. "1h30m" to nomad nanoseconds
   [_ _tag value]
-  (* value 1000000000))
+  (duration->nanoseconds value))
 
 (defmethod aero/reader 'env!
   [_ _tag envvar]
@@ -228,6 +254,7 @@
                 :cljdoc-profile "default"
                 :secrets-filename "../../../resources/secrets.edn"})
 
+
   (local-test
    (nomad-post! "/v1/validate/job" (jobspec deploy-opts)))
   ;; => {"DriverConfigValidated" true,
@@ -250,12 +277,12 @@
   ;;        :Tasks
   ;;        [{:Env
   ;;          {:CLJDOC_SECRETS "/etc/cljdoc/secrets.edn", :CLJDOC_PROFILE "default"},
-  ;;          :Resources {:CPU 1000, :MemoryMB 1600},
+  ;;          :Resources {:CPU 2000, :MemoryMB 3648},
   ;;          :KillSignal "",
   ;;          :Config
-  ;;          {:image "cljdoc/cljdoc:0.0.2705-91bda72e",
+  ;;          {:image "cljdoc/cljdoc:0.0.2732-lread-explore-mem-usage-6f7fa85",
   ;;           :ports ["http" "jmx"],
-  ;;           :volumes ["secrets:/etc/cljdoc" "/data/cljdoc:/var/cljdoc"]},
+  ;;           :volumes ["secrets:/etc/cljdoc" "/data/cljdoc:/app/data"]},
   ;;          :Templates
   ;;          [{:DestPath "secrets/secrets.edn",
   ;;            :EmbeddedTmpl "{{key \"config/cljdoc/secrets-edn\"}}"}],
@@ -271,15 +298,20 @@
   ;;              :Type "tcp"}],
   ;;            :Tags
   ;;            ["traefik.enable=true"
+  ;;             "traefik.tcp.routers.jxm-router.entrypoints=jmx"
+  ;;             "traefik.tcp.routers.jmx-router.rule=HostSNI(`*`)"
+  ;;             "traefik.tcp.routers.jmx-router.service=jmx-service"
+  ;;             "traefik.tcp.services.jmx-service.loadbalancer.server.port=${NOMAD_HOST_PORT_jmx}"
   ;;             "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
   ;;             "traefik.http.middlewares.redirect-to-https.redirectscheme.permanent=true"
   ;;             "traefik.http.routers.cljdoc-http.entrypoints=web"
   ;;             "traefik.http.routers.cljdoc-http.middlewares=redirect-to-https"
   ;;             "traefik.http.routers.cljdoc-http.rule=PathPrefix(`/`)"
   ;;             "traefik.http.middlewares.compress-response.compress=true"
+  ;;             "traefik.http.middlewares.compress-response.compress.encodings=gzip"
   ;;             "traefik.http.routers.cljdoc-https.entrypoints=websecure"
   ;;             "traefik.http.routers.cljdoc-https.tls=true"
-  ;;             "traefik.http.routers.cljdoc-https.tls.certresolver=lets-encrypt"
+  ;;             "traefik.http.routers.cljdoc-https.tls.certresolver=letsencrypt"
   ;;             "traefik.http.routers.cljdoc-https.rule=PathPrefix(`/`)"
   ;;             "traefik.http.routers.cljdoc-https.tls.domains[0].main=cljdoc.org"
   ;;             "traefik.http.routers.cljdoc-https.tls.domains[1].main=cljdoc.xyz"
@@ -302,7 +334,7 @@
   ;;           {:Label "https", :Value 443}]}],
   ;;        :Tasks
   ;;        [{:Config
-  ;;          {:image "traefik:3.1.5",
+  ;;          {:image "traefik:3.2.1",
   ;;           :network_mode "host",
   ;;           :ports ["api" "http" "https"],
   ;;           :volumes ["local:/etc/traefik" "/data/traefik:/data"]},
@@ -426,5 +458,17 @@
 
   (local-test
    (deploy! deploy-opts))
+
+  (duration->nanoseconds "1d1h1m1s1ms1us1ns")
+  ;; => 90061001001001
+
+  (duration->nanoseconds "1h")
+  ;; => 3600000000000
+
+  (= (duration->nanoseconds "0.5h") (duration->nanoseconds "30m"))
+  ;; => true
+
+  (= (duration->nanoseconds "0.5d0.5h0.5m0.5s") (duration->nanoseconds "12h30m30s500ms"))
+  ;; => true
 
   :eoc)


### PR DESCRIPTION
Replace good `#nomad/seconds 1800` with even better `#nomad/duration 30m` for at-a-glance human-friendly durations.

Can express multiple units, e.g. 3m30s and decimal values, e.g 3.5m.