### PR TITLE
ui: os-specific modifier key for keyboard help

### DIFF
--- a/front-end/src/cljdoc/client/project_doc.cljs
+++ b/front-end/src/cljdoc/client/project_doc.cljs
@@ -1,7 +1,8 @@
 (ns cljdoc.client.project-doc
   "Misc support for project documentation page"
   (:require [cljdoc.client.dom :as dom]
-            [cljdoc.client.page :as page]))
+            [cljdoc.client.page :as page]
+            [clojure.string :as str]))
 
 (warn-on-lazy-reusage!)
 
@@ -14,6 +15,9 @@
           meta-close (dom/query "[data-id='cljdoc-js--meta-close']")
           display "db-ns"
           hide "dn"]
+      (when (str/starts-with? js/navigator.platform "Mac")
+        (doseq [el (dom/query-all "[data-id='cljdoc-js--modifier-key']" meta-dialog)]
+          (set! (.-innerText el) "⌘")))
       (when meta-icon
         (.addEventListener meta-icon "click"
                            (fn []

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -159,7 +159,13 @@
   [:span
    (->> key-seq
         (mapv (fn [key]
-                [:kbd.dib.mid-gray.bw1.b--solid.b--light-silver.bg-light-gray.br2.pa1 key]))
+                (let [{:keys [key attrs]} (if (= :modifier key)
+                                            {:key "Ctrl" ;; default to Ctrl, will adjust client-side if need be
+                                             :attrs {:data-id "cljdoc-js--modifier-key"}}
+                                            {:key key
+                                             :attrs {}})]
+                  [:kbd.dib.mid-gray.bw1.b--solid.b--light-silver.bg-light-gray.br2.pa1
+                   attrs key])))
         (interpose [:span.pa1.code "+"]))])
 
 (defn- meta-icon
@@ -187,10 +193,10 @@
     [:div.overflow-auto
      [:table.w-auto
       [:tbody.lh-copy
-       (for [[key-seq help] [[["⌘" "k"] "Jump to recent docs"]
-                             [["←"]     "Move to previous article"]
-                             [["→"]     "Move to next article"]
-                             [["⌘" "/"] "Jump to the search field"]]]
+       (for [[key-seq help] [[[:modifier "k"] "Jump to recent docs"]
+                             [["←"]           "Move to previous article"]
+                             [["→"]           "Move to next article"]
+                             [[:modifier "/"] "Jump to the search field"]]]
          [:tr
           [:td.nowrap.tl.gray.f5 (kbd key-seq)]
           [:td.pl2.tl help]])]]]]


### PR DESCRIPTION
Was always showing ⌘, but we are not all on macOS, are we?

Now showing ⌘ if on macOS, else Ctrl.