### PR TITLE
ui: focus on jump to recent docs input on show

### DIFF
--- a/front-end/src/cljdoc/client/lib_switcher.cljs
+++ b/front-end/src/cljdoc/client/lib_switcher.cljs
@@ -74,8 +74,9 @@
                                     (or (and is-macos? metaKey) (and (not is-macos?) ctrlKey)))
                                (do
                                  (.preventDefault e)
-                                 (set-show! true)
-                                 (set-results! recently-visited-docs))
+                                 (when (seq recently-visited-docs)
+                                   (set-show! true)
+                                   (set-results! recently-visited-docs)))
 
                                (= "Escape" key)
                                (do

--- a/front-end/src/cljdoc/client/list_search.cljs
+++ b/front-end/src/cljdoc/client/list_search.cljs
@@ -20,6 +20,7 @@
         [input-value set-input-value!] (useState (or initialValue ""))
         [refresh set-refresh!] (useState 0)] ;; to force refresh when we want
     (useEffect (fn setup []
+                 (.focus (.-current input-node))
                  (when initialValue
                    (resultsFetcher initialValue)))
                [])


### PR DESCRIPTION
`autofocus` attribute on input element was not enough.

Don't show recent docs dialog when there are no recent docs, but continue to capture hotkey for consistent behaviour (overriding any default browser behaviour).

Closes #1117