### PR TITLE
ops: tweak nvd-scan to always use latest deps

### DIFF
--- a/modules/nvd-scan/deps.edn
+++ b/modules/nvd-scan/deps.edn
@@ -1,7 +1,4 @@
-{:deps {nvd-clojure/nvd-clojure
-        ;; it is generally considered bad practice to use RELEASE, but we always want the latest
-        ;; security tooling
-        #_:clj-kondo/ignore
-        {:mvn/version "RELEASE"}
-        ;; temporarily try bumping transitive dep to current release
-        org.owasp/dependency-check-core {:mvn/version "12.1.0"}}}
+;; it is generally considered bad practice to use RELEASE, but we always want the latest
+;; security tooling
+{:deps {nvd-clojure/nvd-clojure #_:clj-kondo/ignore {:mvn/version "RELEASE"}
+        org.owasp/dependency-check-core #_:clj-kondo/ignore {:mvn/version "RELEASE"}}}


### PR DESCRIPTION
To avoid dep churn, I've learned on other projects that it probably makes sense to use use latest deps for nvd scan.

[skip ci]