### PR TITLE
Support prototype methods more

### DIFF
--- a/front-end/src/cljdoc/client/namespace_scroll.cljs
+++ b/front-end/src/cljdoc/client/namespace_scroll.cljs
@@ -7,10 +7,10 @@
 (warn-on-lazy-reusage!)
 
 (defn- init-scroll-indicator []
-  (let [main-scroll-view (dom/query ".js--main-scroll-view")
-        sidebar-scroll-view (dom/query ".js--namespace-contents-scroll-view")
-        def-blocks (dom/query-all ".def-block")
-        def-items (dom/query-all ".def-item")
+  (let [def-detail-scroll-view (dom/query ".js--main-scroll-view")
+        def-list-scroll-view (dom/query ".js--namespace-contents-scroll-view")
+        def-detail-blocks (dom/query-all ".def-block" def-detail-scroll-view)
+        def-list-items (dom/query-all ".def-item" def-list-scroll-view)
         is-elem-visible? (fn [container el]
                            (let [{:keys [y height]} (.getBoundingClientRect el)
                                  etop y
@@ -19,22 +19,23 @@
                                  ctop (- cbottom (.-clientHeight container))]
                              (and (<= etop cbottom) (>= ebottom ctop))))
         draw-scroll-indicator (fn []
-                                (doseq [[idx el] (map-indexed vector def-blocks)]
-                                  (let [def-item (get def-items idx)]
-                                    (if-not (and main-scroll-view
-                                                 sidebar-scroll-view
-                                                 (is-elem-visible? main-scroll-view el))
+                                (doseq [[idx el] (map-indexed vector def-detail-blocks)]
+                                  (let [def-item (get def-list-items idx)]
+                                    (.log js/console "item" (is-elem-visible? def-detail-scroll-view el) def-item)
+                                    (if-not (and def-detail-scroll-view
+                                                 def-list-scroll-view
+                                                 (is-elem-visible? def-detail-scroll-view el))
                                       (dom/remove-class def-item "scroll-indicator")
                                       (do
                                         (dom/add-class def-item "scroll-indicator")
                                         (cond
                                           (zero? idx)
-                                          (set! sidebar-scroll-view.scrollTop 1)
+                                          (set! def-list-scroll-view.scrollTop 1)
 
-                                          (not (is-elem-visible? sidebar-scroll-view def-item))
+                                          (not (is-elem-visible? def-list-scroll-view def-item))
                                           (.scrollIntoView def-item)))))))]
-    (when main-scroll-view
-      (.addEventListener main-scroll-view "scroll" draw-scroll-indicator))
+    (when def-detail-scroll-view
+      (.addEventListener def-detail-scroll-view "scroll" draw-scroll-indicator))
 
     (draw-scroll-indicator)))
 

--- a/front-end/src/cljdoc/client/namespace_scroll.cljs
+++ b/front-end/src/cljdoc/client/namespace_scroll.cljs
@@ -8,9 +8,9 @@
 
 (defn- init-scroll-indicator []
   (let [def-detail-scroll-view (dom/query ".js--main-scroll-view")
-        def-list-scroll-view (dom/query ".js--namespace-contents-scroll-view")
+        def-nav-scroll-view (dom/query ".js--namespace-contents-scroll-view")
         def-detail-blocks (dom/query-all ".def-block" def-detail-scroll-view)
-        def-list-items (dom/query-all ".def-item" def-list-scroll-view)
+        def-nav-items (dom/query-all ".def-item" def-nav-scroll-view)
         is-elem-visible? (fn [container el]
                            (let [{:keys [y height]} (.getBoundingClientRect el)
                                  etop y
@@ -26,19 +26,19 @@
                                     (when (>= ndx 0)
                                       (let [detail-el (get def-detail-blocks ndx)
                                             show-indicator? (and def-detail-scroll-view
-                                                                 def-list-scroll-view
+                                                                 def-nav-scroll-view
                                                                  (not indicator-block-found)
                                                                  (is-elem-visible? def-detail-scroll-view detail-el))
-                                            nav-item-el (get def-list-items ndx)]
+                                            nav-item-el (get def-nav-items ndx)]
                                         (if-not show-indicator?
                                           (dom/remove-class nav-item-el "scroll-indicator")
                                           (do
                                             (dom/add-class nav-item-el "scroll-indicator")
                                             (cond
                                               (zero? ndx)
-                                              (set! def-list-scroll-view.scrollTop 1)
+                                              (set! def-detail-scroll-view.scrollTop 1)
 
-                                              (not (is-elem-visible? def-list-scroll-view nav-item-el))
+                                              (not (is-elem-visible? def-nav-scroll-view nav-item-el))
                                               (.scrollIntoView nav-item-el))))
                                         (recur ndx
                                                show-indicator?

--- a/front-end/src/cljdoc/client/namespace_scroll.cljs
+++ b/front-end/src/cljdoc/client/namespace_scroll.cljs
@@ -21,7 +21,6 @@
         draw-scroll-indicator (fn []
                                 (doseq [[idx el] (map-indexed vector def-detail-blocks)]
                                   (let [def-item (get def-list-items idx)]
-                                    (.log js/console "item" (is-elem-visible? def-detail-scroll-view el) def-item)
                                     (if-not (and def-detail-scroll-view
                                                  def-list-scroll-view
                                                  (is-elem-visible? def-detail-scroll-view el))

--- a/front-end/src/cljdoc/client/namespace_scroll.cljs
+++ b/front-end/src/cljdoc/client/namespace_scroll.cljs
@@ -19,20 +19,31 @@
                                  ctop (- cbottom (.-clientHeight container))]
                              (and (<= etop cbottom) (>= ebottom ctop))))
         draw-scroll-indicator (fn []
-                                (doseq [[idx el] (map-indexed vector def-detail-blocks)]
-                                  (let [def-item (get def-list-items idx)]
-                                    (if-not (and def-detail-scroll-view
-                                                 def-list-scroll-view
-                                                 (is-elem-visible? def-detail-scroll-view el))
-                                      (dom/remove-class def-item "scroll-indicator")
-                                      (do
-                                        (dom/add-class def-item "scroll-indicator")
-                                        (cond
-                                          (zero? idx)
-                                          (set! def-list-scroll-view.scrollTop 1)
+                                (loop [ndx (count def-detail-blocks)
+                                       in-indicator-block false
+                                       indicator-block-found false]
+                                  (let [ndx (dec ndx)]
+                                    (when (>= ndx 0)
+                                      (let [detail-el (get def-detail-blocks ndx)
+                                            show-indicator? (and def-detail-scroll-view
+                                                                 def-list-scroll-view
+                                                                 (not indicator-block-found)
+                                                                 (is-elem-visible? def-detail-scroll-view detail-el))
+                                            nav-item-el (get def-list-items ndx)]
+                                        (if-not show-indicator?
+                                          (dom/remove-class nav-item-el "scroll-indicator")
+                                          (do
+                                            (dom/add-class nav-item-el "scroll-indicator")
+                                            (cond
+                                              (zero? ndx)
+                                              (set! def-list-scroll-view.scrollTop 1)
 
-                                          (not (is-elem-visible? def-list-scroll-view def-item))
-                                          (.scrollIntoView def-item)))))))]
+                                              (not (is-elem-visible? def-list-scroll-view nav-item-el))
+                                              (.scrollIntoView nav-item-el))))
+                                        (recur ndx
+                                               show-indicator?
+                                               (or indicator-block-found
+                                                   (and (not show-indicator?) in-indicator-block))))))))]
     (when def-detail-scroll-view
       (.addEventListener def-detail-scroll-view "scroll" draw-scroll-indicator))
 

--- a/front-end/src/cljdoc/client/single_docset_search.cljs
+++ b/front-end/src/cljdoc/client/single_docset_search.cljs
@@ -10,7 +10,7 @@
 
 (warn-on-lazy-reusage!)
 
-(def SEARCHSET_VERSION 5)
+(def SEARCHSET_VERSION 6)
 
 (defn- tokenize [s]
   (if (not s)
@@ -92,7 +92,11 @@
                         (mapv #(assoc % :kind :def) (:defs search-set))
                         (->> (:defs search-set)
                              (keep #(when-let [members (seq (:members %))]
-                                      (mapv (fn [m] (assoc m :namespace (:namespace %))) members)))
+                                      (mapv (fn [m]
+                                              (assoc m
+                                                     :namespace (:namespace %)
+                                                     :protocol-name (:name %)))
+                                            members)))
                              (mapcat identity)
                              (mapv #(assoc % :kind :def)))
                         (mapv #(assoc % :kind :doc) (:docs search-set))]
@@ -134,7 +138,7 @@
                                "doc" {:text "DOC"})
         color (get colors text default-color)]
     #jsx [:<>
-          [:div {:class (str "pa1 white-90 br1 mr2 tc f6 " color)
+          [:div {:class (str "dib pa1 white-90 br1 mr2 tc f6 " color)
                  :style "width:2.5rem; font-size: 13px; margin-bottom: 2px;"
                  :aria-label label
                  :title label}
@@ -147,6 +151,12 @@
            [:span (:namespace item)] "/" (:name item)]]
     #jsx [:<>
           [:div {:class "mb1"} (:name item)]]))
+
+(defn- ResultProtocol [{:keys [item]}]
+  (when (:protocol-name item)
+    #jsx [:<> [:div {:class "ml2 nowrap"}
+               (h ResultIcon {:item {:kind "def" :type "protocol"}})
+               [:span (:protocol-name item)]]]))
 
 (defn- ResultListItem [{:keys [searchResult selected onClick onMouseDown]}]
   (let [item (useRef nil)]
@@ -166,7 +176,9 @@
               [:div {:class "flex flex-row items-end"}
                (h ResultIcon {:item result})
                [:div {:class "flex flex-column"}
-                (h ResultName {:item result})]]]]])))
+                (h ResultName {:item result})]
+               [:div {:class "flex"}
+                (h ResultProtocol {:item result})]]]]])))
 
 (defn- search [search-index query]
   (when search-index

--- a/front-end/src/cljdoc/client/single_docset_search.cljs
+++ b/front-end/src/cljdoc/client/single_docset_search.cljs
@@ -10,7 +10,7 @@
 
 (warn-on-lazy-reusage!)
 
-(def SEARCHSET_VERSION 4)
+(def SEARCHSET_VERSION 5)
 
 (defn- tokenize [s]
   (if (not  s)
@@ -90,6 +90,11 @@
             search-set (js-await (.json response))
             items (->> [(mapv #(assoc % :kind :namespace) (:namespaces search-set))
                         (mapv #(assoc % :kind :def) (:defs search-set))
+                        (->> (:defs search-set)
+                             (keep #(when-let [members (seq (:members %))]
+                                      (mapv (fn [m] (assoc m :namespace (:namespace %))) members)))
+                             (mapcat identity)
+                             (mapv #(assoc % :kind :def)))
                         (mapv #(assoc % :kind :doc) (:docs search-set))]
                        (reduce into [])
                        (map-indexed (fn [ndx item]

--- a/front-end/src/cljdoc/client/single_docset_search.cljs
+++ b/front-end/src/cljdoc/client/single_docset_search.cljs
@@ -13,7 +13,7 @@
 (def SEARCHSET_VERSION 5)
 
 (defn- tokenize [s]
-  (if (not  s)
+  (if (not s)
     []
     (let [candidate-tokens (-> s
                                str

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "elasticlunr": "0.9.5",
         "fuzzysort": "3.1.0",
         "idb": "8.0.3",
-        "preact": "10.27.0",
+        "preact": "10.27.1",
         "squint-cljs": "0.8.152"
       },
       "devDependencies": {
@@ -109,9 +109,9 @@
       "license": "ISC"
     },
     "node_modules/preact": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.0.tgz",
-      "integrity": "sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw==",
+      "version": "10.27.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
+      "integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "elasticlunr": "0.9.5",
     "fuzzysort": "3.1.0",
     "idb": "8.0.3",
-    "preact": "10.27.0"
+    "preact": "10.27.1"
   },
   "devDependencies": {
     "esbuild": "0.25.8"

--- a/src/cljdoc/render.clj
+++ b/src/cljdoc/render.clj
@@ -127,7 +127,7 @@
              :main-sidebar-contents (sidebar/sidebar-contents route-params cache-bundle last-build)
              :vars-sidebar-contents (when (seq ns-defs)
                                       [(api/platforms-supported-note platf-stats)
-                                       (api/definitions-list ns-emap ns-defs {:indicate-platforms-other-than dominant-platf})])
+                                       (api/definitions-list ns-defs {:indicate-platforms-other-than dominant-platf})])
              :content (api/namespace-page {:ns-entity ns-emap
                                            :ns-data ns-data
                                            :defs ns-defs

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -141,7 +141,7 @@
        (render-docs (platf/get-field n :doc))))
    (docstring-format-toggle-control n opts)])
 
-(defn- render-def-detail-title [def]
+(defn- render-def-details-title [def]
   (let [def-name (platf/get-field def :name)]
   [:h4.def-block-title.mv0.pv3
       {:name def-name :id def-name}
@@ -242,7 +242,7 @@
   {:pre [(platf/multiplatform? def)]}
   [:div.def-block
    [:hr.mv3.b--black-10]
-   (render-def-detail-title def)
+   (render-def-details-title def)
    (render-var-args-and-docs def render-wiki-link opts)
    (render-protocol-members def render-wiki-link opts)
    (render-source-links def)

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -144,13 +144,13 @@
 
 (defn- render-def-details-title [def]
   (let [def-name (platf/get-field def :name)]
-  [:h4.def-block-title.mv0.pv3
-      {:name def-name :id def-name}
-      def-name (render-var-annotation (platforms->var-annotation def))
-      (when-not (= :var (platf/get-field def :type))
-        [:span.f7.ttu.normal.gray.ml2 (platf/get-field def :type)])
-      (when (platf/get-field def :deprecated)
-        [:span.fw3.f6.light-red.ml2 "deprecated"])]))
+    [:h4.def-block-title.mv0.pv3
+     {:name def-name :id def-name}
+     def-name (render-var-annotation (platforms->var-annotation def))
+     (when-not (= :var (platf/get-field def :type))
+       [:span.f7.ttu.normal.gray.ml2 (platf/get-field def :type)])
+     (when (platf/get-field def :deprecated)
+       [:span.fw3.f6.light-red.ml2 "deprecated"])]))
 
 (defn- looks-like-arglists? [x]
   (and (sequential? x)
@@ -229,14 +229,14 @@
 
 (defn- render-source-links [def]
   (when (or (platf/varies? def :src-uri) ; if it varies they can't be both nil
-               (platf/get-field def :src-uri)) ; if it doesn't vary, ensure non-nil
-       (if (platf/varies? def :src-uri)
-         (for [p (sort (platf/platforms def))
-               :when (platf/get-field def :src-uri p)]
-           [:a.link.f7.gray.hover-dark-gray.mr2
-            {:href (platf/get-field def :src-uri p)}
-            (format "source (%s)" p)])
-         [:a.link.f7.gray.hover-dark-gray.mr2 {:href (platf/get-field def :src-uri)} "source"])))
+            (platf/get-field def :src-uri)) ; if it doesn't vary, ensure non-nil
+    (if (platf/varies? def :src-uri)
+      (for [p (sort (platf/platforms def))
+            :when (platf/get-field def :src-uri p)]
+        [:a.link.f7.gray.hover-dark-gray.mr2
+         {:href (platf/get-field def :src-uri p)}
+         (format "source (%s)" p)])
+      [:a.link.f7.gray.hover-dark-gray.mr2 {:href (platf/get-field def :src-uri)} "source"])))
 
 (defn def-details
   [def render-wiki-link opts]
@@ -303,20 +303,20 @@
 (defn- definitions-list* [defs {:keys [indicate-platforms-other-than level] :as opts}]
   (let [level (or level 0)]
     (for [def defs
-           :let [def-name (platf/get-field def :name)]]
-       [:li.def-item
-        [:a.link.dim.blue.dib.pa1.pl0
-         {:href (str "#" def-name) :style {:margin-left (str (* level 10) "px")}}
-         def-name
-         (render-var-annotation (var-index-platform-annotation indicate-platforms-other-than def))]
-        (let [members (platf/get-field def :members)]
-          (when (seq members)
-            (definitions-list* members (assoc opts :level (inc level)))))])))
+          :let [def-name (platf/get-field def :name)]]
+      [:li.def-item
+       [:a.link.dim.blue.dib.pa1.pl0
+        {:href (str "#" def-name) :style {:margin-left (str (* level 10) "px")}}
+        def-name
+        (render-var-annotation (var-index-platform-annotation indicate-platforms-other-than def))]
+       (let [members (platf/get-field def :members)]
+         (when (seq members)
+           (definitions-list* members (assoc opts :level (inc level)))))])))
 
 (defn definitions-list [defs opts]
   [:div.pb4
    [:ul.list.pl0
-   (definitions-list* defs opts)]])
+    (definitions-list* defs opts)]])
 
 (defn namespace-overview
   [ns-url-fn mp-ns defs valid-ref-pred opts]

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -231,14 +231,6 @@
         [:span.fw3.f6.light-red.ml2 "deprecated"])]
      (render-var-args-and-docs def render-wiki-link opts)
      (render-protocol-members def render-wiki-link opts)
-     (when (seq (platf/get-field def :members))
-       [:div.lh-copy.pl3.bl.b--black-10
-        (for [m (platf/get-field def :members)]
-          [:div
-           [:h5 (:name m)]
-           (render-arglists (:name m) (:arglists m))
-           (when (:doc m)
-             [:p (docstring->html (:doc m) render-wiki-link opts)])])])
      (when (or (platf/varies? def :src-uri) ; if it varies they can't be both nil
                (platf/get-field def :src-uri)) ; if it doesn't vary, ensure non-nil
        (if (platf/varies? def :src-uri)

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -299,14 +299,22 @@
             (varies-for-platforms? d))
     (platforms->var-annotation d)))
 
-(defn definitions-list [_ns-entity defs {:keys [indicate-platforms-other-than]}]
-  [:div.pb4
-   [:ul.list.pl0
-    (for [def defs
-          :let [def-name (platf/get-field def :name)]]
-      [:li.def-item
-       [:a.link.dim.blue.dib.pa1.pl0 {:href (str "#" def-name)} def-name
-        (render-var-annotation (var-index-platform-annotation indicate-platforms-other-than def))]])]])
+(defn- definitions-list* [defs {:keys [indicate-platforms-other-than level] :as opts}]
+  (let [level (or level 0)]
+    [:ul.list.pl0 {:style {:margin-left (str (* level 10) "px")}}
+     (for [def defs
+           :let [def-name (platf/get-field def :name)]]
+       [:li.def-item
+        [:a.link.dim.blue.dib.pa1.pl0
+         {:href (str "#" def-name)}
+         def-name
+         (render-var-annotation (var-index-platform-annotation indicate-platforms-other-than def))]
+        (let [members (platf/get-field def :members)]
+          (when (seq members)
+            (definitions-list* members (assoc opts :level (inc level)))))])]))
+
+(defn definitions-list [defs opts]
+  [:div.pb4 (definitions-list* defs opts)])
 
 (defn namespace-overview
   [ns-url-fn mp-ns defs valid-ref-pred opts]

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -63,6 +63,7 @@
        (markdown-docstring->html doc-str render-wiki-link opts)
        (plaintext-docstring->html doc-str :hidden)])))
 
+;; TODO: Allow for protocol functions.
 (defn valid-ref-pred-fn [{:keys [defs] :as _cache-bundle}]
   (fn [current-ns target-ns target-var]
     (let [target-ns (if target-ns (ns-tree/replant-ns current-ns target-ns) current-ns)]
@@ -315,7 +316,6 @@
 
 (defn definitions-list [defs opts]
   [:div.pb4
-
    [:ul.list.pl0
    (definitions-list* defs opts)]])
 

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -63,13 +63,14 @@
        (markdown-docstring->html doc-str render-wiki-link opts)
        (plaintext-docstring->html doc-str :hidden)])))
 
-;; TODO: Allow for protocol functions.
 (defn valid-ref-pred-fn [{:keys [defs] :as _cache-bundle}]
   (fn [current-ns target-ns target-var]
     (let [target-ns (if target-ns (ns-tree/replant-ns current-ns target-ns) current-ns)]
       (if target-var
-        (some #(and (= target-var (:name %))
-                    (= target-ns (:namespace %)))
+        (some (fn [{:keys [namespace name members]}]
+                (and (= target-ns namespace)
+                     (or (= target-var name)
+                         (some #(= target-var (str (:name %))) members))))
               defs)
         (some #(= target-ns (:namespace %)) defs)))))
 

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -207,11 +207,12 @@
   (let [members (platf/get-field def :members)]
     (when (seq members)
       [:div.pl3.bl.b--black-10
-       (for [m members]
+       (for [m members
+             :let [def-name (platf/get-field m :name)]]
          [:div.bb.b--black-10.mb1
           [:h4.def-block-title.mv0.pt2.pb3
-           (platf/get-field m :name)
-           (render-var-annotation (platforms->var-annotation m))]
+           {:name def-name :id def-name}
+           def-name (render-var-annotation (platforms->var-annotation m))]
           (render-var-args-and-docs m render-wiki-link opts)])])))
 
 (defn def-block
@@ -221,7 +222,7 @@
     [:div.def-block
      [:hr.mv3.b--black-10]
      [:h4.def-block-title.mv0.pv3
-      {:name (platf/get-field def :name), :id def-name}
+      {:name def-name :id def-name}
       def-name (render-var-annotation (platforms->var-annotation def))
       (when-not (= :var (platf/get-field def :type))
         [:span.f7.ttu.normal.gray.ml2 (platf/get-field def :type)])

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -209,7 +209,7 @@
       [:div.pl3.bl.b--black-10
        (for [m members
              :let [def-name (platf/get-field m :name)]]
-         [:div.bb.b--black-10.mb1
+         [:div.bb.b--black-10.mb1.def-block
           [:h4.def-block-title.mv0.pt2.pb3
            {:name def-name :id def-name}
            def-name (render-var-annotation (platforms->var-annotation m))]
@@ -302,20 +302,22 @@
 
 (defn- definitions-list* [defs {:keys [indicate-platforms-other-than level] :as opts}]
   (let [level (or level 0)]
-    [:ul.list.pl0 {:style {:margin-left (str (* level 10) "px")}}
-     (for [def defs
+    (for [def defs
            :let [def-name (platf/get-field def :name)]]
        [:li.def-item
         [:a.link.dim.blue.dib.pa1.pl0
-         {:href (str "#" def-name)}
+         {:href (str "#" def-name) :style {:margin-left (str (* level 10) "px")}}
          def-name
          (render-var-annotation (var-index-platform-annotation indicate-platforms-other-than def))]
         (let [members (platf/get-field def :members)]
           (when (seq members)
-            (definitions-list* members (assoc opts :level (inc level)))))])]))
+            (definitions-list* members (assoc opts :level (inc level)))))])))
 
 (defn definitions-list [defs opts]
-  [:div.pb4 (definitions-list* defs opts)])
+  [:div.pb4
+
+   [:ul.list.pl0
+   (definitions-list* defs opts)]])
 
 (defn namespace-overview
   [ns-url-fn mp-ns defs valid-ref-pred opts]

--- a/src/cljdoc/render/api_searchset.clj
+++ b/src/cljdoc/render/api_searchset.clj
@@ -249,8 +249,10 @@
        vec))
 
 (defn- ->searchset-members
-  [members]
-  (map #(select-keys % [:type :name :arglists :doc]) members))
+  [members version-entity parent]
+  (->> members
+       (mapv #(select-keys % [:type :name :arglists :doc]))
+       (mapv #(assoc % :path (path-for-def version-entity (:namespace parent) (:name %)) ))))
 
 (defn- update-if-exists [m k f]
   (if (contains? m k)
@@ -276,7 +278,7 @@
              (comp
               (map #(select-keys % [:platform :type :namespace :name :arglists :doc :members]))
               (map #(update-if-exists % :arglists ->deregexify))
-              (map #(update % :members ->searchset-members))
+              (map #(update % :members ->searchset-members version-entity %))
               (map #(assoc % :path (path-for-def version-entity (:namespace %) (:name %)))))
              cache-bundle-defs)
        (sort-by (juxt :namespace :name :platform))

--- a/src/cljdoc/render/api_searchset.clj
+++ b/src/cljdoc/render/api_searchset.clj
@@ -252,7 +252,7 @@
   [members version-entity parent]
   (->> members
        (mapv #(select-keys % [:type :name :arglists :doc]))
-       (mapv #(assoc % :path (path-for-def version-entity (:namespace parent) (:name %)) ))))
+       (mapv #(assoc % :path (path-for-def version-entity (:namespace parent) (:name %))))))
 
 (defn- update-if-exists [m k f]
   (if (contains? m k)

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -144,7 +144,7 @@
                     [:span.fw3.f6.light-red.ml2 "deprecated"])]
      (api/render-ns-docs ns render-wiki-link opts)
      (for [def defs]
-       (api/def-block def render-wiki-link opts))]))
+       (api/def-details def render-wiki-link opts))]))
 
 (defn- docs-files
   "Return a list of [file-path content] pairs describing a zip archive.

--- a/src/cljdoc/render/rich_text.clj
+++ b/src/cljdoc/render/rich_text.clj
@@ -69,7 +69,8 @@
     render-wiki-link
     ;; Replicate the interesting parts of flexmark's WikiLinkLinkRefProcessor
     ;; while customizing to our use case.
-    ;; We only want a wikilink to be considered such when it actually resolves.
+    ;; We only want a wikilink to be considered such when it actually resolves to a valid
+    ;; destination.
     (.linkRefProcessorFactory
      (reify LinkRefProcessorFactory
        (getWantExclamationPrefix [_this _opts] false)

--- a/src/cljdoc/spec/searchset.clj
+++ b/src/cljdoc/spec/searchset.clj
@@ -28,7 +28,8 @@
                [:type keyword?]
                [:name symbol?]
                [:arglists [:sequential [:vector any?]]]
-               [:doc {:optional true} string?]]]]]]]
+               [:doc {:optional true} string?]
+               [:path string?]]]]]]]
    [:docs [:vector
            [:map
             [:name string?]


### PR DESCRIPTION
# Prototype methods now support wikilinks in docstrings:

## Before
Notice `[[proto1-same2]]`, etc, are rendered as text.

<img width="1212" height="327" alt="image" src="https://github.com/user-attachments/assets/ae3663e4-1b4c-46f9-9f18-36db6a8dfb54" />

## After
<img width="1156" height="308" alt="image" src="https://github.com/user-attachments/assets/dfd6ab95-6704-4274-ac9e-1d71dd424cdf" />|

# Prototype methods are now shown in the navigator:

## Before 
<img width="1268" height="502" alt="image" src="https://github.com/user-attachments/assets/718cb14f-727a-4c59-a7f3-188fca40438c" />

## After
<img width="1287" height="564" alt="image" src="https://github.com/user-attachments/assets/a0cf7bb3-5ebc-4885-8c28-1549e7b11d52" />


# Prototype methods now show up in docset search:

## Before
<img width="542" height="516" alt="image" src="https://github.com/user-attachments/assets/c277168a-6a76-4f5f-9c13-0e0498127085" />

## After
<img width="537" height="457" alt="image" src="https://github.com/user-attachments/assets/4158c1bf-e753-402b-a90f-b41954cb087d" />

Closes #707

I did not bother with the special case I described here: https://github.com/cljdoc/cljdoc/issues/707#issuecomment-1575368259. We can address it separately someday if the need arises.