### PR TITLE
Url Fixups: Allow for cljdoc.org url with no path

### DIFF
--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -159,7 +159,10 @@
                                            (map (fn [^Element e] (.attributes e)))
                                            (filter (fn [^Attributes a] (absolute-uri? (.get a "href")))))]
       (let [href (.get absolute-link "href")
-            {:keys [host scheme ^String path] :as uri} (uri/parse href)]
+            {:keys [host scheme ^String path] :as uri} (let [uri (uri/parse href)]
+                                                         (if (:path uri)
+                                                           uri
+                                                           (assoc uri :path "/")))]
         (if-not (and (= "https" scheme) (= "cljdoc.org" host))
           (.put absolute-link "rel" "nofollow")
           (let [{:keys [route-name path-params]} (routes/match-route path)

--- a/test/cljdoc/util/fixref_test.clj
+++ b/test/cljdoc/util/fixref_test.clj
@@ -80,9 +80,9 @@
   (t/is
    (match?
     (m/nested-equals
-      [[:a {:href "/some/path/here"} "absolute link to cljdoc"]
-       [:a {:href "/"} "root path"]
-       [:a {:href "/"} "no path"]])
+     [[:a {:href "/some/path/here"} "absolute link to cljdoc"]
+      [:a {:href "/"} "root path"]
+      [:a {:href "/"} "no path"]])
     (fix [[:a {:href "https://cljdoc.org/some/path/here"} "absolute link to cljdoc"]
           [:a {:href "https://cljdoc.org/"} "root path"]
           [:a {:href "https://cljdoc.org"} "no path"]]

--- a/test/cljdoc/util/fixref_test.clj
+++ b/test/cljdoc/util/fixref_test.clj
@@ -80,8 +80,12 @@
   (t/is
    (match?
     (m/nested-equals
-     [[:a {:href "/some/path/here"} "absolute link to cljdoc"]])
-    (fix [[:a {:href "https://cljdoc.org/some/path/here"} "absolute link to cljdoc"]]
+      [[:a {:href "/some/path/here"} "absolute link to cljdoc"]
+       [:a {:href "/"} "root path"]
+       [:a {:href "/"} "no path"]])
+    (fix [[:a {:href "https://cljdoc.org/some/path/here"} "absolute link to cljdoc"]
+          [:a {:href "https://cljdoc.org/"} "root path"]
+          [:a {:href "https://cljdoc.org"} "no path"]]
          fix-opts))))
 
 (t/deftest unknown-scm-links-when-relative-point-to-normalized-scm-test
@@ -278,7 +282,10 @@
                  [:a {:href "https://cljdoc.org/d/not-mygroupid/not-myartifactid/CURRENT"}
                   "doesn't replace CURRENT if not my group-id/artifact-id"]
                  [:a {:href "https://cljdoc.org/doopsie/mygroupid/myartifactid/CURRENT"}
-                  "doesn't replace CURRENT if not a cljdoc route"]]]
+                  "doesn't replace CURRENT if not a cljdoc route"]
+                 [:a {:href "https://cljdoc.org/some/path"} "arbitrary path"]
+                 [:a {:href "https://cljdoc.org/"} "root path"]
+                 [:a {:href "https://cljdoc.org"} "no path"]]]
       (t/is
        (match?
         (m/nested-equals input)


### PR DESCRIPTION
Closes #1177
Addendum for #1172