### PR TITLE
front-end: fix: previously opened migration booboo

### DIFF
--- a/front-end/src/cljdoc/client/lib_switcher.cljs
+++ b/front-end/src/cljdoc/client/lib_switcher.cljs
@@ -16,7 +16,7 @@
        (== (:artifact-id p1) (:artifact-id p2))))
 
 (defn- load-prev-opened []
-  (.parse js/JSON (or (.getItem js/localStorage "previouslyOpened") "[]")))
+  (.parse js/JSON (or (.getItem js/localStorage "previously_opened") "[]")))
 
 (defn- is-error-page? []
   (.querySelector js/document "head > title[data-error]"))
@@ -34,7 +34,7 @@
               prev-opened (->> prev-opened
                                (take max-track-count)
                                doall)]
-          (.setItem js/localStorage "previouslyOpened" (.stringify js/JSON prev-opened)))))))
+          (.setItem js/localStorage "previously_opened" (.stringify js/JSON prev-opened)))))))
 
 (defn- RowView [{:keys [result isSelected selectResult]}]
   (let [uri (lib/docs-path result)

--- a/front-end/src/cljdoc/client/recent_doc_links.cljs
+++ b/front-end/src/cljdoc/client/recent_doc_links.cljs
@@ -27,7 +27,7 @@
 
 (defn- init-doc-links [doc-links]
   (let [previously-opened (some-> js/localStorage
-                                  (.getItem "previouslyOpened")
+                                  (.getItem "previously_opened")
                                   (js/JSON.parse))]
     (when (> (count previously-opened) 0)
       (when (>= (count previously-opened) 3)


### PR DESCRIPTION
I must have changed a name of a saved thing when migrating from TypeScript to cljs.
Fix by renaming previously opened local storage name. This will effectively wipe folks prev opened history, but such is life.