### PR TITLE
ops: bump traefik

### DIFF
--- a/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
+++ b/ops/exoscale/deploy/resources/cljdoc.jobspec.edn
@@ -69,7 +69,7 @@
                                 {:Label "http" :Value 80}
                                 {:Label "https" :Value 443}]}]
     :Tasks
-    [{:Config {:image "traefik:3.2.1"
+    [{:Config {:image "traefik:3.3.2"
                :network_mode "host"
                :ports ["api" "http" "https"]
                :volumes ["local:/etc/traefik"


### PR DESCRIPTION
Martin received a "certificate expire notice" email from letsencrypt. If we look at cljdoc ssl certs they are slated to expire on Feb 6. Which matches the email.

Does it mean that traefik is not auto-renewing our certs? I don't see anything in the traefik.log.

If I read https://letsencrypt.org/docs/expiration-emails/, maybe this is nothing to worry about?

Let's bump traefik to see if that has any effect.