### PR TITLE
squint: only need `warn-on-lazy-reusage!` once

### DIFF
--- a/.clj-kondo/inline-configs/cljdoc.client.list_search.cljs/config.edn
+++ b/.clj-kondo/inline-configs/cljdoc.client.list_search.cljs/config.edn
@@ -1,1 +1,1 @@
-{:config-in-call {cljdoc.client.list-search/SearchInput {:ignore {:row 10, :col 10, :end-row 10, :end-col 27, :linters :all}}, cljdoc.client.list-search/ResultsView {:ignore {:row 53, :col 10, :end-row 53, :end-col 27, :linters :all}}}}
+{:config-in-call #:cljdoc.client.list-search{SearchInput {:ignore {:row 8, :col 10, :end-row 8, :end-col 27, :linters :all}}, ResultsView {:ignore {:row 51, :col 10, :end-row 51, :end-col 27, :linters :all}}}}

--- a/front-end/src/cljdoc/client/docstring_toggler.cljs
+++ b/front-end/src/cljdoc/client/docstring_toggler.cljs
@@ -2,8 +2,6 @@
   (:require [cljdoc.client.dom :as dom]
             [cljdoc.client.page :as page]))
 
-(warn-on-lazy-reusage!)
-
 (defn- init-toggle-docstring-raw []
   (let [toggles (dom/query-all ".js--toggle-raw")
         add-toggle-handlers (fn []

--- a/front-end/src/cljdoc/client/dom.cljs
+++ b/front-end/src/cljdoc/client/dom.cljs
@@ -1,7 +1,5 @@
 (ns cljdoc.client.dom)
 
-(warn-on-lazy-reusage!)
-
 (defn query
   ([q el]
    (when el (.querySelector el q)))

--- a/front-end/src/cljdoc/client/flow.cljs
+++ b/front-end/src/cljdoc/client/flow.cljs
@@ -1,7 +1,5 @@
 (ns cljdoc.client.flow)
 
-(warn-on-lazy-reusage!)
-
 (defn debounced
   "Debounce funtion `f` with a `delay-ms`."
   [delay-ms f]

--- a/front-end/src/cljdoc/client/hljs_copy_button_plugin.cljs
+++ b/front-end/src/cljdoc/client/hljs_copy_button_plugin.cljs
@@ -3,8 +3,6 @@
   There is https://github.com/arronhunt/highlightjs-copy but it seems to have some
   unresolved issues. There is not much code to this, so let's just do a bare bones ourselves.")
 
-(warn-on-lazy-reusage!)
-
 (def copyButtonPlugin
   {"before:highlightElement"
    (fn [{:keys [el]}]

--- a/front-end/src/cljdoc/client/lib_search.cljs
+++ b/front-end/src/cljdoc/client/lib_search.cljs
@@ -9,8 +9,6 @@
             [cljdoc.client.list-search :refer [ListSearch]]
             [clojure.string :as str]))
 
-(warn-on-lazy-reusage!)
-
 (defn- clean-search-str [s]
   (str/replace s #"[{}[]\"]" ""))
 

--- a/front-end/src/cljdoc/client/lib_switcher.cljs
+++ b/front-end/src/cljdoc/client/lib_switcher.cljs
@@ -9,8 +9,6 @@
             [cljdoc.client.list-search :refer [ListSearch]]
             [clojure.string :as str]))
 
-(warn-on-lazy-reusage!)
-
 (defn- is-same-project [p1 p2]
   (and (== (:group-id p1) (:group-id p2))
        (== (:artifact-id p1) (:artifact-id p2))))

--- a/front-end/src/cljdoc/client/library.cljs
+++ b/front-end/src/cljdoc/client/library.cljs
@@ -1,8 +1,6 @@
 (ns cljdoc.client.library
   (:require [clojure.string :as str]))
 
-(warn-on-lazy-reusage!)
-
 (defn docs-coords-path
   "Return coords portion of docs path for given `coords`"
   [{:keys [group-id artifact-id version] :as _coords}]

--- a/front-end/src/cljdoc/client/list_search.cljs
+++ b/front-end/src/cljdoc/client/list_search.cljs
@@ -5,8 +5,6 @@
             #_:clj-kondo/ignore ;; used in #jsx as tag
             [clojure.string :as str]))
 
-(warn-on-lazy-reusage!)
-
 (defn- #_:clj-kondo/ignore ;; used in jsx as tag
   SearchInput [{:keys [place-holder-text initial-value focus unfocus results-fetcher
                        onEnter onArrowUp onArrowDown]}]

--- a/front-end/src/cljdoc/client/mobile.cljs
+++ b/front-end/src/cljdoc/client/mobile.cljs
@@ -5,8 +5,6 @@
             [cljdoc.client.dom :as dom]
             [cljdoc.client.page :as page]))
 
-(warn-on-lazy-reusage!)
-
 (defn MobileNav []
   (let [[scroll-pos-main set-scroll-pos-main] (useState nil)
         [scroll-pos-nav set-scroll-pos-nav] (useState nil)

--- a/front-end/src/cljdoc/client/namespace_scroll.cljs
+++ b/front-end/src/cljdoc/client/namespace_scroll.cljs
@@ -4,8 +4,6 @@
             [cljdoc.client.library :as lib]
             [cljdoc.client.page :as page]))
 
-(warn-on-lazy-reusage!)
-
 (defn- init-scroll-indicator []
   (let [def-detail-scroll-view (dom/query ".js--main-scroll-view")
         def-nav-scroll-view (dom/query ".js--namespace-contents-scroll-view")

--- a/front-end/src/cljdoc/client/page.cljs
+++ b/front-end/src/cljdoc/client/page.cljs
@@ -2,8 +2,6 @@
   (:require [cljdoc.client.dom :as dom]
             [cljdoc.client.library :as lib]))
 
-(warn-on-lazy-reusage!)
-
 (defn is-namespace-overview []
   (boolean (dom/query ".ns-overview-page")))
 

--- a/front-end/src/cljdoc/client/project_doc.cljs
+++ b/front-end/src/cljdoc/client/project_doc.cljs
@@ -4,8 +4,6 @@
             [cljdoc.client.page :as page]
             [clojure.string :as str]))
 
-(warn-on-lazy-reusage!)
-
 (defn- toggle-meta-dialog
   "Support for the little helper window brought up by the bottom right icon when viewing a project"
   []

--- a/front-end/src/cljdoc/client/recent_doc_links.cljs
+++ b/front-end/src/cljdoc/client/recent_doc_links.cljs
@@ -5,8 +5,6 @@
             [cljdoc.client.dom :as dom]
             [cljdoc.client.library :as lib]))
 
-(warn-on-lazy-reusage!)
-
 (defn- day-date [date]
   (js/Date. (.getFullYear date)
             (.getMonth date)

--- a/front-end/src/cljdoc/client/single_docset_search.cljs
+++ b/front-end/src/cljdoc/client/single_docset_search.cljs
@@ -8,8 +8,6 @@
             [cljdoc.client.flow :as flow]
             [clojure.string :as str]))
 
-(warn-on-lazy-reusage!)
-
 (def SEARCHSET_VERSION 6)
 
 (defn- tokenize [s]

--- a/front-end/src/cljdoc/client/versions_form.cljs
+++ b/front-end/src/cljdoc/client/versions_form.cljs
@@ -3,8 +3,6 @@
   (:require ["preact" :refer [h render]]
             [cljdoc.client.dom :as dom]))
 
-(warn-on-lazy-reusage!)
-
 (defn onsubmit [e]
   (.preventDefault e)
   (let [form (.getElementById js/document "cljdoc-navigator")


### PR DESCRIPTION
On a tip from borkdude, I learned that `warn-on-lazy-reusage!` only needs to be called once from the entrypoint namespace.