### PR TITLE
lint: ignore clj-kondo lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ project.clj
 .DS_Store
 .cache
 .clj-kondo/.cache
+.clj-kondo/.lock
 node_modules
 .envrc
 .calva


### PR DESCRIPTION
This will be going away in a future release of clj-kondo, but get rid of git status annoyance today.