### PR TITLE
ops: preparatory changes for ops sweep

### DIFF
--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [get-in])
   (:require [aero.core :as aero]
             [babashka.fs :as fs]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]))
 
 (defmethod aero/reader 'slurp
@@ -25,13 +26,28 @@
     (throw (ex-info (format "No config found for path %s\nDid you configure your secrets.edn file?" ks)
                     {:ks ks, :profile (profile)}))))
 
-(defn config-file []
+(defn- config-file []
   (or (some-> (System/getenv "CLJDOC_CONFIG_EDN") fs/file)
       (io/resource "config.edn")))
 
-(defn config
-  ([] (aero/read-config (config-file) {:profile (profile)}))
-  ([profile] (aero/read-config (config-file) {:profile profile})))
+(defn- config-override-map
+  "Used for staging, when we sometimes want to tweak config."
+  []
+  (or (some-> (System/getenv "CLJDOC_CONFIG_OVERRIDE_MAP") edn/read-string)
+      {}))
+
+(defn- deep-merge
+  [& maps]
+  (if (every? map? maps)
+    (apply merge-with deep-merge maps)
+    (last maps)))
+
+(defn- read-config [f profile]
+  (aero/read-config f {:profile profile}))
+
+(defn config []
+  (deep-merge (aero/read-config (config-file) {:profile (profile)})
+              (config-override-map)))
 
 ;; Accessors
 

--- a/src/cljdoc/server/clojars_stats.clj
+++ b/src/cljdoc/server/clojars_stats.clj
@@ -140,7 +140,7 @@
   [k {:keys [db-spec retention-days] :as opts}]
   (when (> retention-days 1000)
     (throw (ex-info (format "retention-days is %d, but max for cljdoc's clojars stats is currently 1000" retention-days) {})))
-  (log/info "Starting" k)
+  (log/infof "Starting %s, with retention-days %d" k retention-days)
   (-> (->ClojarsStats db-spec)
       (assoc ::poll-job (tt/every! (.toSeconds TimeUnit/HOURS 1) (wrap-error #(update-stats! opts))))))
 


### PR DESCRIPTION
Add support for CLJDOC_CONFIG_OVERRIDE_MAP env var for upcoming opts tweaks in #1136. This will support tweaks when deploying to a non-prod test compute instance.

We do this in advance because these changes need to be in our built docker image on docker hub to be used.