### PR TITLE
maint: retire Cora's experimental REST endpoint

### DIFF
--- a/src/cljdoc/server/pedestal.clj
+++ b/src/cljdoc/server/pedestal.clj
@@ -589,20 +589,6 @@
                      :headers {"Content-Type" "application/json"}
                      :body (json/generate-string {:version cljdoc-version})}))}))
 
-(def api-docsets
-  "Creates an API response with a JSON representation of a `docset`."
-  (interceptor/interceptor
-   {:name ::api/docsets
-    :enter (fn api-docsets [{:keys [docset] :as ctx}]
-             (->> (if docset
-                    {:status 200
-                     :headers {"Content-Type" "application/json"}
-                     :body (json/generate-string docset)}
-                    {:status 404
-                     :headers {"Content-Type" "application/json"}
-                     :body (json/generate-string {:error "Could not find data, please request a build first"})})
-                  (assoc ctx :response)))}))
-
 (defn route-resolver
   "Given a route name return a list of interceptors to handle requests
   to that route.
@@ -633,10 +619,6 @@
                          api-searchset]
 
          :api/server-info [(api-server-info cljdoc-version)]
-
-         :api/docsets [(pom-loader cached-pom-fetcher)
-                       (artifact-data-loader storage)
-                       api-docsets]
 
          :ping          [(interceptor/interceptor {:name ::pong :enter #(pu/ok-html % "pong")})]
          :request-build [(body/body-params)

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -27,8 +27,7 @@
     ["/api/search" :get nop :route-name :api/search]
     ["/api/search-suggest" :get nop :route-name :api/search-suggest]
     ["/api/searchset/:group-id/:artifact-id/:version" :get nop :route-name :api/searchset]
-    ["/api/server-info" :get nop :route-name :api/server-info]
-    ["/experiments/cora/api/docsets/:group-id/:artifact-id/:version" :get nop :route-name :api/docsets]})
+    ["/api/server-info" :get nop :route-name :api/server-info]})
 
 (defn build-log-routes []
   #{["/builds/:id" :get nop :route-name :show-build]

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -227,4 +227,6 @@
                     (.startsWith (.get % "src") "https://")))
        (map #(doto % (.put "src" (fix-image (.get % "src") fix-opts)))))
 
-  (.get (.attributes (first (.select doc "a"))) "href"))
+  (.get (.attributes (first (.select doc "a"))) "href")
+
+  :eoc)


### PR DESCRIPTION
Spike was introduced in #756.

In the spirit of turfing what we don't use...
It has been 3 years.
We can add it back if there is renewed interest.