### PR TITLE
dev: try out borkdude's new unused-deps

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -4,7 +4,8 @@
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}
-        etaoin/etaoin {:mvn/version "1.1.43"}}
+        etaoin/etaoin {:mvn/version "1.1.43"}
+        io.github.borkdude/unused-deps {:git/sha "77fc627b3a0dc547841a17bdaa09ea51c392676c"}}
  :pods {org.babashka/fswatcher {:version "0.0.5"}}
  :tasks
  {;; setup
@@ -153,6 +154,17 @@
   check-contributors
   {:doc "who'd we miss?"
    :task check-contributors/-main}
+  unused-deps
+  {:doc "find unused dependencies"
+   :task (do
+           (status/line :detail "Dependencies that do not seem to be referenced by code")
+           (status/line :detail "NOTE: some unused deps are overrides to bring in later version of a dep to compensate for bugs or CVEs")
+           (status/line :detail "")
+           (doseq [unused (-> (exec 'borkdude.unused-deps/unused-deps)
+                                :unused-deps
+                                sort)]
+
+               (prn unused)))}
   nvd-scan
   {:doc "Scan Clojure deps for vulnerabilities"
    :task (let [cp (with-out-str (clojure "-Spath -M:cli"))]


### PR DESCRIPTION
Very cool. Current output is:

```
[ TASK unused-deps ]-------------------------------------------------------------
Dependencies that do not seem to be referenced by code
NOTE: some unused deps are overrides to bring in later version of a dep to compensate for bugs or CVEs

[ch.qos.logback/logback-classic #:mvn{:version "1.5.18"}]
[dev.weavejester/ragtime #:mvn{:version "0.9.5"}]
[org.apache.lucene/lucene-queryparser #:mvn{:version "10.2.1"}]
[org.asciidoctor/asciidoctorj #:mvn{:version "3.0.0"}]
[org.eclipse.jetty/jetty-alpn-client #:mvn{:version "11.0.25"}]
[org.eclipse.jetty/jetty-alpn-server #:mvn{:version "11.0.25"}]
[org.eclipse.jetty/jetty-servlet #:mvn{:version "11.0.25"}]
[org.eclipse.jetty.http2/http2-server #:mvn{:version "11.0.25"}]
[org.eclipse.jetty.websocket/websocket-jakarta-server #:mvn{:version "11.0.25"}]

TASK unused-deps done.
```

The jetty deps are CVE overrides.
Not sure about lucene-queryparser.
asciidoctorj and ragtime: false positives?