### PR TITLE
ops: docker: revert clojure pinning

### DIFF
--- a/ops/docker/Dockerfile
+++ b/ops/docker/Dockerfile
@@ -4,9 +4,7 @@ WORKDIR /tmp
 
 RUN apk add --update --no-cache bash curl git tar zstd procps
 
-# There's a problem with 1.12.4.1597, see: https://ask.clojure.org/index.php/14906/tdeps-269-checksums-should-use-sha256sum-instead-of-shasum
-# Switch back to latest when resolved.
-RUN curl -L -O https://github.com/clojure/brew-install/releases/download/1.12.4.1582/linux-install.sh \
+RUN curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
     && chmod +x linux-install.sh \
     && ./linux-install.sh
 


### PR DESCRIPTION
That was fast, it is fixed: https://clojure.atlassian.net/browse/TDEPS-275