### PR TITLE
fix lucene dep (thanks @borkude for unused-deps!)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -35,7 +35,7 @@
         org.apache.lucene/lucene-core {:mvn/version "10.2.1"} ;; search engine
         org.apache.lucene/lucene-analysis-common {:mvn/version "10.2.1"}
         org.apache.lucene/lucene-analysis-icu {:mvn/version "10.2.1"}
-        org.apache.lucene/lucene-queryparser {:mvn/version "10.2.1"}
+        org.apache.lucene/lucene-queries {:mvn/version "10.2.1"}
 
         ;; markdown
         org.asciidoctor/asciidoctorj {:mvn/version "3.0.0"} ;; render adoc to html


### PR DESCRIPTION
We were depending on lucene-queryparser but were actually only using its dependency, lucene-queries. Now depending on lucene-queries instead.

Follow up from #1031