### PR TITLE
Allow for GitLab groups in scm-url

### DIFF
--- a/src/cljdoc/util/scm.clj
+++ b/src/cljdoc/util/scm.clj
@@ -52,7 +52,10 @@
   [scm-url]
   (cond
     (string/starts-with? scm-url "http")
-    (re-find #"http.*//[^/]*/[^/]*/[^/]*" scm-url)
+    ;; gitlab supports groups and subgroups, so no stripping of extra segments for it
+    (if (= :gitlab (provider scm-url))
+      scm-url
+      (re-find #"http.*//[^/]*/[^/]*/[^/]*" scm-url))
 
     (or (string/starts-with? scm-url "git@")
         (string/starts-with? scm-url "ssh://"))
@@ -60,7 +63,7 @@
         (string/replace #":" "/")
         (string/replace #"\.git$" "")
         ;; three slashes because of prior :/ replace
-        (string/replace #"^(ssh///)*git@" "http://"))))
+        (string/replace #"^(ssh///)*git@" "https://"))))
 
 (defn fs-uri
   "Normalize a provided `scm-path` to it's canonical path,
@@ -134,5 +137,5 @@
   [s]
   (cond-> s
     (string/starts-with? s "http") (string/replace #"^http://" "https://")
-    (string/starts-with? s "git@github.com:") (string/replace #"^git@github.com:" "https://github.com/")
+    (string/starts-with? s "git@") (string/replace #"^git@(.*):" "https://$1/")
     (string/ends-with? s ".git") (string/replace #".git$" "")))

--- a/test/cljdoc/util/scm_test.clj
+++ b/test/cljdoc/util/scm_test.clj
@@ -90,12 +90,17 @@
   (t/is (= "git@gitea.heevyis.ninja:josha/formulare.git" (scm/ssh-uri "https://gitea.heevyis.ninja/josha/formulare")))
   (t/is (= "git@unknown-scm.com:circleci/clj-yaml.git" (scm/ssh-uri "https://unknown-scm.com/circleci/clj-yaml"))))
 
-(t/deftest scm-uri-inversion-test-to-http
-  (t/is (= "http://github.com/circleci/clj-yaml" (scm/http-uri "git@github.com:circleci/clj-yaml.git")))
-  (t/is (= "http://gitea.heevyis.ninja/josha/formulare" (scm/http-uri "git@gitea.heevyis.ninja:josha/formulare.git")))
-  (t/is (= "http://unknown-scm.com/circleci/clj-yaml" (scm/http-uri "git@unknown-scm.com:circleci/clj-yaml"))))
+(t/deftest scm-uri-inversion-test-to-https
+  (t/is (= "https://github.com/circleci/clj-yaml" (scm/http-uri "git@github.com:circleci/clj-yaml.git")))
+  (t/is (= "https://gitea.heevyis.ninja/josha/formulare" (scm/http-uri "git@gitea.heevyis.ninja:josha/formulare.git")))
+  (t/is (= "https://unknown-scm.com/circleci/clj-yaml" (scm/http-uri "git@unknown-scm.com:circleci/clj-yaml"))))
 
-(t/deftest http-uri-remove-extra-segments
+(t/deftest http-preserve-groups-for-gitlab
+  ;; gitlab supports groups and subgroups
+  (t/is (= "https://gitlab.com/group1/group2/group3/project"
+           (scm/http-uri "https://gitlab.com/group1/group2/group3/project"))))
+
+(t/deftest http-uri-remove-extra-segments-for-non-gitlab
   (t/is (= "http://github.com/circleci/clj-yaml" (scm/http-uri "http://github.com/circleci/clj-yaml/some/extra/stuff")))
   (t/is (= "https://github.com/circleci/clj-yaml" (scm/http-uri "https://github.com/circleci/clj-yaml/some/extra/stuff"))))
 
@@ -108,6 +113,8 @@
 (t/deftest normalize-git-url-test
   (t/is (= (scm/normalize-git-url "git@github.com:clojure/clojure.git")
            "https://github.com/clojure/clojure"))
+  (t/is (= (scm/normalize-git-url "git@foobar.com:clojure/clojure.git")
+           "https://foobar.com/clojure/clojure"))
   (t/is (= (scm/normalize-git-url "http://github.com/clojure/clojure.git")
            "https://github.com/clojure/clojure"))
   (t/is (= (scm/normalize-git-url "http://github.com/clojure/clojure")


### PR DESCRIPTION
Also git@ urls now:
- convert to https: (instead of http:)
- normalize for all scm hosts, not just github.com

Short term solution for #1099