### PR TITLE
ops: downgrade aws sdk

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -68,7 +68,9 @@
 
         ;; s3 for database backups at Exoscale Simple Object Store
         ;; started with aws-api but it loads entire objects on the heap, and we don't have enough heap for that!
-        software.amazon.awssdk/s3 {:mvn/version "2.30.11"}
+        ;; v2.30.9 introduces out of memory errors when uploading large files with a smaller heap
+        ;; https://github.com/cljdoc/cljdoc/issues/996 wait for fix before upgrading further
+        software.amazon.awssdk/s3 {:mvn/version "2.30.8"}
 
         ;; reaching out to other services
         org.eclipse.jgit/org.eclipse.jgit.ssh.jsch {:mvn/version "7.1.0.202411261347-r"} ;; git with jsch

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -17,9 +17,9 @@
                  :enable-sentry? #profile {:default false
                                            :prod true}
                  :enable-db-backup? #profile {:default false
-                                              :prod false} ;; temporarily turn off see https://github.com/cljdoc/cljdoc/issues/996
+                                              :prod true}
                  :enable-db-restore? #profile {:default false
-                                               :prod false} ;; temporarily turn off see https://github.com/cljdoc/cljdoc/issues/996
+                                               :prod true}
                  :dir #or [#env CLJDOC_DATA_DIR ;; constant for docker prod/local-preview, see DockerFile
                            #profile {:default "data/"
                                      :test "test-data/"}]


### PR DESCRIPTION
Looks aws team introduced a bug in 2.30.9 that causes out of memory errors when uploading large files when the heap is relatively small.

Re-enable backup. It should work under this older version.